### PR TITLE
P0 fixes: JSONL locks, idle timer, fork timing, ChatWindow render, hooks mount

### DIFF
--- a/app/api/agent/[id]/events/route.ts
+++ b/app/api/agent/[id]/events/route.ts
@@ -40,12 +40,16 @@ export async function GET(
         encode(event);
       });
 
-      // Heartbeat every 30s to prevent server/proxy timeout (Next.js default ~120-150s)
+      // Heartbeat every 30s to prevent server/proxy timeout (Next.js default ~120-150s).
+      // keepAlive() is called only after a successful enqueue so that when the client
+      // silently disappears, the idle timer eventually fires and destroys the wrapper.
       const heartbeat = setInterval(() => {
         try {
           controller.enqueue(new TextEncoder().encode(":\n\n"));
+          session.keepAlive();
         } catch {
-          // controller already closed
+          // controller already closed; do not call keepAlive so the idle
+          // timer can eventually destroy the wrapper (no orphan).
         }
       }, 30_000);
 

--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
-import { readdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from "fs";
+import { readdirSync, readFileSync, statSync, unlinkSync } from "fs";
+import { writeFile, rename, unlink } from "fs/promises";
 import { join } from "path";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import {
@@ -9,6 +10,8 @@ import {
   listAllSessions,
 } from "@/lib/session-reader";
 import { getRpcSession } from "@/lib/rpc-manager";
+import { rewriteChildHeader } from "@/lib/session-cascade";
+import { withFileLock } from "@/lib/session-lock";
 
 export async function GET(
   req: Request,
@@ -111,40 +114,59 @@ export async function DELETE(
       return NextResponse.json({ error: "Session not found" }, { status: 404 });
     }
 
-    // Read header before deleting to get parentSession path
-    const firstLine = readFileSync(filePath, "utf8").split("\n")[0];
-    let parentSessionPath: string | undefined;
+    // 1. Read parent's first line to get grandparent path
+    let parentSessionPath: string | null = null;
     try {
+      const firstLine = readFileSync(filePath, "utf8").split("\n")[0];
       const header = JSON.parse(firstLine) as { type?: string; parentSession?: string };
-      if (header.type === "session") parentSessionPath = header.parentSession;
-    } catch { /* ignore */ }
+      if (header.type === "session") parentSessionPath = header.parentSession ?? null;
+    } catch { /* malformed parent — grandparent remains null */ }
 
-    // Re-attach all direct children to this session's parent (cascade re-parent)
-    // Scan sibling files in the same directory
+    // 2. Enumerate siblings
     const dir = filePath.replace(/\\/g, "/").split("/").slice(0, -1).join("/");
+    const siblingFiles: string[] = [];
     try {
-      const files = readdirSync(dir).filter((f) => f.endsWith(".jsonl") && join(dir, f) !== filePath);
-      for (const file of files) {
-        const childPath = join(dir, file);
-        try {
-          const content = readFileSync(childPath, "utf8");
-          const lines = content.split("\n");
-          const header = JSON.parse(lines[0]) as { type?: string; parentSession?: string };
-          if (header.type === "session" && header.parentSession === filePath) {
-            // Rewrite header with new parentSession
-            header.parentSession = parentSessionPath;
-            lines[0] = JSON.stringify(header);
-            writeFileSync(childPath, lines.join("\n"));
-          }
-        } catch { /* skip malformed */ }
-      }
-    } catch { /* skip if dir unreadable */ }
+      siblingFiles.push(
+        ...readdirSync(dir)
+          .filter((f) => f.endsWith(".jsonl"))
+          .map((f) => join(dir, f))
+          .filter((p) => p !== filePath)
+      );
+    } catch { /* dir unreadable — no cascade possible */ }
 
+    // 3. Identify and rewrite children (under per-file lock, atomic write)
+    for (const childPath of siblingFiles) {
+      let content: string;
+      try { content = readFileSync(childPath, "utf8"); }
+      catch { continue; /* race: child deleted between readdir and read */ }
+
+      const { newContent, changed } = rewriteChildHeader(content, filePath, parentSessionPath);
+      if (!changed) continue;
+
+      await withFileLock(childPath, () => atomicWriteFile(childPath, newContent));
+    }
+
+    // 4. Destroy any active RPC wrapper for this session
     getRpcSession(id)?.destroy();
-    unlinkSync(filePath);
+
+    // 5. Unlink parent (under lock, swallow race-condition unlink failure)
+    await withFileLock(filePath, async () => {
+      try { unlinkSync(filePath); } catch { /* race: already deleted */ }
+    });
     invalidateSessionPathCache(id);
     return NextResponse.json({ ok: true });
   } catch (error) {
     return NextResponse.json({ error: String(error) }, { status: 500 });
+  }
+}
+
+async function atomicWriteFile(p: string, content: string): Promise<void> {
+  const tmp = `${p}.tmp`;
+  await writeFile(tmp, content, "utf8");
+  try {
+    await rename(tmp, p);
+  } catch (e) {
+    try { await unlink(tmp); } catch { /* best effort */ }
+    throw e;
   }
 }

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import type { AgentMessage, SessionInfo, SessionTreeNode } from "@/lib/types";
-import { MessageView } from "./MessageView";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { SessionInfo, SessionTreeNode, ToolResultMessage } from "@/lib/types";
+import { MessageList } from "./MessageList";
 import { ChatInput, type ChatInputHandle } from "./ChatInput";
 import { ChatMinimap, useMessageRefs } from "./ChatMinimap";
 import { useAgentSession, type AgentPhase } from "@/hooks/useAgentSession";
@@ -157,6 +157,37 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
   const visibleMessages = messages.filter((m) => m.role === "user" || m.role === "assistant");
   const messageRefs = useMessageRefs(visibleMessages.length);
 
+  const toolResultsMap = useMemo(() => {
+    const m = new Map<string, ToolResultMessage>();
+    for (const msg of messages) {
+      if (msg.role === "toolResult") {
+        m.set((msg as ToolResultMessage).toolCallId, msg as ToolResultMessage);
+      }
+    }
+    return m;
+  }, [messages]);
+
+  const { nextUserIdx, nextAssistantIdx } = useMemo(() => {
+    const nextUserIdx: number[] = new Array(messages.length).fill(-1);
+    const nextAssistantIdx: number[] = new Array(messages.length).fill(-1);
+    let lastUser = -1;
+    let lastAssistant = -1;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "user") {
+        nextUserIdx[i] = lastUser;
+        lastUser = i;
+      } else if (messages[i].role === "assistant") {
+        nextAssistantIdx[i] = lastAssistant;
+        lastAssistant = i;
+      }
+    }
+    return { nextUserIdx, nextAssistantIdx };
+  }, [messages]);
+
+  const handleEditContent = useCallback((content: string) => {
+    chatInputRef?.current?.insertIfEmpty(content);
+  }, [chatInputRef]);
+
   const isEmptyNew = isNew && messages.length === 0 && !streamState.isStreaming && !agentRunning;
 
   const availableThinkingLevels = displayModelValue
@@ -292,69 +323,24 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
         <div ref={scrollContainerRef} className="flex-1 overflow-y-auto pt-4 [scrollbar-width:none]">
           <div className="mx-auto max-w-[820px] px-4">
 
-            {(() => {
-              const toolResultsMap = new Map<string, import("@/lib/types").ToolResultMessage>();
-              for (const msg of messages) {
-                if (msg.role === "toolResult") {
-                  toolResultsMap.set((msg as import("@/lib/types").ToolResultMessage).toolCallId, msg as import("@/lib/types").ToolResultMessage);
-                }
-              }
-              let lastUserIdx = -1;
-              for (let i = messages.length - 1; i >= 0; i--) {
-                if (messages[i].role === "user") { lastUserIdx = i; break; }
-              }
-              let refIdx = 0;
-              return messages.map((msg, idx) => {
-                const prevAssistantEntryId =
-                  msg.role === "user" && idx > 0 && messages[idx - 1].role === "assistant"
-                    ? entryIds[idx - 1]
-                    : undefined;
-                const isVisible = msg.role === "user" || msg.role === "assistant";
-                const currentRefIdx = isVisible ? refIdx++ : -1;
-                let showTimestamp = false;
-                if (msg.role === "assistant") {
-                  showTimestamp = true;
-                  for (let j = idx + 1; j < messages.length; j++) {
-                    const r = messages[j].role;
-                    if (r === "user") break;
-                    if (r === "assistant") { showTimestamp = false; break; }
-                  }
-                  // Hide on the currently-streaming tail (the streaming bubble owns the live timestamp)
-                  if (showTimestamp && streamState.isStreaming && idx === messages.length - 1) {
-                    showTimestamp = false;
-                  }
-                }
-                const view = (
-                  <MessageView
-                    key={idx}
-                    message={msg}
-                    toolResults={toolResultsMap}
-                    modelNames={modelNames}
-                    entryId={entryIds[idx]}
-                    onFork={agentRunning || isNew || (idx === 0 && msg.role === "user") ? undefined : handleFork}
-                    forking={forkingEntryId === entryIds[idx]}
-                    onNavigate={agentRunning ? undefined : handleNavigate}
-                    prevAssistantEntryId={agentRunning ? undefined : prevAssistantEntryId}
-                    onEditContent={(content) => chatInputRef?.current?.insertIfEmpty(content)}
-                    showTimestamp={showTimestamp}
-                    prevTimestamp={idx > 0 ? (messages[idx - 1] as import("@/lib/types").AgentMessage & { timestamp?: number }).timestamp : undefined}
-                  />
-                );
-                if (!isVisible) return view;
-                return (
-                  <div key={idx} ref={(el) => {
-                    messageRefs.current[currentRefIdx] = el;
-                    if (idx === lastUserIdx) { (lastUserMsgRef as { current: HTMLDivElement | null }).current = el; }
-                  }}>
-                    {view}
-                  </div>
-                );
-              });
-            })()}
-
-            {streamState.isStreaming && streamState.streamingMessage && (
-              <MessageView message={streamState.streamingMessage as AgentMessage} isStreaming modelNames={modelNames} />
-            )}
+            <MessageList
+              messages={messages}
+              entryIds={entryIds}
+              toolResultsMap={toolResultsMap}
+              nextUserIdx={nextUserIdx}
+              nextAssistantIdx={nextAssistantIdx}
+              isStreaming={streamState.isStreaming}
+              streamingMessage={streamState.streamingMessage}
+              isNew={isNew}
+              agentRunning={agentRunning}
+              forkingEntryId={forkingEntryId}
+              onFork={handleFork}
+              onNavigate={handleNavigate}
+              onEditContent={handleEditContent}
+              messageRefs={messageRefs}
+              lastUserMsgRef={lastUserMsgRef}
+              modelNames={modelNames}
+            />
 
             {agentRunning && !streamState.streamingMessage && (
               <div className="py-2 text-[13px] text-text-muted">

--- a/components/MessageList.tsx
+++ b/components/MessageList.tsx
@@ -1,0 +1,92 @@
+import React, { useMemo } from "react";
+import type { AgentMessage, ToolResultMessage } from "@/lib/types";
+import { MessageView } from "./MessageView.tsx";
+
+interface MessageListProps {
+  messages: AgentMessage[];
+  entryIds: string[];
+  toolResultsMap: Map<string, ToolResultMessage>;
+  nextUserIdx: number[];
+  nextAssistantIdx: number[];
+  isStreaming: boolean;
+  streamingMessage: Partial<AgentMessage> | null;
+  isNew: boolean;
+  agentRunning: boolean;
+  forkingEntryId: string | null;
+  onFork: (entryId: string) => void;
+  onNavigate: (entryId: string) => void;
+  onEditContent: (content: string) => void;
+  messageRefs: React.MutableRefObject<(HTMLDivElement | null)[]>;
+  lastUserMsgRef: React.MutableRefObject<HTMLDivElement | null>;
+  modelNames: Record<string, string>;
+}
+
+export const MessageList = React.memo(function MessageList({
+  messages, entryIds, toolResultsMap, nextUserIdx, nextAssistantIdx,
+  isStreaming, streamingMessage, isNew, agentRunning, forkingEntryId,
+  onFork, onNavigate, onEditContent, messageRefs, lastUserMsgRef,
+  modelNames,
+}: MessageListProps) {
+  const lastUserIdx = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "user") return i;
+    }
+    return -1;
+  }, [messages]);
+
+  let refIdx = 0;
+  return (
+    <>
+      {messages.map((msg, idx) => {
+        const isFirstUserMessage = idx === 0 && msg.role === "user";
+        const canFork = !agentRunning && !isNew && !isFirstUserMessage;
+        const canNavigate = !agentRunning;
+        const isUserOrAssistant = msg.role === "user" || msg.role === "assistant";
+        const showTimestamp = msg.role !== "assistant"
+          || nextUserIdx[idx] !== -1
+          || nextAssistantIdx[idx] === -1;
+        const finalShowTimestamp = showTimestamp && !(isStreaming && idx === messages.length - 1);
+        const prevAssistantEntryId = msg.role === "user" && idx > 0 && messages[idx - 1].role === "assistant"
+          ? entryIds[idx - 1]
+          : undefined;
+        const prevTimestamp = idx > 0
+          ? (messages[idx - 1] as AgentMessage & { timestamp?: number }).timestamp
+          : undefined;
+
+        const view = (
+          <MessageView
+            key={entryIds[idx] ?? `idx-${idx}`}
+            message={msg}
+            toolResults={toolResultsMap}
+            modelNames={modelNames}
+            entryId={entryIds[idx]}
+            onFork={canFork ? onFork : undefined}
+            forking={forkingEntryId === entryIds[idx]}
+            onNavigate={canNavigate ? onNavigate : undefined}
+            prevAssistantEntryId={prevAssistantEntryId}
+            onEditContent={onEditContent}
+            showTimestamp={finalShowTimestamp}
+            prevTimestamp={prevTimestamp}
+          />
+        );
+
+        if (!isUserOrAssistant) return view;
+        const currentRefIdx = refIdx++;
+        return (
+          <div
+            key={entryIds[idx] ?? `idx-${idx}`}
+            ref={(el) => {
+              messageRefs.current[currentRefIdx] = el;
+              if (idx === lastUserIdx) lastUserMsgRef.current = el;
+            }}
+          >
+            {view}
+          </div>
+        );
+      })}
+      {isStreaming && streamingMessage && (
+        <MessageView message={streamingMessage as AgentMessage} isStreaming modelNames={modelNames} />
+      )}
+    </>
+  );
+});

--- a/components/MessageView.tsx
+++ b/components/MessageView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useMemo } from "react";
+import React, { useState, useRef, useEffect, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
@@ -65,7 +65,7 @@ function copyText(text: string): Promise<void> {
   }
 }
 
-export function MessageView({ message, isStreaming, toolResults, modelNames, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp }: Props) {
+export const MessageView = React.memo(function MessageView({ message, isStreaming, toolResults, modelNames, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp }: Props) {
   if (message.role === "user") {
     return <UserMessageView message={message as UserMessage} entryId={entryId} onFork={onFork} forking={forking} onNavigate={onNavigate} prevAssistantEntryId={prevAssistantEntryId} onEditContent={onEditContent} />;
   }
@@ -77,7 +77,7 @@ export function MessageView({ message, isStreaming, toolResults, modelNames, ent
     return null;
   }
   return null;
-}
+});
 
 function UserMessageView({ message, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent }: {
   message: UserMessage;

--- a/docs/architecture-review-2026-06-01.md
+++ b/docs/architecture-review-2026-06-01.md
@@ -1,0 +1,455 @@
+# Pi Agent Desktop 架构优化评审
+
+> 分支：`analysis/architecture-optimization-review` · 日期：2026-06-01 · 基准提交：`1a33476`
+>
+> 本文档是对当前架构的深度扫描结果，按"必改 / 应该改 / 锦上添花"分级。每条发现都给出位置、问题、修复方向、严重性。所有行号以基准提交为准，文件后续修改后会漂移。
+>
+> **使用方式**：从 P0 开始逐条消化；改动 P0 时同步补齐对应测试。修复示例仅给出形状，不要照抄——结合实际上下文再定。
+
+---
+
+## 0. 摘要
+
+| 严重性 | 数量 | 类别 |
+|---|---|---|
+| 🔴 P0 必改 | 6 | 数据丢失 / 崩溃 / 安全 |
+| 🟡 P1 应该改 | 10 | 性能 / 可维护性 / 可发布性 |
+| 🟢 P2 锦上添花 | 6 | DX / 一致性 / 可观测性 |
+| 📋 建议重构项 | 3 | 跨文件、需 1 周以上 |
+
+**最大风险**：
+
+1. **JSONL 文件无写锁** — DELETE 操作会静默损坏子会话 header。
+2. **10 分钟 idle timer 与 SSE heartbeat 解耦** — 长思考模型下会误杀 session。
+3. **fork / navigate_tree 是隐式 fire-and-forget** — 状态时序无显式契约。
+
+---
+
+## 1. P0 — 必改
+
+### P0-1. JSONL 写并发无锁，DELETE 级联重写必然损坏
+
+**位置**：`app/api/sessions/[id]/route.ts:122-141`
+
+**问题**：DELETE 会扫描同目录下所有 `.jsonl` 文件，对每个 `parentSession === filePath` 的子文件做 `readFileSync → JSON.parse → mutate header → writeFileSync`。两个并发 DELETE（删父 + 删子，或两个子）会交叉覆盖；同一文件被两个请求同时改写时，后写的完全丢失前写的结果。
+
+**当前代码**（核心片段）：
+```ts
+// route.ts:126-140
+for (const file of files) {
+  const childPath = join(dir, file);
+  const content = readFileSync(childPath, "utf8");
+  const lines = content.split("\n");
+  const header = JSON.parse(lines[0]) as { ... };
+  if (header.type === "session" && header.parentSession === filePath) {
+    header.parentSession = parentSessionPath;
+    lines[0] = JSON.stringify(header);
+    writeFileSync(childPath, lines.join("\n"));  // ← 无锁
+  }
+}
+```
+
+**修复方向**：
+- 在 `globalThis` 上加写锁 `Map<sessionPath, Promise>`，对同一文件的所有写入串行化。
+- 收集所有要重写的 child 路径到内存，先全部读完解析，最后用 `fs.promises.writeFile` + tmp + rename 原子替换每个文件。
+- 严格：子文件的 `parentSession` 是绝对路径，DELETE 时**先**把父文件 unlink，再批量改 child header，最后再处理 parentSession 路径失效的 child——避免"重写后又被父路径失效"的中间态。
+
+**建议测试**：
+- 模拟并发 N 个 DELETE 同一父 + 多个子，断言所有 child header 最终一致。
+- 模拟父文件先 unlink 再批量重写 child，断言无 race。
+
+---
+
+### P0-2. 10 分钟 idle timer 与 SSE heartbeat 解耦，长任务被误杀
+
+**位置**：`lib/rpc-manager.ts:50-53`、`app/api/agent/[id]/events/route.ts`（heartbeat）
+
+**问题**：`resetIdleTimer()` 只在 `subscribe` 回调（收到 pi 真实事件）时触发。SSE heartbeat 发的是 `:\n\n` comment frame，不会触发 `subscribe`，因此 timer 不会被重置。agent 等 LLM 响应超过 10 分钟（Opus thinking、长时间工具执行）→ session 被销毁 → SSE 断流 → 用户看到"连接已断开"，需手动重连。
+
+**当前代码**：
+```ts
+// rpc-manager.ts:42-48
+start(): void {
+  this.unsubscribe = this.inner.subscribe((event: AgentEvent) => {
+    this.resetIdleTimer();
+    for (const l of this.listeners) l(event);
+  });
+  this.resetIdleTimer();
+}
+```
+
+**修复方向**（任选一种）：
+- **A. heartbeat 重置 timer**：在 SSE route 里发 heartbeat 时调用 `session.keepAlive()`，wrapper 暴露 `keepAlive()` 只 reset timer。
+- **B. 双向 timer**：把 idle timer 改为"仅在 SSE 断开时启动"——只要有连接就保持 session 存活。理由：SSE 断开意味着用户不再关心这个 session，10 分钟是合理的回收时间。
+- **C. 把 timer 延长到 30 分钟 + 增加 LLM 响应计时器**：长思考模型是已知场景，硬编码 10 分钟偏短。
+
+**建议测试**：
+- 模拟连续 11 分钟只有 heartbeat（无业务事件），断言 wrapper 仍 alive。
+- 模拟 SSE 断开 11 分钟后，断言 wrapper 被销毁。
+
+---
+
+### P0-3. fork / navigate_tree 的状态时序是隐式契约
+
+**位置**：`lib/rpc-manager.ts:113-143`（fork）、`hooks/useAgentSession.ts:431-447`（navigate）
+
+**问题**：
+- `fork` 命令末尾 `this.destroy()` 立即触发 `onDestroyCallback → registry.delete(realSessionId)`，但 `newSessionId` 对应的新 session 此时还没在注册表里（要等 UI 收到响应后主动 `startRpcSession(newSessionId)`）。中间窗口里如果 UI 已用 `newSessionId` 发请求，会落到"重新创建"路径，绕过 pi 的 fork 状态。
+- `navigate_tree` 是 fire-and-forget，UI 立即 `setActiveLeafId(entryId)` + `loadContext(sid, entryId)`，但 navigate 命令本身可能失败（被 pi 拒绝），UI 显示的 leafId 和 agent 实际状态会不一致。
+
+**当前代码**：
+```ts
+// rpc-manager.ts:140-143 (fork)
+const newSessionId = SessionManager.open(newSessionFile, sessionDir).getSessionId();
+cacheSessionPath(newSessionId, newSessionFile);
+this.destroy();   // ← 立即销毁
+return { cancelled: false, newSessionId };
+
+// useAgentSession.ts:434-436 (navigate)
+sendAgentCommand(sid, { type: "navigate_tree", targetId: entryId }).catch(() => {});
+setActiveLeafId(entryId);
+await loadContext(sid, entryId);
+```
+
+**修复方向**：
+- 引入**命令确认事件**：命令 send → 收到 `command_ack` 事件 → UI 才更新。`fork` 拆成两步：先 `prepare_fork` 拿到 newSessionId 并预先注册，再 `commit_fork` 销毁旧 wrapper。中间状态对 UI 透明。
+- 或者更轻量：在 fork 返回前 await `cacheSessionPath` 落盘，并主动 `startRpcSession(newSessionId, newFile, cwd)` 把新 wrapper 注册好（这样销毁旧的同时新已在册）。
+- `navigate_tree` 改为 `await` + 失败时回滚 `setActiveLeafId` 到旧值。
+
+**建议测试**：
+- 模拟 fork 后立即用 newSessionId 发请求，断言不重新创建。
+- 模拟 navigate_tree 失败，断言 UI leafId 回滚。
+
+---
+
+### P0-4. dev 模式 `process.env` 全量透传给 Next.js 子进程
+
+**位置**：`electron/main.ts:158`（推测行号，需要核对）
+
+**问题**：`env: { ...process.env, PORT: String(port) }` 把 Electron 进程的所有环境变量透传给 Next.js dev server。`ELECTRON_*`、`npm_config_*` 暴露给 Next.js 会影响 dev server 行为，且泄露 Electron 内部状态。
+
+**修复方向**：
+```ts
+env: {
+  PORT: String(port),
+  NODE_ENV: process.env.NODE_ENV ?? "development",
+  NEXT_TELEMETRY_DISABLED: "1",
+  ELECTRON_RUN_AS_NODE: "1",  // 显式保留需要的
+  // 显式放行 pi / OpenAI / Anthropic API key 等
+  ...(process.env.ANTHROPIC_API_KEY ? { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY } : {}),
+}
+```
+
+**建议测试**：
+- 启动 dev electron 子进程，断言 Next.js 进程 env 中不含 `npm_config_*`、`ELECTRON_*`（除显式白名单）。
+
+---
+
+### P0-5. ChatWindow 每帧 O(n) 重渲染，长对话卡顿
+
+**位置**：`components/ChatWindow.tsx:295-353`
+
+**问题**：在 `messages.map` 上包了一个 IIFE，每次 render 重新：
+- 建 `toolResultsMap`（O(n)）
+- 反向扫描找 last user（O(n)）
+- 对每条消息 forward scan 找下个 user/assistant（O(n) inside O(n) = O(n²) worst case）
+- 用 `idx` 作 key 触发整列 unmount/remount
+
+**当前代码**（节选）：
+```tsx
+{(() => {
+  const toolResultsMap = new Map<string, ToolResultMessage>();
+  for (const msg of messages) { ... }   // O(n)
+  let lastUserIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) { ... }  // O(n)
+  return messages.map((msg, idx) => {  // O(n) × O(n) = O(n²)
+    // ...
+  });
+})()}
+```
+
+**修复方向**：
+- 抽 `MessageList` 组件，用 `useMemo` 计算 `toolResultsMap` 和 `lastUserIdx`。
+- 给 `MessageView` 套 `React.memo`，key 改用 `entryIds[idx]`（稳定 ID 而非 index）。
+- 内部状态（tool calls 展开、diff 展开）放到 `MessageView` 自己管理。
+- forward scan 改为预计算 `nextUserIdx[]` / `nextAssistantIdx[]` 的 Map。
+
+**建议测试**：
+- 用 React Profiler 记录 1000 条消息的 render 时间，断言优化后 < 16ms。
+- 滚动时无重新 mount 警告。
+
+---
+
+### P0-6. `useAgentSession.ts` mount effect 无依赖 + `eslint-disable`
+
+**位置**：`hooks/useAgentSession.ts:559-584`
+
+**问题**：mount effect 用 `eslint-disable-next-line react-hooks/exhaustive-deps` 强制压制。`session` prop 从 A→B（组件未卸载）时：旧 session 的 SSE 不会被关闭（cleanup 只在 unmount 触发），新的 `connectEvents(session.id)` 在 EventSource 已存在时不会自动重连（`useCallback` 内部检查 `eventSourceRef.current` 才会 close 旧的，但新调用可能直接走 else 分支）。
+
+AppShell 靠 `sessionKey` 强制 remount 掩盖这个 bug——是**隐性契约**，未来加新 prop 必然踩坑。
+
+**当前代码**：
+```ts
+useEffect(() => {
+  if (session) {
+    sessionIdRef.current = session.id;
+    loadSession(session.id, true, true).then((agentState) => { ... });
+  }
+  return () => {
+    eventSourceRef.current?.close();
+    eventSourceRef.current = null;
+  };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+}, []);
+```
+
+**修复方向**：
+- 把 `session?.id` 加进 deps。Effect 内部用 `session.id` 而不是闭包变量。
+- `connectEvents` 内部已经检查 `eventSourceRef.current` 并 close，直接调用即可，无需额外清理逻辑。
+- 移除 `eslint-disable`——CLAUDE.md 提到的"显式关闭三条 react-hooks 规则"应逐条评估必要性，能开的就开。
+
+**建议测试**：
+- 模拟 `session` prop 从 A→B，断言旧 EventSource 被关闭、新 EventSource 已建立。
+- 模拟 `session` 从 A→null，断言 EventSource 被关闭、无 in-flight loadSession 副作用。
+
+---
+
+## 2. P1 — 应该改
+
+### P1-1. `lib/normalize.ts` 用了 `as` 断言 + API catch 返回 `String(error)`
+
+**位置**：`lib/normalize.ts:23, 29`、`app/api/agent/[id]/route.ts:34-35`、`app/api/sessions/[id]/route.ts:74-75, 97-98, 147-148`
+
+**问题**：
+- `normalizeToolCalls` 接收 `Partial<AgentMessage>` 然后 `as AssistantMessage` 强制断言，运行时类型不匹配会静默错乱。
+- API route 的 `catch (error) { return NextResponse.json({ error: String(error) }) }` 丢 stack、丢上下文，调试只能看客户端 console。
+
+**修复方向**：
+- `normalize.ts` 入口加 zod schema 或运行时类型守卫（`isAssistantMessage(msg: AgentMessage): msg is AssistantMessage & { ... }`）。
+- API catch 统一走 `logError(err, { route, params })` 写结构化日志（用项目里已有的 `writeLog`），response 返回 `{ error: { code, message, requestId } }`。
+- 引入 `requestId` middleware（`x-request-id` header），日志和响应贯穿。
+
+**严重性说明**：单独看每个都是 🟡，但叠加效果是"pi 包输出意外格式 → UI 静默错乱 + 调试无门"，应一起修。
+
+---
+
+### P1-2. SSE `JSON.parse` 失败被静默吞掉
+
+**位置**：`hooks/useAgentSession.ts:226-228`
+
+```ts
+es.onmessage = (e) => {
+  try {
+    const event = JSON.parse(e.data) as AgentEvent;
+    handleAgentEventRef.current?.(event);
+  } catch {
+    // ignore
+  }
+};
+```
+
+**修复**：`console.warn("[SSE] malformed event", e.data)`。dev 环境带 stack，prod 上报到 Sentry 类服务（前提是 P2-1 的可观测性建设）。
+
+---
+
+### P1-3. `FileViewer` 大文件无虚拟滚动
+
+**位置**：`components/FileViewer.tsx:815-838`
+
+**问题**：`SyntaxHighlighter` 渲染全部内容，5000+ 行文件每次 render 全量 diff/高亮。
+
+**修复方向**：
+- 行数 > 1000 时启用虚拟滚动（`@tanstack/react-virtual`）。
+- 或者：只渲染可见区域 + 滚动时增量加载。
+- 文件大小 > 256KB 时给"以原始文本查看"选项。
+
+---
+
+### P1-4. URL 状态 ↔ React 状态双向同步用 `suppressCwdBumpRef` 互相抑制
+
+**位置**：`components/AppShell.tsx:164-184`、`components/SessionSidebar.tsx:254-259`
+
+**问题**：典型的"打补丁式状态同步"——`Sidebar` 的 `setSelectedCwd` → `onCwdChange` effect → AppShell 的 `handleCwdChange` → `router.replace` → URL 变 → Sidebar 重新 render → `setSelectedCwd` 再次触发。中间用 `suppressCwdBumpRef` 抑制信号避免循环。任何后续改动都可能打破这个脆弱的契约。
+
+**修复方向**：
+- AppShell 作为 URL 的 **single source of truth**，用 `useSearchParams` 监听 URL 变化，push 到内部 state。
+- Sidebar 只发 action（onCwdChange 回调），不读 URL。
+- 删除 `suppressCwdBumpRef` 和所有 `if (suppressRef.current) return` 分支。
+
+---
+
+### P1-5. 端口扫描 TOCTOU 竞争
+
+**位置**：`electron/main.ts:136-152`（推测）
+
+**问题**：`isPortReachable(port)` 和 `reservePort(port)` 之间有竞争窗口，另一进程可能在中间抢走端口。
+
+**修复**：直接 `net.createServer().listen(port).unref()`，成功即代表端口可用，失败换下一个。
+
+---
+
+### P1-6. 启动后 Next.js 进程崩溃无自动恢复
+
+**位置**：`electron/main.ts:205-213`
+
+**问题**：进程退出后只更新状态显示"已停止"，不重启。生产环境短暂端口冲突让用户必须手动重启整个 app。
+
+**修复方向**：
+- 引入 supervisor 状态机：`starting → ready → supervised`。`supervised` 状态下进程退出 → 自动重试（指数退避 1s/2s/4s/...），最多 3 次。
+- 重试次数用完后切回 `error` 状态，弹"重试"按钮。
+
+---
+
+### P1-7. `electron-builder.yml` 的 extraResources 列表手工维护
+
+**位置**：`electron-builder.yml:50-56`
+
+**问题**：19 个 npm 包手写，漏一个就 `MODULE_NOT_FOUND`。依赖图变化后这个列表需要手动同步。
+
+**修复方向**：
+```yaml
+extraResources:
+  - from: .next/standalone
+    to: standalone
+    filter: ["**/*", "!node_modules"]
+  - from: .next/standalone/node_modules
+    to: standalone/node_modules
+  - from: .next/static
+    to: standalone/.next/static
+  - from: public
+    to: standalone/public
+  # 不再手写 electron-updater 的传递依赖
+```
+让 electron-builder 自己解析。`asarUnpack` 处理需要写入的目录（logs、config）。
+
+---
+
+### P1-8. `electron/startup.html:133` 的 CSP 是 `script-src 'unsafe-inline'`
+
+**位置**：`electron/startup.html:133`
+
+**问题**：CSP 允许内联脚本，message 注入虽然用 `textContent`（安全），但纵深不足——任何后续改 `innerHTML` 的提交都会引入 XSS。
+
+**修复**：用 `<script src="...">` 拆出内联脚本，CSP 改为 `script-src 'self'`。
+
+---
+
+### P1-9. SKILLS_API_URL 改 env 后可能变 SSRF
+
+**位置**：`app/api/skills/search/route.ts:63`
+
+**问题**：`SKILLS_API_URL` 默认是 `https://skills.sh`，但 env 变量没有校验。如果攻击者通过某种途径修改（共享电脑、CI 注入）会变成任意 URL → SSRF。
+
+**修复方向**：
+- 启动时校验 env，URL 必须在白名单（`skills.sh` / staging / 本地 mock）。
+- 或在 `route.ts` 入口固定 `const ALLOWED_HOSTS = ["skills.sh", "staging.skills.sh"]`，请求前比对。
+
+---
+
+### P1-10. 派生值未 memo
+
+**位置**：`hooks/useAgentSession.ts:131`（currentModel）、`hooks/useAgentSession.ts:134-149`（sessionStats）
+
+**问题**：`currentModel` 和 `sessionStats` 每次 render 重算。`sessionStats` 遍历整个 messages 数组。
+
+**修复**：包 `useMemo`。`currentModel` 的 deps 是 `[currentModelOverride, data?.context.model, pendingModel]`；`sessionStats` 的 deps 是 `[messages]`。
+
+---
+
+## 3. P2 — 锦上添花
+
+### P2-1. 完全没有可观测性
+
+**现状**：`console.*` 在 Electron 同步写文件但无级别；autoUpdater 有 `logError` 但其他全无。生产环境出错只能看本地文件。
+
+**修复方向**：
+- 引入轻量结构化日志（`pino`）替代 `console.*`。
+- API route catch 统一 `logError(err, { route, requestId })`。
+- 可选：接 Sentry 类服务（需要权衡隐私 vs 调试便利）。
+
+---
+
+### P2-2. fork / compact 核心逻辑零测试
+
+**位置**：`lib/rpc-manager.ts:113-143`（fork）、`lib/rpc-manager.ts:163-181`（compact）
+
+**修复**：
+- `lib/rpc-manager.test.ts` 测 fork 成功 / 取消（cancelled）/ invalid entryId / 旧 wrapper 已销毁。
+- `electron/process-tree.test.ts` 测 pid 为 null、Windows 路径、`taskkill /T` 退出码。
+
+---
+
+### P2-3. 工具名白名单硬编码
+
+**位置**：`lib/rpc-manager.ts:299`
+
+```ts
+const allCodingToolNames = ["read", "bash", "edit", "write", "grep", "find", "ls"];
+```
+
+**修复**：首次启动时从 `inner.getAllTools()` 缓存到 `globalThis.__piBuiltInToolNames`，避免硬编码与 pi 包不同步。
+
+---
+
+### P2-4. 启动日志缺关键信息
+
+**位置**：`electron/main.ts:100`
+
+**修复**：`logStartupTiming` 在 dev 模式 console.log，prod 模式写文件。错误状态（`serverState === "stopped"`）的 message 应带退出码、信号量、最近 N 行 stdout/stderr。
+
+---
+
+### P2-5. 无 git hooks / CI
+
+**修复**：加 `husky` + `lint-staged`（`pre-commit` 跑 `tsc --noEmit` + `eslint --fix`），GitHub Actions 跑 `npm test` + `npm run build`。
+
+---
+
+### P2-6. AGENTS.md 警告与脚本命名歧义
+
+**修复**：把 `npm run build` 重命名为 `npm run build:standalone`（更明确），AGENTS.md 警告改为指向这个明确名字。
+
+---
+
+## 4. 测试覆盖盲区（建议修复 P0 时同步补）
+
+| 模块 | 现状 | 建议补 |
+|---|---|---|
+| `lib/rpc-manager.ts` fork | 0 测试 | fork 成功 / 取消 / invalid entryId / 旧 wrapper 销毁 |
+| `lib/rpc-manager.ts` compact | 0 测试 | `historyEnd <= boundaryStart` 抛错 / 正常路径 |
+| `app/api/sessions/[id]/route.ts` DELETE | 0 测试 | 并发 DELETE 父 + 子 / 级联重写原子性 |
+| `app/api/agent/[id]/events/route.ts` SSE | 0 测试 | heartbeat 触发 / client disconnect 清理 / `req.signal.abort` |
+| `electron/process-tree.ts` | 0 测试 | Windows `taskkill /T` / pid 为 null 边界 |
+| `hooks/useAgentSession.ts` SSE 重连 | 0 测试 | 1s 后重连 / `agentRunningRef` 切换时不重连 |
+| `lib/normalize.ts` | 缺边界 | `toolCallId` / `id` 都缺 / 都是空串的降级 |
+
+---
+
+## 5. 重构优先级（如果你只有 1 周）
+
+| 优先级 | 项 | 理由 |
+|---|---|---|
+| **P0 周一** | P0-1 JSONL 写锁 + P0-2 idle timer | 唯一可能导致**静默数据丢失**的两条 |
+| **P0 周二** | P0-3 fork 时序契约 | 跨 RPC + SSE + UI 三层，迟早踩 |
+| **P0 周三-四** | P0-5 ChatWindow 渲染 + P0-6 hooks mount effect | 影响**所有**长会话用户的体验，根因都在 hooks 层 |
+| **P0 周五** | P1-1 normalize + API catch（一个 PR 拿到类型安全 + 可观测性） |  |
+| **P1 同步** | 补 P0 涉及的测试（参考第 4 节） | 避免回归 |
+| **P1 第二周** | P1-4 URL 状态 + P1-7 extraResources + P1-6 启动恢复 | 影响发版质量，不影响日常开发 |
+| **P2 攒批** | 上面 6 条 | 见仁见智，可分配 1 PR / 1 条 |
+
+---
+
+## 6. 范围外 / 后续议题
+
+- **i18n**：当前 UI 文案英文 + 部分 thinking level 描述中文（混合状态）。P2 之外。
+- **Error Boundary**：组件级错误边界缺失，SSE 断连或数据异常可能导致整页崩溃。P1 范围但优先级低于上述项。
+- **OAuth 流程**：`/api/auth/login/[provider]` 的 SSE 流式认证未深入审。
+- **打包体积**：`build/` 目录的具体包体未实测，P1-7 改完后建议跑一次对比。
+
+---
+
+## 7. 评审方法
+
+- 4 个并行 Explore agent 分别扫描：数据层 + Agent 生命周期 / UI 状态 + React 数据流 / API + Electron 集成 / 横切关注点（测试/类型/错误/可观测性）。
+- 本文档对 P0 全部位置在主分支上做了 Read 复核；P1/P2 引用的是 agent 报告的行号，建议动手前用 Read 核对一次。
+- 没有运行 `npm test` / `npm run build` / 启动 dev server——本评审仅静态分析。修复时建议同步跑一遍验证。

--- a/docs/superpowers/plans/2026-06-01-p0-1-jsonl-write-lock.md
+++ b/docs/superpowers/plans/2026-06-01-p0-1-jsonl-write-lock.md
@@ -1,0 +1,543 @@
+# P0-1 JSONL 写并发安全 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** DELETE /api/sessions/[id] 路径在并发场景下保证 JSONL 文件写串行化 + 单次写原子可见，并通过纯函数层单测覆盖级联改写的所有边界。
+
+**Architecture:** 抽两个新文件（`lib/session-cascade.ts` 纯函数 + `lib/session-lock.ts` 进程内文件级写锁），promise chain + `globalThis` Map 实现锁；DELETE route 用 `withFileLock(atomicWriteFile)` 串行化所有 child 改写和 parent unlink。
+
+**Tech Stack:** Node 20+、TypeScript 5 (strict)、ESM only、`node --test`。无新依赖。
+
+**Spec:** `docs/superpowers/specs/2026-06-01-p0-1-jsonl-write-lock-design.md`
+
+---
+
+## File Structure
+
+| 文件 | 动作 | 职责 |
+|---|---|---|
+| `lib/session-cascade.ts` | 新建 | 纯函数 `rewriteChildHeader(content, oldParent, newParent) → { newContent, changed }` |
+| `lib/session-cascade.test.ts` | 新建 | 9 个单元测试 |
+| `lib/session-lock.ts` | 新建 | 进程内文件级写锁 `withFileLock(path, fn)` |
+| `lib/session-lock.test.ts` | 新建 | 4 个并发测试 |
+| `app/api/sessions/[id]/route.ts` | 修改 | DELETE handler 用 cascade + lock + atomicWriteFile |
+
+`atomicWriteFile` 内联在 route 内（一次性 helper，不抽到 lib）。
+
+---
+
+## Task 1: 纯函数 `rewriteChildHeader`
+
+**Files:**
+- Create: `lib/session-cascade.test.ts`
+- Create: `lib/session-cascade.ts`
+
+- [ ] **Step 1.1: 写 9 个失败测试**
+
+Create `lib/session-cascade.test.ts`:
+
+```typescript
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { rewriteChildHeader } from "./session-cascade";
+
+const sampleChild = (parent: string | undefined) => ({
+  type: "session",
+  version: 3,
+  id: "child-uuid",
+  timestamp: "2026-06-01T00:00:00Z",
+  cwd: "/tmp/test",
+  ...(parent !== undefined ? { parentSession: parent } : {}),
+});
+
+const format = (header: object) =>
+  JSON.stringify(header) + "\n" +
+  JSON.stringify({ type: "message", id: "m1", parentId: null, message: { role: "user", content: "hi" } }) + "\n";
+
+test("rewrites child when parentSession matches oldParent", () => {
+  const oldParent = "/sessions/parent.jsonl";
+  const newParent = "/sessions/grandparent.jsonl";
+  const content = format(sampleChild(oldParent));
+  const { newContent, changed } = rewriteChildHeader(content, oldParent, newParent);
+  assert.equal(changed, true);
+  const newHeader = JSON.parse(newContent.split("\n")[0]);
+  assert.equal(newHeader.parentSession, newParent);
+  assert.equal(newHeader.id, "child-uuid");
+});
+
+test("leaves child unchanged when parentSession is different", () => {
+  const content = format(sampleChild("/sessions/other.jsonl"));
+  const { newContent, changed } = rewriteChildHeader(
+    content,
+    "/sessions/parent.jsonl",
+    "/sessions/grandparent.jsonl",
+  );
+  assert.equal(changed, false);
+  assert.equal(newContent, content);
+});
+
+test("leaves child unchanged when header is malformed JSON", () => {
+  const content = "not json at all\n" + JSON.stringify({ type: "message" });
+  const { newContent, changed } = rewriteChildHeader(
+    content,
+    "/sessions/parent.jsonl",
+    "/sessions/grandparent.jsonl",
+  );
+  assert.equal(changed, false);
+  assert.equal(newContent, content);
+});
+
+test("leaves child unchanged when type is not 'session'", () => {
+  const content = JSON.stringify({ type: "message", id: "m1" }) + "\n";
+  const { newContent, changed } = rewriteChildHeader(
+    content,
+    "/sessions/parent.jsonl",
+    "/sessions/grandparent.jsonl",
+  );
+  assert.equal(changed, false);
+  assert.equal(newContent, content);
+});
+
+test("removes parentSession when newParent is null", () => {
+  const oldParent = "/sessions/parent.jsonl";
+  const content = format(sampleChild(oldParent));
+  const { newContent, changed } = rewriteChildHeader(content, oldParent, null);
+  assert.equal(changed, true);
+  const newHeader = JSON.parse(newContent.split("\n")[0]);
+  assert.equal("parentSession" in newHeader, false);
+  assert.equal(newHeader.id, "child-uuid");
+});
+
+test("preserves all other header fields", () => {
+  const header = {
+    type: "session",
+    version: 3,
+    id: "child-uuid",
+    timestamp: "2026-06-01T00:00:00Z",
+    cwd: "/tmp/test",
+    customField: "preserved",
+    nested: { a: 1, b: 2 },
+    parentSession: "/sessions/parent.jsonl",
+  };
+  const content = JSON.stringify(header) + "\n";
+  const { newContent, changed } = rewriteChildHeader(
+    content,
+    "/sessions/parent.jsonl",
+    "/sessions/grandparent.jsonl",
+  );
+  assert.equal(changed, true);
+  const newHeader = JSON.parse(newContent.split("\n")[0]);
+  assert.equal(newHeader.customField, "preserved");
+  assert.deepEqual(newHeader.nested, { a: 1, b: 2 });
+});
+
+test("preserves rest of file content beyond first line", () => {
+  const line1 = JSON.stringify(sampleChild("/sessions/parent.jsonl"));
+  const line2 = JSON.stringify({ type: "message", id: "m1", parentId: null, message: { role: "user", content: "hi" } });
+  const line3 = JSON.stringify({ type: "message", id: "m2", parentId: "m1", message: { role: "assistant", content: [] } });
+  const content = line1 + "\n" + line2 + "\n" + line3 + "\n";
+  const { newContent, changed } = rewriteChildHeader(
+    content,
+    "/sessions/parent.jsonl",
+    "/sessions/grandparent.jsonl",
+  );
+  assert.equal(changed, true);
+  const lines = newContent.split("\n");
+  assert.equal(JSON.parse(lines[0]).parentSession, "/sessions/grandparent.jsonl");
+  assert.equal(lines[1], line2);
+  assert.equal(lines[2], line3);
+  assert.equal(lines[3], "");
+});
+
+test("handles empty content", () => {
+  const { newContent, changed } = rewriteChildHeader(
+    "",
+    "/sessions/parent.jsonl",
+    "/sessions/grandparent.jsonl",
+  );
+  assert.equal(changed, false);
+  assert.equal(newContent, "");
+});
+
+test("handles content without trailing newline", () => {
+  const line1 = JSON.stringify(sampleChild("/sessions/parent.jsonl"));
+  const line2 = JSON.stringify({ type: "message", id: "m1" });
+  const content = line1 + "\n" + line2;
+  const { newContent, changed } = rewriteChildHeader(
+    content,
+    "/sessions/parent.jsonl",
+    "/sessions/grandparent.jsonl",
+  );
+  assert.equal(changed, true);
+  const lines = newContent.split("\n");
+  assert.equal(lines.length, 2);
+  assert.equal(JSON.parse(lines[0]).parentSession, "/sessions/grandparent.jsonl");
+  assert.equal(lines[1], line2);
+});
+```
+
+- [ ] **Step 1.2: 运行测试，验证失败**
+
+Run: `node --test lib/session-cascade.test.ts`
+Expected: FAIL with `Cannot find module './session-cascade'` or similar module-not-found.
+
+- [ ] **Step 1.3: 实现 `rewriteChildHeader`**
+
+Create `lib/session-cascade.ts`:
+
+```typescript
+export interface RewriteResult {
+  newContent: string;
+  changed: boolean;
+}
+
+/**
+ * Pure function: decide whether to rewrite a child session file's first-line
+ * header to change its `parentSession` from `oldParent` to `newParent`.
+ *
+ * - If the first line is malformed JSON, type is not "session", or
+ *   parentSession doesn't match oldParent, returns { newContent: content,
+ *   changed: false }.
+ * - If newParent is null, removes the parentSession key from the header
+ *   (not sets it to null).
+ * - Preserves all other header fields and all content beyond the first line.
+ */
+export function rewriteChildHeader(
+  content: string,
+  oldParent: string,
+  newParent: string | null,
+): RewriteResult {
+  if (content.length === 0) return { newContent: content, changed: false };
+
+  const newlineIdx = content.indexOf("\n");
+  const firstLineRaw = newlineIdx === -1 ? content : content.slice(0, newlineIdx);
+  const rest = newlineIdx === -1 ? "" : content.slice(newlineIdx);
+
+  let header: Record<string, unknown>;
+  try {
+    header = JSON.parse(firstLineRaw) as Record<string, unknown>;
+  } catch {
+    return { newContent: content, changed: false };
+  }
+
+  if (header.type !== "session" || header.parentSession !== oldParent) {
+    return { newContent: content, changed: false };
+  }
+
+  if (newParent === null) {
+    delete header.parentSession;
+  } else {
+    header.parentSession = newParent;
+  }
+
+  return { newContent: JSON.stringify(header) + rest, changed: true };
+}
+```
+
+- [ ] **Step 1.4: 运行测试，验证通过**
+
+Run: `node --test lib/session-cascade.test.ts`
+Expected: PASS — all 9 tests.
+
+- [ ] **Step 1.5: 提交**
+
+```bash
+git add lib/session-cascade.ts lib/session-cascade.test.ts
+git commit -m "feat(session-cascade): pure rewriteChildHeader for parent reparenting"
+```
+
+---
+
+## Task 2: 文件级写锁 `withFileLock`
+
+**Files:**
+- Create: `lib/session-lock.test.ts`
+- Create: `lib/session-lock.ts`
+
+- [ ] **Step 2.1: 写 4 个失败测试**
+
+Create `lib/session-lock.test.ts`:
+
+```typescript
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { withFileLock } from "./session-lock";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __piWriteLocks: Map<string, Promise<unknown>> | undefined;
+}
+
+beforeEach(() => {
+  globalThis.__piWriteLocks = undefined;
+});
+
+test("serializes 100 concurrent calls on same path", async () => {
+  const target = path.resolve("/tmp/lock-test-A");
+  const order: number[] = [];
+  const tasks = Array.from({ length: 100 }, (_, i) =>
+    withFileLock(target, async () => {
+      const prev = order[order.length - 1] ?? -1;
+      assert.equal(i, prev + 1, `task ${i} ran out of order (prev was ${prev})`);
+      order.push(i);
+      await new Promise((r) => setImmediate(r));
+    }),
+  );
+  await Promise.all(tasks);
+  assert.equal(order.length, 100);
+  assert.equal(order[0], 0);
+  assert.equal(order[99], 99);
+});
+
+test("does not block calls on different paths", async () => {
+  const a = path.resolve("/tmp/lock-test-B");
+  const b = path.resolve("/tmp/lock-test-C");
+  const start = Date.now();
+  await Promise.all([
+    withFileLock(a, async () => {
+      await new Promise((r) => setTimeout(r, 100));
+    }),
+    withFileLock(b, async () => {
+      await new Promise((r) => setTimeout(r, 100));
+    }),
+  );
+  const elapsed = Date.now() - start;
+  assert.ok(elapsed < 180, `expected < 180ms, got ${elapsed}ms`);
+});
+
+test("releases lock when fn throws", async () => {
+  const target = path.resolve("/tmp/lock-test-D");
+  await assert.rejects(
+    withFileLock(target, async () => {
+      throw new Error("intentional");
+    }),
+    /intentional/,
+  );
+  const start = Date.now();
+  await withFileLock(target, async () => {});
+  const elapsed = Date.now() - start;
+  assert.ok(elapsed < 50, `lock not released: ${elapsed}ms wait`);
+});
+
+test("cleans up map entry after release", async () => {
+  const target = path.resolve("/tmp/lock-test-E");
+  await withFileLock(target, async () => {});
+  const map = globalThis.__piWriteLocks;
+  if (map !== undefined) {
+    assert.equal(map.has(target), false, "map should not contain entry after release");
+  }
+});
+```
+
+- [ ] **Step 2.2: 运行测试，验证失败**
+
+Run: `node --test lib/session-lock.test.ts`
+Expected: FAIL with `Cannot find module './session-lock'`.
+
+- [ ] **Step 2.3: 实现 `withFileLock`**
+
+Create `lib/session-lock.ts`:
+
+```typescript
+import path from "node:path";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __piWriteLocks: Map<string, Promise<unknown>> | undefined;
+}
+
+/**
+ * Acquire a process-level write lock on a file path, run `fn`, then release.
+ *
+ * - Per-file granularity: different paths do not block each other.
+ * - Reentrancy NOT supported: calling withFileLock(samePath) inside a fn
+ *   holding the lock will deadlock.
+ * - Map entry is cleaned up after release if no later caller has chained on.
+ * - globalThis is used to survive Next.js hot reloads (matches the
+ *   __piSessions / __piStartLocks pattern in lib/rpc-manager.ts).
+ */
+export async function withFileLock<T>(
+  filePath: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const key = path.resolve(filePath);
+  const locks = (globalThis.__piWriteLocks ??= new Map<string, Promise<unknown>>());
+
+  const prev = locks.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const ourEntry = prev.then(() => gate);
+  locks.set(key, ourEntry);
+
+  try {
+    await prev;
+    return await fn();
+  } finally {
+    release();
+    if (locks.get(key) === ourEntry) {
+      locks.delete(key);
+    }
+  }
+}
+```
+
+- [ ] **Step 2.4: 运行测试，验证通过**
+
+Run: `node --test lib/session-lock.test.ts`
+Expected: PASS — all 4 tests.
+
+- [ ] **Step 2.5: 提交**
+
+```bash
+git add lib/session-lock.ts lib/session-lock.test.ts
+git commit -m "feat(session-lock): process-level file write lock"
+```
+
+---
+
+## Task 3: 改造 DELETE handler
+
+**Files:**
+- Modify: `app/api/sessions/[id]/route.ts` (import block + DELETE handler)
+
+- [ ] **Step 3.1: 替换 import 块**
+
+In `app/api/sessions/[id]/route.ts`, replace the import block (lines 1-11) with:
+
+```typescript
+import { NextResponse } from "next/server";
+import { readdirSync, readFileSync, statSync, unlinkSync } from "fs";
+import { writeFile, rename, unlink } from "fs/promises";
+import { join } from "path";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import {
+  resolveSessionPath,
+  invalidateSessionPathCache,
+  buildSessionContext,
+  listAllSessions,
+} from "@/lib/session-reader";
+import { getRpcSession } from "@/lib/rpc-manager";
+import { rewriteChildHeader } from "@/lib/session-cascade";
+import { withFileLock } from "@/lib/session-lock";
+```
+
+变更：
+- 移除 `writeFileSync`（不再使用）
+- 新增 `import { writeFile, rename, unlink } from "fs/promises"` 给 atomicWriteFile
+- 新增 cascade + lock 的 import
+
+- [ ] **Step 3.2: 替换 DELETE 函数 + 新增 atomicWriteFile helper**
+
+替换 `app/api/sessions/[id]/route.ts` 中 line 102-150（整个 DELETE handler）为：
+
+```typescript
+// DELETE /api/sessions/[id]
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  try {
+    const filePath = await resolveSessionPath(id);
+    if (!filePath) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    // 1. Read parent's first line to get grandparent path
+    let parentSessionPath: string | null = null;
+    try {
+      const firstLine = readFileSync(filePath, "utf8").split("\n")[0];
+      const header = JSON.parse(firstLine) as { type?: string; parentSession?: string };
+      if (header.type === "session") parentSessionPath = header.parentSession ?? null;
+    } catch { /* malformed parent — grandparent remains null */ }
+
+    // 2. Enumerate siblings
+    const dir = filePath.replace(/\\/g, "/").split("/").slice(0, -1).join("/");
+    const siblingFiles: string[] = [];
+    try {
+      siblingFiles.push(
+        ...readdirSync(dir)
+          .filter((f) => f.endsWith(".jsonl"))
+          .map((f) => join(dir, f))
+          .filter((p) => p !== filePath)
+      );
+    } catch { /* dir unreadable — no cascade possible */ }
+
+    // 3. Identify and rewrite children (under per-file lock, atomic write)
+    for (const childPath of siblingFiles) {
+      let content: string;
+      try { content = readFileSync(childPath, "utf8"); }
+      catch { continue; /* race: child deleted between readdir and read */ }
+
+      const { newContent, changed } = rewriteChildHeader(content, filePath, parentSessionPath);
+      if (!changed) continue;
+
+      await withFileLock(childPath, () => atomicWriteFile(childPath, newContent));
+    }
+
+    // 4. Unlink parent (under lock, swallow race-condition unlink failure)
+    await withFileLock(filePath, () => {
+      try { unlinkSync(filePath); } catch { /* race: already deleted */ }
+    });
+    invalidateSessionPathCache(id);
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    return NextResponse.json({ error: String(error) }, { status: 500 });
+  }
+}
+
+async function atomicWriteFile(p: string, content: string): Promise<void> {
+  const tmp = `${p}.tmp`;
+  await writeFile(tmp, content, "utf8");
+  try {
+    await rename(tmp, p);
+  } catch (e) {
+    try { await unlink(tmp); } catch { /* best effort */ }
+    throw e;
+  }
+}
+```
+
+- [ ] **Step 3.3: 类型检查 + lint**
+
+Run: `npx tsc --noEmit`
+Expected: 通过，无错误。
+
+Run: `npm run lint`
+Expected: 通过，无错误。
+
+- [ ] **Step 3.4: 提交**
+
+```bash
+git add app/api/sessions/[id]/route.ts
+git commit -m "fix(sessions-delete): cascade reparent under file lock + atomic write"
+```
+
+---
+
+## Task 4: 验证
+
+- [ ] **Step 4.1: 跑新增测试**
+
+Run: `node --test lib/session-cascade.test.ts lib/session-lock.test.ts`
+Expected: 全部通过（13 tests: 9 cascade + 4 lock）。
+
+- [ ] **Step 4.2: 跑全量测试套件**
+
+Run: `node --test lib/*.test.ts electron/*.test.ts 'app/**/*.test.ts'`
+Expected: 全部通过（已有测试 + 新增 13 个）。
+
+- [ ] **Step 4.3: 类型检查 + lint**
+
+Run: `npx tsc --noEmit && npm run lint`
+Expected: 通过。
+
+- [ ] **Step 4.4: 手动验证（写进 PR description）**
+
+- [ ] 启动 dev (`npm run dev`)，浏览器创建父会话、发消息、fork 子会话
+- [ ] 删父会话，验证子会话在 sidebar 重新挂到 grandparent
+- [ ] 同时打开两个浏览器 tab 登同一 cwd，分别删父和子；用 `head -1 <file>.jsonl` 看第一行是合法 JSON
+- [ ] 手动改坏一个 child jsonl 的第一行（比如改成 `not json`），触发 cascade；验证 DELETE 仍能完成（malformed child 被 skip，其他 child 正常改写）

--- a/docs/superpowers/plans/2026-06-01-p0-2-idle-timer.md
+++ b/docs/superpowers/plans/2026-06-01-p0-2-idle-timer.md
@@ -1,0 +1,261 @@
+# P0-2 idle timer 与 SSE heartbeat 解耦 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 长任务下 SSE heartbeat 重置 idle timer，避免 wrapper 被误杀；客户端断开后 timer 仍能正常回收 wrapper。
+
+**Architecture:** `AgentSessionWrapper` 暴露 `keepAlive()` 方法，调用现有 `resetIdleTimer()`；SSE heartbeat 把 `keepAlive()` 放在 `enqueue` 成功之后的同一 try 块内——客户端断开时跳过 keepAlive，timer 正常到期销毁。
+
+**Tech Stack:** Node 20+、TypeScript 5 (strict)、ESM only、`node --test` + `mock.timers`。无新依赖。
+
+**Spec:** `docs/superpowers/specs/2026-06-01-p0-2-idle-timer-design.md`
+
+---
+
+## File Structure
+
+| 文件 | 动作 | 职责 |
+|---|---|---|
+| `lib/rpc-manager.test.ts` | 新建 | 3 个 fake-timer 测试（无活动销毁、keepAlive 重置、事件重置回归） |
+| `lib/rpc-manager.ts` | 修改 | `AgentSessionWrapper` 加 `keepAlive()` 公开方法 |
+| `app/api/agent/[id]/events/route.ts` | 修改 | heartbeat 调 `session.keepAlive()` |
+
+---
+
+## Task 1: `keepAlive()` + tests
+
+**Files:**
+- Create: `lib/rpc-manager.test.ts`
+- Modify: `lib/rpc-manager.ts` (在 `onDestroy` 之后、`send` 之前新增 `keepAlive` 方法)
+
+- [ ] **Step 1.1: 写 3 个失败测试**
+
+Create `lib/rpc-manager.test.ts`:
+
+```typescript
+import test, { mock } from "node:test";
+import assert from "node:assert/strict";
+import { AgentSessionWrapper } from "./rpc-manager.ts";
+
+type SubscribeFn = (cb: (event: unknown) => void) => () => void;
+
+function makeStubInner(overrides: { subscribe?: SubscribeFn } = {}) {
+  return {
+    sessionId: "stub",
+    sessionFile: "stub.jsonl",
+    isStreaming: false,
+    isCompacting: false,
+    autoCompactionEnabled: false,
+    autoRetryEnabled: false,
+    model: null,
+    getContextUsage: () => null,
+    agent: { state: { systemPrompt: "", thinkingLevel: "off" } },
+    sessionManager: null,
+    modelRegistry: null,
+    subscribe: overrides.subscribe ?? ((_cb: (event: unknown) => void) => () => {}),
+  } as never;
+}
+
+test("wrapper is destroyed after 10 min of inactivity", () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  try {
+    const w = new AgentSessionWrapper(makeStubInner());
+    let destroyed = false;
+    w.onDestroy(() => { destroyed = true; });
+    w.start();
+
+    mock.timers.tick(9 * 60 * 1000);
+    assert.equal(destroyed, false, "should still be alive after 9 min");
+
+    mock.timers.tick(60 * 1000);
+    assert.equal(destroyed, true, "should be destroyed after 10 min");
+  } finally {
+    mock.timers.reset();
+  }
+});
+
+test("keepAlive resets the idle timer", () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  try {
+    const w = new AgentSessionWrapper(makeStubInner());
+    let destroyed = false;
+    w.onDestroy(() => { destroyed = true; });
+    w.start();
+
+    mock.timers.tick(9 * 60 * 1000);
+    assert.equal(destroyed, false);
+
+    w.keepAlive();
+
+    mock.timers.tick(9 * 60 * 1000);
+    assert.equal(destroyed, false, "should still be alive 9 min after keepAlive");
+
+    mock.timers.tick(60 * 1000);
+    assert.equal(destroyed, true, "should be destroyed 10 min after keepAlive");
+  } finally {
+    mock.timers.reset();
+  }
+});
+
+test("events reset the idle timer (regression)", () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  try {
+    let emittedCb: ((event: unknown) => void) | null = null;
+    const inner = makeStubInner({
+      subscribe: (cb) => { emittedCb = cb; return () => {}; },
+    });
+    const w = new AgentSessionWrapper(inner);
+    let destroyed = false;
+    w.onDestroy(() => { destroyed = true; });
+    w.start();
+
+    mock.timers.tick(9 * 60 * 1000);
+    assert.equal(destroyed, false);
+
+    emittedCb!({ type: "agent_start" });
+
+    mock.timers.tick(9 * 60 * 1000);
+    assert.equal(destroyed, false, "should still be alive 9 min after pi event");
+
+    mock.timers.tick(60 * 1000);
+    assert.equal(destroyed, true, "should be destroyed 10 min after last event");
+  } finally {
+    mock.timers.reset();
+  }
+});
+```
+
+- [ ] **Step 1.2: 运行测试，验证失败**
+
+Run: `node --test lib/rpc-manager.test.ts`
+Expected: FAIL — 第二个和第三个测试因 `keepAlive` 不存在会报 `TypeError: w.keepAlive is not a function`。第一个测试可能因同样的原因或在编译期就失败。
+
+- [ ] **Step 1.3: 实现 `keepAlive`**
+
+In `lib/rpc-manager.ts`，找到 `onDestroy` 方法（位于 `onEvent` 之后、`send` 之前），在其后插入：
+
+```typescript
+  /**
+   * Signal that this wrapper is still in use (e.g., SSE heartbeat).
+   * Resets the idle timer without emitting any events.
+   */
+  keepAlive(): void {
+    this.resetIdleTimer();
+  }
+```
+
+注意：
+- 缩进匹配上下文（class 内部 2 空格）
+- 放在 `onDestroy` 块（line ~63-65）之后、`async send` 之前
+
+- [ ] **Step 1.4: 运行测试，验证通过**
+
+Run: `node --test lib/rpc-manager.test.ts`
+Expected: PASS — 3/3 tests。
+
+- [ ] **Step 1.5: 提交**
+
+```bash
+git add lib/rpc-manager.ts lib/rpc-manager.test.ts
+git commit -m "feat(rpc-manager): keepAlive() resets idle timer for SSE heartbeats"
+```
+
+---
+
+## Task 2: SSE heartbeat 调 `keepAlive`
+
+**Files:**
+- Modify: `app/api/agent/[id]/events/route.ts:44-50` (heartbeat setInterval 块)
+
+- [ ] **Step 2.1: 修改 heartbeat 块**
+
+In `app/api/agent/[id]/events/route.ts`，替换 line 44-50 的 heartbeat 块：
+
+替换前：
+```typescript
+      // Heartbeat every 30s to prevent server/proxy timeout (Next.js default ~120-150s)
+      const heartbeat = setInterval(() => {
+        try {
+          controller.enqueue(new TextEncoder().encode(":\n\n"));
+        } catch {
+          // controller already closed
+        }
+      }, 30_000);
+```
+
+替换为：
+```typescript
+      // Heartbeat every 30s to prevent server/proxy timeout (Next.js default ~120-150s).
+      // keepAlive() is called only after a successful enqueue so that when the client
+      // silently disappears, the idle timer eventually fires and destroys the wrapper.
+      const heartbeat = setInterval(() => {
+        try {
+          controller.enqueue(new TextEncoder().encode(":\n\n"));
+          session.keepAlive();
+        } catch {
+          // controller already closed; do not call keepAlive so the idle
+          // timer can eventually destroy the wrapper (no orphan).
+        }
+      }, 30_000);
+```
+
+变更点：
+- 在 `controller.enqueue(...)` 之后、`try` 块内加 `session.keepAlive();`
+- 注释说明为什么 keepAlive 在 try 块内
+
+- [ ] **Step 2.2: 类型检查 + lint**
+
+Run: `npx tsc --noEmit` (use `node_modules/.bin/tsc.cmd` on Windows if `npx tsc` resolves wrong package)
+Expected: 通过，无错误。
+
+Run: `node_modules/.bin/eslint .`
+Expected: 通过，无错误（已有的 1 个 `MessageView.tsx` warning 不算新错）。
+
+- [ ] **Step 2.3: 提交**
+
+```bash
+git add app/api/agent/[id]/events/route.ts
+git commit -m "fix(agent-events): call keepAlive on successful SSE heartbeat"
+```
+
+---
+
+## Task 3: 验证
+
+- [ ] **Step 3.1: 跑全量测试套件**
+
+Run: `node --test lib/*.test.ts electron/*.test.ts 'app/**/*.test.ts'`
+Expected: 全部通过（已有 32 + 新增 3 = 35 tests）。
+
+- [ ] **Step 3.2: 类型检查 + lint**
+
+Run: `node_modules/.bin/tsc --noEmit && node_modules/.bin/eslint .`
+Expected: 通过。
+
+- [ ] **Step 3.3: 手动验证清单（写进 PR description）**
+
+- [ ] 启动 dev (`npm run dev`)，浏览器发送消息触发 agent；进入长思考任务（用一个真正耗时的 prompt，比如 "think very deeply about X"），保持页面打开 > 10 分钟；DevTools Network 面板看 SSE 收到 `:` comment frames；验证 wrapper 仍 alive（不会"连接已断开"）
+- [ ] 关闭浏览器 tab；约 10 分钟后验证 wrapper 被销毁（间接：观察 `globalThis.__piSessions` 不再包含该 id，或下一个请求时 wrapper 是新创建）
+
+---
+
+## Self-Review
+
+**1. Spec 覆盖**：
+- keepAlive 公开方法 → Task 1 step 1.3 ✓
+- SSE heartbeat 内 try 块调用 → Task 2 step 2.1 ✓
+- 3 个 fake-timer 测试 → Task 1 step 1.1 ✓
+- 不重构 wrapper → Task 1 step 1.3 只插入方法、不动其他代码 ✓
+- 不写 SSE route 集成测试 → 只有手动验证 ✓
+- 手动验证 2 条 → Task 3 step 3.3 ✓
+- 验证清单（test/tsc/lint）→ Task 3 steps 3.1-3.2 ✓
+- 实施顺序（tests → impl → route → verify）→ 4 tasks 顺序一致 ✓
+
+**2. 占位符扫描**：无 TBD/TODO/未定义引用；所有代码块完整。
+
+**3. 类型一致性**：
+- `keepAlive(): void` 在 Task 1 step 1.3 定义，Task 1 step 1.1 测试中调用，Task 2 step 2.1 SSE route 中调用 — 三处签名一致 ✓
+- `makeStubInner` 在 Task 1 step 1.1 定义，三个测试都用 — 一致 ✓
+- `mock.timers.enable/reset/tick` API 跨 step 一致 ✓
+
+无 inline 修正。

--- a/docs/superpowers/plans/2026-06-01-p0-3-fork-navigate-timing.md
+++ b/docs/superpowers/plans/2026-06-01-p0-3-fork-navigate-timing.md
@@ -1,0 +1,373 @@
+# P0-3 fork / navigate_tree 状态时序契约 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** fork 返回时新 session id 已在注册表里；navigate_tree 被 agent 拒绝时 UI 不更新。
+
+**Architecture:** fork case 改为先 `startRpcSession` 预注册再 `this.destroy()`；`useAgentSession` 抽出 `navigateToLeaf` helper，await `sendAgentCommand` 并检查 `cancelled` 标志。
+
+**Tech Stack:** Node 20+、TypeScript 5 (strict)、React 19、`node --test` + `mock.timers`。无新依赖。
+
+**Spec:** `docs/superpowers/specs/2026-06-01-p0-3-fork-navigate-timing-design.md`
+
+---
+
+## File Structure
+
+| 文件 | 动作 | 职责 |
+|---|---|---|
+| `lib/rpc-manager.ts` | 修改 | fork case 插入 `startRpcSession` 预注册 |
+| `lib/rpc-manager.test.ts` | 修改 | 加 1 个 fork cancelled 回归测试 + 扩 `makeStubInner` 支持 `sessionManager` override |
+| `hooks/useAgentSession.ts` | 修改 | 抽 `navigateToLeaf` helper；`handleNavigate` / `handleLeafChange` 改用它 |
+
+---
+
+## Task 1: fork cancelled 回归测试
+
+> 评审 §4 把 "fork 无测试" 列入测试盲区。现有 fork 逻辑（`!isPersisted → cancelled: true`）没有自动化测试。本任务加 1 个测试锁住这个已有契约。注意：这是已有逻辑的测试，不是新功能的 TDD —— 写完会直接 pass。
+
+**Files:**
+- Modify: `lib/rpc-manager.test.ts`
+
+- [ ] **Step 1.1: 扩 `makeStubInner` 支持 `sessionManager` override**
+
+In `lib/rpc-manager.test.ts`，替换 `makeStubInner` 函数：
+
+替换前：
+```typescript
+function makeStubInner(overrides: { subscribe?: SubscribeFn } = {}) {
+  return {
+    sessionId: "stub",
+    sessionFile: "stub.jsonl",
+    isStreaming: false,
+    isCompacting: false,
+    autoCompactionEnabled: false,
+    autoRetryEnabled: false,
+    model: null,
+    getContextUsage: () => null,
+    agent: { state: { systemPrompt: "", thinkingLevel: "off" } },
+    sessionManager: null,
+    modelRegistry: null,
+    subscribe: overrides.subscribe ?? ((cb: (event: unknown) => void) => { void cb; return () => {}; }),
+  } as never;
+}
+```
+
+替换为：
+```typescript
+function makeStubInner(overrides: {
+  subscribe?: SubscribeFn;
+  sessionManager?: unknown;
+} = {}) {
+  return {
+    sessionId: "stub",
+    sessionFile: "stub.jsonl",
+    isStreaming: false,
+    isCompacting: false,
+    autoCompactionEnabled: false,
+    autoRetryEnabled: false,
+    model: null,
+    getContextUsage: () => null,
+    agent: { state: { systemPrompt: "", thinkingLevel: "off" } },
+    sessionManager: overrides.sessionManager ?? null,
+    modelRegistry: null,
+    subscribe: overrides.subscribe ?? ((cb: (event: unknown) => void) => { void cb; return () => {}; }),
+  } as never;
+}
+```
+
+变更：`sessionManager: null` 改为 `overrides.sessionManager ?? null`，新增 `sessionManager` 字段到 `overrides` 类型。
+
+- [ ] **Step 1.2: 加 fork cancelled 测试**
+
+In `lib/rpc-manager.test.ts`，在最后一个 test（`keepAlive is a no-op on a destroyed wrapper`）之后追加：
+
+```typescript
+test("fork returns {cancelled: true} for non-persisted session", async () => {
+  const inner = makeStubInner({
+    sessionManager: { isPersisted: () => false },
+  });
+  const w = new AgentSessionWrapper(inner);
+  w.start();
+  const result = await w.send({ type: "fork", entryId: "x" });
+  assert.deepEqual(result, { cancelled: true });
+});
+```
+
+- [ ] **Step 1.3: 跑测试，验证通过**
+
+Run: `node --test lib/rpc-manager.test.ts`
+Expected: 5/5 pass（原 4 + 新增 1）。
+
+- [ ] **Step 1.4: 提交**
+
+```bash
+git add lib/rpc-manager.test.ts
+git commit -m "test(rpc-manager): cover fork returns {cancelled:true} for non-persisted session"
+```
+
+---
+
+## Task 2: fork case 加预注册
+
+> fork 命令末尾不再直接 `this.destroy()`，先 `await startRpcSession(newSessionId, newSessionFile, newCwd)` 把新 wrapper 注册进 registry，再 destroy 旧 wrapper。
+
+**Files:**
+- Modify: `lib/rpc-manager.ts` (case "fork" 块, lines 113-143)
+
+- [ ] **Step 2.1: 在 fork case 插入 `startRpcSession` 预注册**
+
+In `lib/rpc-manager.ts`，找到 `case "fork":` 块（line 113-143），替换整个块：
+
+替换前（line 113-143）：
+```typescript
+      case "fork": {
+        const entryId = command.entryId as string;
+        const sessionManager = this.inner.sessionManager;
+        const currentSessionFile = this.inner.sessionFile;
+
+        if (!sessionManager.isPersisted()) return { cancelled: true };
+        if (!currentSessionFile) throw new Error("Persisted session is missing a session file");
+
+        const entry = sessionManager.getEntry(entryId);
+        if (!entry) throw new Error("Invalid entry ID for forking");
+
+        const sessionDir = sessionManager.getSessionDir();
+        let newSessionFile: string;
+
+        if (!entry.parentId) {
+          // Fork before the first message: create an empty session linked to this one
+          const newManager = SessionManager.create(sessionManager.getCwd(), sessionDir);
+          newManager.newSession({ parentSession: currentSessionFile });
+          newSessionFile = newManager.getSessionFile() as string;
+        } else {
+          // Fork after some history: copy path up to (but not including) the fork point
+          const sourceManager = SessionManager.open(currentSessionFile, sessionDir);
+          const forkedPath = sourceManager.createBranchedSession(entry.parentId);
+          if (!forkedPath) throw new Error("Failed to create forked session");
+          newSessionFile = forkedPath;
+        }
+
+        const newSessionId = SessionManager.open(newSessionFile, sessionDir).getSessionId();
+        cacheSessionPath(newSessionId, newSessionFile);
+        this.destroy();
+        return { cancelled: false, newSessionId };
+      }
+```
+
+替换为：
+```typescript
+      case "fork": {
+        const entryId = command.entryId as string;
+        const sessionManager = this.inner.sessionManager;
+        const currentSessionFile = this.inner.sessionFile;
+
+        if (!sessionManager.isPersisted()) return { cancelled: true };
+        if (!currentSessionFile) throw new Error("Persisted session is missing a session file");
+
+        const entry = sessionManager.getEntry(entryId);
+        if (!entry) throw new Error("Invalid entry ID for forking");
+
+        const sessionDir = sessionManager.getSessionDir();
+        let newSessionFile: string;
+
+        if (!entry.parentId) {
+          // Fork before the first message: create an empty session linked to this one
+          const newManager = SessionManager.create(sessionManager.getCwd(), sessionDir);
+          newManager.newSession({ parentSession: currentSessionFile });
+          newSessionFile = newManager.getSessionFile() as string;
+        } else {
+          // Fork after some history: copy path up to (but not including) the fork point
+          const sourceManager = SessionManager.open(currentSessionFile, sessionDir);
+          const forkedPath = sourceManager.createBranchedSession(entry.parentId);
+          if (!forkedPath) throw new Error("Failed to create forked session");
+          newSessionFile = forkedPath;
+        }
+
+        const newSessionId = SessionManager.open(newSessionFile, sessionDir).getSessionId();
+        cacheSessionPath(newSessionId, newSessionFile);
+
+        // Pre-register the new wrapper BEFORE destroying the old.
+        // Contract: by the time send() returns, newSessionId is in the registry.
+        // If startRpcSession throws, do NOT destroy — old wrapper stays usable,
+        // new file remains on disk (acceptable; next fork overwrites).
+        const newCwd = sessionManager.getHeader()?.cwd ?? process.cwd();
+        await startRpcSession(newSessionId, newSessionFile, newCwd);
+
+        this.destroy();
+        return { cancelled: false, newSessionId };
+      }
+```
+
+变更点（4 行新代码 + 2 行注释）：
+- 在 `cacheSessionPath(newSessionId, newSessionFile);` 之后、`this.destroy();` 之前插入 `newCwd` + `await startRpcSession(...)` 两行
+- 注释解释契约和失败时的行为
+
+- [ ] **Step 2.2: 类型检查 + lint**
+
+Run: `node_modules/.bin/tsc --noEmit`
+Expected: 通过，无错误。
+
+Run: `node_modules/.bin/eslint .`
+Expected: 通过，无错误（已有的 1 个 `MessageView.tsx` warning 不算新错）。
+
+- [ ] **Step 2.3: 跑 rpc-manager 测试 + 全量测试，确认没回归**
+
+Run: `node --test lib/rpc-manager.test.ts`
+Expected: 5/5 pass（确认 fork cancelled 测试仍 pass，行为未变）。
+
+Run: `node --test lib/*.test.ts electron/*.test.ts 'app/**/*.test.ts'`
+Expected: 36/36 pass（之前总数 + 0，因为我们改的是 src 文件，test 数不变）。
+
+- [ ] **Step 2.4: 提交**
+
+```bash
+git add lib/rpc-manager.ts
+git commit -m "fix(rpc-manager): pre-register new wrapper before destroying old in fork
+
+By the time the fork send() returns, the new session id is in the
+registry. Window where requests to the new id would re-create the
+wrapper (with implicit dependencies on pi SDK behavior) is closed.
+
+If startRpcSession throws, do NOT destroy — old wrapper stays
+usable; new file remains on disk (acceptable; next fork overwrites)."
+```
+
+---
+
+## Task 3: `useAgentSession` 抽 `navigateToLeaf` helper
+
+> 把 `handleNavigate` / `handleLeafChange` 里的 fire-and-forget 改为 await + check `cancelled` 的显式契约。抽 `navigateToLeaf` 共享逻辑。
+
+**Files:**
+- Modify: `hooks/useAgentSession.ts` (line 411-447, `handleNavigate` 和 `handleLeafChange`)
+
+- [ ] **Step 3.1: 替换 `handleNavigate` 和 `handleLeafChange`**
+
+In `hooks/useAgentSession.ts`，找到 line 431-447 的 `handleNavigate` 和 `handleLeafChange`：
+
+替换前（line 431-447）：
+```typescript
+  const handleNavigate = useCallback(async (entryId: string) => {
+    const sid = sessionIdRef.current;
+    if (!sid) return;
+    sendAgentCommand(sid, { type: "navigate_tree", targetId: entryId }).catch(() => {});
+    setActiveLeafId(entryId);
+    await loadContext(sid, entryId);
+  }, [loadContext]);
+
+  const handleLeafChange = useCallback(async (leafId: string | null) => {
+    setActiveLeafId(leafId);
+    const sid = sessionIdRef.current;
+    if (!sid) return;
+    await loadContext(sid, leafId);
+    if (leafId) {
+      sendAgentCommand(sid, { type: "navigate_tree", targetId: leafId }).catch(() => {});
+    }
+  }, [loadContext]);
+```
+
+替换为：
+```typescript
+  const navigateToLeaf = useCallback(async (leafId: string | null) => {
+    if (!leafId) {
+      setActiveLeafId(null);
+      return;
+    }
+    const sid = sessionIdRef.current;
+    if (!sid) return;
+    try {
+      const result = await sendAgentCommand<{ cancelled?: boolean }>(sid, {
+        type: "navigate_tree",
+        targetId: leafId,
+      });
+      if (result?.cancelled) {
+        console.warn("navigate_tree cancelled:", leafId);
+        return;
+      }
+      setActiveLeafId(leafId);
+      await loadContext(sid, leafId);
+    } catch (e) {
+      console.error("navigate_tree failed:", e);
+    }
+  }, [loadContext]);
+
+  const handleNavigate = useCallback((entryId: string) => {
+    return navigateToLeaf(entryId);
+  }, [navigateToLeaf]);
+
+  const handleLeafChange = useCallback((leafId: string | null) => {
+    return navigateToLeaf(leafId);
+  }, [navigateToLeaf]);
+```
+
+变更点：
+- 新增 `navigateToLeaf`：await `sendAgentCommand`，检查 `result.cancelled`，取消时仅 `console.warn` 不更新 UI
+- `handleNavigate` / `handleLeafChange` 改为对 `navigateToLeaf` 的薄转发，签名不变（`useChatWindow` 调用方无感）
+- 旧的 fire-and-forget `.catch(() => {})` 改为 try/catch + `console.error`
+
+- [ ] **Step 3.2: 类型检查 + lint**
+
+Run: `node_modules/.bin/tsc --noEmit`
+Expected: 通过，无错误。
+
+Run: `node_modules/.bin/eslint .`
+Expected: 通过，无错误。
+
+- [ ] **Step 3.3: 提交**
+
+```bash
+git add hooks/useAgentSession.ts
+git commit -m "fix(useAgentSession): await navigate_tree and respect cancelled flag
+
+Old code: fire-and-forget, setActiveLeafId fires before agent
+acknowledges, BranchNavigator UI can show a leaf the agent
+rejected. New code: await the command, check {cancelled:true},
+leave UI unchanged on rejection."
+```
+
+---
+
+## Task 4: 验证
+
+- [ ] **Step 4.1: 跑全量测试套件**
+
+Run: `node --test lib/*.test.ts electron/*.test.ts 'app/**/*.test.ts'`
+Expected: 36/36 pass（之前 35 + 1 个 fork cancelled 测试）。
+
+- [ ] **Step 4.2: 类型检查 + lint**
+
+Run: `node_modules/.bin/tsc --noEmit && node_modules/.bin/eslint .`
+Expected: 通过。
+
+- [ ] **Step 4.3: 手动验证清单（写进 PR description）**
+
+- [ ] 启动 dev，浏览器创建会话、发送消息、fork 出子会话；UI 立即切换；DevTools Network 面板观察子会话的 SSE / loadSession / connectEvents 都正常返回（无 404 / "Session not found"）
+- [ ] 在 BranchNavigator 上点击当前 leaf 的不同分支；UI 平滑切换；新 leaf 的消息历史正确显示
+- [ ] （如果能构造）尝试 navigate 到一个 pi 会拒绝的 entryId；BranchNavigator 不切换、UI 不更新、console 出现 `navigate_tree cancelled: ...`
+
+---
+
+## Self-Review
+
+**1. Spec 覆盖**：
+- fork 预注册 → Task 2 step 2.1 ✓
+- `navigateToLeaf` helper + cancelled 检查 → Task 3 step 3.1 ✓
+- `startRpcSession` 抛错时 **不** destroy 旧 wrapper → Task 2 step 2.1 注释 + Task 2 step 2.3 跑测试覆盖 ✓
+- `console.warn` 静默取消 → Task 3 step 3.1 ✓
+- 错误处理表（fork 预注册失败、network error、cancelled）→ Task 2/3 ✓
+- 测试策略（1 个 fork cancelled 测试）→ Task 1 ✓
+- 不测 fork 完整成功路径 / 不测 navigate（hook）→ Task 4 step 4.3 手动清单 + spec 解释 ✓
+- 手动验证 3 条 → Task 4 step 4.3 ✓
+- 验证清单（test/tsc/lint）→ Task 4 steps 4.1-4.2 ✓
+- 实施顺序（test 1 → fork 2 → navigate 3 → verify 4）→ 4 tasks 顺序匹配 ✓
+
+**2. 占位符扫描**：无 TBD/TODO/未定义引用；所有代码块完整。
+
+**3. 类型一致性**：
+- `makeStubInner` 新签名 `{ subscribe?, sessionManager? }` 在 Task 1 step 1.1 定义，Task 1 step 1.2 调用 — 一致 ✓
+- `navigateToLeaf(leafId: string | null)` 签名在 Task 3 step 3.1 定义，调用方 `handleNavigate` / `handleLeafChange` 转发 — 一致 ✓
+- `startRpcSession(newSessionId, newSessionFile, newCwd)` 三参调用与 `lib/rpc-manager.ts` 现有签名一致 ✓
+- `sendAgentCommand<{ cancelled?: boolean }>(...)` 类型断言 — 与 `agent-client.ts` 现有泛型一致 ✓
+
+无 inline 修正。

--- a/docs/superpowers/plans/2026-06-01-p0-5-chatwindow-render.md
+++ b/docs/superpowers/plans/2026-06-01-p0-5-chatwindow-render.md
@@ -1,0 +1,389 @@
+# P0-5 ChatWindow 渲染性能优化 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 消除 ChatWindow 流式期的 O(n²) forward scan，并让 MessageView 在 ChatWindow 任意非消息相关的 state 变化时跳过 re-render。
+
+**Architecture:** 抽 `components/MessageList.tsx` 子组件；ChatWindow 用 `useMemo` 预计算 `toolResultsMap` / `nextUserIdx` / `nextAssistantIdx` / `lastUserIdx`；顶层 `MessageView` export 包 `React.memo`；条件 `onFork`/`onNavigate` 保持引用稳定；stable key 用 `entryIds[idx]`。
+
+**Tech Stack:** React 19、TypeScript 5 (strict)、Next.js 16、`node --test`（无 React testing infra，无新增自动化测试）。无新依赖。
+
+**Spec:** `docs/superpowers/specs/2026-06-01-p0-5-chatwindow-render-design.md`
+
+---
+
+## File Structure
+
+| 文件 | 动作 | 职责 |
+|---|---|---|
+| `components/MessageView.tsx` | 修改 | 顶层 export 包 `React.memo`（~3 行） |
+| `components/MessageList.tsx` | 新建 | 消息列表子组件，包 `React.memo`（~110 行） |
+| `components/ChatWindow.tsx` | 修改 | useMemo + useCallback + 替换 IIFE（~10 行改动） |
+
+---
+
+## Task 1: MessageView 包 `React.memo`
+
+**Files:**
+- Modify: `components/MessageView.tsx` (line 68 export 签名)
+
+- [ ] **Step 1.1: 修改 export 签名**
+
+In `components/MessageView.tsx`，line 68 把：
+
+```typescript
+export function MessageView({ message, isStreaming, toolResults, modelNames, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp }: Props) {
+```
+
+替换为：
+
+```typescript
+export const MessageView = React.memo(function MessageView({ message, isStreaming, toolResults, modelNames, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp }: Props) {
+```
+
+注意：
+- 现有 line 1 `import { useState, useRef, useEffect, useMemo } from "react";` **需扩展为** `import React, { useState, useRef, useEffect, useMemo } from "react";`（先 Edit 这一行）
+- 函数体一字不动
+- `React.memo` 用默认浅比较（按引用比 props），符合条件 `onFork`/`onNavigate` 引用稳定性的契约
+
+- [ ] **Step 1.2: 类型检查 + lint**
+
+Run: `node_modules/.bin/tsc --noEmit`
+Expected: 通过，无错误。
+
+Run: `node_modules/.bin/eslint components/MessageView.tsx`
+Expected: 通过，无错误。
+
+- [ ] **Step 1.3: 提交**
+
+```bash
+git add components/MessageView.tsx
+git commit -m "perf(MessageView): wrap top-level export in React.memo"
+```
+
+---
+
+## Task 2: 创建 `MessageList.tsx`
+
+**Files:**
+- Create: `components/MessageList.tsx`
+
+- [ ] **Step 2.1: 写 MessageList 组件**
+
+Create `components/MessageList.tsx`：
+
+```typescript
+import React from "react";
+import type { AgentMessage, ToolResultMessage } from "@/lib/types";
+import { MessageView } from "./MessageView.tsx";
+
+interface MessageListProps {
+  messages: AgentMessage[];
+  entryIds: string[];
+  toolResultsMap: Map<string, ToolResultMessage>;
+  nextUserIdx: number[];
+  nextAssistantIdx: number[];
+  isStreaming: boolean;
+  streamingMessage: Partial<AgentMessage> | null;
+  isNew: boolean;
+  agentRunning: boolean;
+  forkingEntryId: string | null;
+  onFork: (entryId: string) => void;
+  onNavigate: (entryId: string) => void;
+  onEditContent: (content: string) => void;
+  handleScrollToUserMsg: (idx: number) => void;
+  messageRefs: React.MutableRefObject<(HTMLDivElement | null)[]>;
+  lastUserIdx: number;
+  modelNames: Record<string, string>;
+}
+
+export const MessageList = React.memo(function MessageList({
+  messages, entryIds, toolResultsMap, nextUserIdx, nextAssistantIdx,
+  isStreaming, streamingMessage, isNew, agentRunning, forkingEntryId,
+  onFork, onNavigate, onEditContent, handleScrollToUserMsg, messageRefs,
+  lastUserIdx, modelNames,
+}: MessageListProps) {
+  let refIdx = 0;
+  return (
+    <>
+      {messages.map((msg, idx) => {
+        const isFirstUserMessage = idx === 0 && msg.role === "user";
+        const canFork = !agentRunning && !isNew && !isFirstUserMessage;
+        const canNavigate = !agentRunning;
+        const isUserOrAssistant = msg.role === "user" || msg.role === "assistant";
+        const showTimestamp = msg.role !== "assistant"
+          || nextUserIdx[idx] !== -1
+          || nextAssistantIdx[idx] === -1;
+        const finalShowTimestamp = showTimestamp && !(isStreaming && idx === messages.length - 1);
+        const prevAssistantEntryId = msg.role === "user" && idx > 0 && messages[idx - 1].role === "assistant"
+          ? entryIds[idx - 1]
+          : undefined;
+        const prevTimestamp = idx > 0
+          ? (messages[idx - 1] as AgentMessage & { timestamp?: number }).timestamp
+          : undefined;
+
+        const view = (
+          <MessageView
+            key={entryIds[idx] ?? `idx-${idx}`}
+            message={msg}
+            toolResults={toolResultsMap}
+            modelNames={modelNames}
+            entryId={entryIds[idx]}
+            onFork={canFork ? onFork : undefined}
+            forking={forkingEntryId === entryIds[idx]}
+            onNavigate={canNavigate ? onNavigate : undefined}
+            prevAssistantEntryId={prevAssistantEntryId}
+            onEditContent={onEditContent}
+            showTimestamp={finalShowTimestamp}
+            prevTimestamp={prevTimestamp}
+          />
+        );
+
+        if (!isUserOrAssistant) return view;
+        const currentRefIdx = refIdx++;
+        return (
+          <div
+            key={entryIds[idx] ?? `idx-${idx}`}
+            ref={(el) => {
+              messageRefs.current[currentRefIdx] = el;
+              if (idx === lastUserIdx) handleScrollToUserMsg(idx);
+            }}
+          >
+            {view}
+          </div>
+        );
+      })}
+      {isStreaming && streamingMessage && (
+        <MessageView message={streamingMessage as AgentMessage} isStreaming modelNames={modelNames} />
+      )}
+    </>
+  );
+});
+```
+
+- [ ] **Step 2.2: 类型检查**
+
+Run: `node_modules/.bin/tsc --noEmit`
+Expected: 应当有错——`MessageList` 当前未在 ChatWindow 中引用，但 tsc 不会因此报错。`import { MessageView } from "./MessageView.tsx"` 现在是 named import 而非之前的 `function` import，**可能**有未使用导入的 lint 警告（如果 eslint 规则开启 no-unused-vars）。但 tsc 应通过。
+
+预期: tsc 通过、lint 通过（仅 pre-existing `MessageView.tsx` 的 `isRunning` warning——已在 P0-1 时确认）。
+
+如果 tsc 报"`MessageList` 已声明但未使用"——可能不会，因为我们刚 import 了 `MessageView`，但 MessageList 也被 export 了，TypeScript 对未使用的 exports 不报错。OK 应该没问题。
+
+---
+
+## Task 3: 改 ChatWindow 集成 MessageList
+
+**Files:**
+- Modify: `components/ChatWindow.tsx` (line 295-353 IIFE 替换为 useMemo + useCallback + MessageList render)
+
+- [ ] **Step 3.1: 加 `useMemo` 块（替换原 IIFE 的同义计算）**
+
+In `components/ChatWindow.tsx`，找到 line 295-353 的 IIFE，**整段替换为**以下三段（按顺序）：
+
+**第一段——useMemo toolResultsMap：**
+
+```typescript
+  const toolResultsMap = useMemo(() => {
+    const m = new Map<string, ToolResultMessage>();
+    for (const msg of messages) {
+      if (msg.role === "toolResult") {
+        m.set((msg as ToolResultMessage).toolCallId, msg as ToolResultMessage);
+      }
+    }
+    return m;
+  }, [messages]);
+```
+
+**第二段——useMemo nextIndices：**
+
+```typescript
+  const { nextUserIdx, nextAssistantIdx, lastUserIdx } = useMemo(() => {
+    const nextUserIdx: number[] = new Array(messages.length).fill(-1);
+    const nextAssistantIdx: number[] = new Array(messages.length).fill(-1);
+    let lastUser = -1;
+    let lastAssistant = -1;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "user") {
+        nextUserIdx[i] = lastUser;
+        lastUser = i;
+      } else if (messages[i].role === "assistant") {
+        nextAssistantIdx[i] = lastAssistant;
+        lastAssistant = i;
+      }
+    }
+    return { nextUserIdx, nextAssistantIdx, lastUserIdx: lastUser };
+  }, [messages]);
+```
+
+注意：ChatWindow 原本用的是 `let lastUserIdx = -1;` 在 IIFE 内声明，**现在它被 useMemo 返回**。如果 ChatWindow 其它地方有引用 `lastUserIdx`，需要改读 useMemo 的返回值。如果原代码 IIFE 内的 `lastUserIdx` 是局部变量、外部没用，那现在丢掉就 OK。
+
+需要确认：先 grep `components/ChatWindow.tsx` 看是否有 `lastUserIdx` 引用。若有，保持 useMemo 返回并改读；若没有，新 useMemo 内的 `lastUserIdx: lastUser` 可以省略（不返），改为：
+```typescript
+  const { nextUserIdx, nextAssistantIdx } = useMemo(() => {
+    ...
+  }, [messages]);
+  const lastUserIdx = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "user") return i;
+    }
+    return -1;
+  }, [messages]);
+```
+
+或更简单，把 `lastUserIdx` 单独 useMemo。如果 IIFE 内的 `lastUserIdx` 是真的只 IIFE 内用，外部不引用，可以完全删掉这一行（spec 里 MessageList 自己用 `lastUserIdx`，但 MessageList 的 lastUserIdx 来自 props）。看 spec：MessageList 接 `lastUserIdx: number` 作为 prop。所以 ChatWindow 必须 export 它。
+
+OK 简化为单 useMemo 返回三件套最干净。
+
+**第三段——useCallback handleEditContent 和 handleScrollToUserMsg：**
+
+找到 line 550 附近的 `scrollUserMsgToTop` useCallback（或类似名），把它替换为：
+
+```typescript
+  const handleEditContent = useCallback((content: string) => {
+    chatInputRef?.current?.insertIfEmpty(content);
+  }, []);
+
+  const handleScrollToUserMsg = useCallback((idx: number) => {
+    if (idx !== lastUserIdx) return;
+    const container = scrollContainerRef.current;
+    const el = lastUserMsgRef.current;
+    if (!container || !el) return;
+    const elAbsTop = el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
+    container.scrollTo({ top: elAbsTop - 16, behavior: "smooth" });
+  }, [lastUserIdx]);
+```
+
+注：原 `scrollUserMsgToTop` 函数体可参照（如果存在）拷过来；逻辑等价。
+
+如果原函数不存在（lastUserIdx 仅 IIFE 内部用），则新加 `handleScrollToUserMsg` 的实现——`lastUserMsgRef` + `scrollContainerRef` 已存在于 ChatWindow 局部 refs。
+
+- [ ] **Step 3.2: 替换原 IIFE 为 `<MessageList>` 渲染**
+
+找到 line 295-353 整段 IIFE（包裹在 `{(() => { ... })()}` 里），替换为：
+
+```typescript
+            <MessageList
+              messages={messages}
+              entryIds={entryIds}
+              toolResultsMap={toolResultsMap}
+              nextUserIdx={nextUserIdx}
+              nextAssistantIdx={nextAssistantIdx}
+              isStreaming={streamState.isStreaming}
+              streamingMessage={streamState.streamingMessage}
+              isNew={isNew}
+              agentRunning={agentRunning}
+              forkingEntryId={forkingEntryId}
+              onFork={handleFork}
+              onNavigate={handleNavigate}
+              onEditContent={handleEditContent}
+              handleScrollToUserMsg={handleScrollToUserMsg}
+              messageRefs={messageRefs}
+              lastUserIdx={lastUserIdx}
+              modelNames={modelNames}
+            />
+```
+
+注意：原 IIFE 渲染在 JSX 内的特定位置（被 chatInputElement 上下的 div 包住），保留这个位置不动，只换掉内部。
+
+- [ ] **Step 3.3: 加 `import { MessageList } from "./MessageList"` 到 ChatWindow 顶部 imports**
+
+In `components/ChatWindow.tsx` 顶部 import 块，添加：
+
+```typescript
+import { MessageList } from "./MessageList";
+```
+
+（位置：按字母序插到现有 import 中间。）
+
+- [ ] **Step 3.4: 类型检查 + lint**
+
+Run: `node_modules/.bin/tsc --noEmit`
+Expected: 通过，无错误。
+
+Run: `node_modules/.bin/eslint .`
+Expected: 通过，无错误（pre-existing `MessageView.tsx` warning 不算新错）。
+
+如果 lint 报 `handleScrollToUserMsg` 中 `lastUserIdx` 是 stale closure 之类——检查 deps 是否正确。`useCallback(..., [lastUserIdx])` 是合理的。
+
+- [ ] **Step 3.5: 全量测试套件**
+
+Run: `node --test lib/*.test.ts electron/*.test.ts 'app/**/*.test.ts'`
+Expected: 37/37 pass（不变——本次只动 React 组件层，不动测试逻辑）。
+
+- [ ] **Step 3.6: 提交**
+
+```bash
+git add components/MessageList.tsx components/ChatWindow.tsx
+git commit -m "perf(ChatWindow): extract MessageList + pre-compute indices + memo toolResultsMap
+
+Long-conversation perf fixes:
+- useMemo toolResultsMap / nextUserIdx / nextAssistantIdx / lastUserIdx
+  (deps: messages) — replaces O(n) and O(n²) work in per-render IIFE.
+- useCallback handleEditContent and handleScrollToUserMsg — stable
+  references for React.memo(MessageView) and React.memo(MessageList).
+- React.memo(MessageList) — skip re-render when ChatWindow state changes
+  unrelated to messages.
+- Stable key entryIds[idx] ?? 'idx-{idx}' — avoid remount on array shift.
+- Conditional onFork/onNavigate keep stable refs across renders."
+```
+
+---
+
+## Task 4: 验证 + Code Review + Push
+
+- [ ] **Step 4.1: 最终验证**
+
+Run: `node_modules/.bin/tsc --noEmit && node_modules/.bin/eslint . && node --test lib/*.test.ts electron/*.test.ts 'app/**/*.test.ts'`
+Expected: 全通过。
+
+- [ ] **Step 4.2: 派 code reviewer**
+
+按 `superpowers:requesting-code-review` skill 派 general-purpose subagent 审查本 PR 的 2 commit（base = Task 1 之前，head = 当前）。
+
+- [ ] **Step 4.3: 应用 review 修复（如有）**
+
+按 review 反馈修复 Critical / Important 问题，Minor 留给后续。
+
+- [ ] **Step 4.4: Push 到远端**
+
+If review 干净（或修复后干净）：
+
+```bash
+git push -u origin analysis/architecture-optimization-review
+```
+
+如果用户后续决定开 PR，单独走 `finishing-a-development-branch` 的 Option 2 流程。
+
+- [ ] **Step 4.5: 写 PR 描述草稿（手动验证清单）**
+
+P0-5 手动验证 4 条（打开 100+ 消息会话，Profiler 录制，触发打字/滚动/stream/fork 切换）。
+
+---
+
+## Self-Review
+
+**1. Spec 覆盖**：
+- MessageList 抽到独立文件 → Task 2 step 2.1 ✓
+- useMemo toolResultsMap / nextUserIdx / nextAssistantIdx / lastUserIdx → Task 3 step 3.1 ✓
+- useCallback handleEditContent / handleScrollToUserMsg → Task 3 step 3.1 ✓
+- React.memo(MessageView) 顶层 export → Task 1 ✓
+- 条件 onFork/onNavigate 引用稳定 → Task 2 step 2.1 内的 `canFork ? onFork : undefined` ✓
+- stable key entryIds[idx] → Task 2 step 2.1 ✓
+- 错误处理（无新增）✓
+- 测试策略（无自动化测试、Profiler 手动验证）→ Task 4 step 4.5 ✓
+- 验证清单 → Task 4 step 4.1 ✓
+- 实施顺序（MessageView memo → MessageList 创建 → ChatWindow 集成）→ 3 tasks 顺序一致 ✓
+- PR 范围（1 新建 + 2 修改、~120 行、1 个 commit）→ 实际 2 commit（MessageView memo + 集成）✓
+
+**2. 占位符扫描**：无 TBD/TODO/未定义引用；所有代码块完整。
+
+**3. 类型一致性**：
+- `MessageListProps` 14 字段 — Task 2 定义、Task 3 引用、ChatWindow 调用全部一致 ✓
+- `React.memo` 用默认浅比较 — 一致 ✓
+- `useMemo` deps `[messages]` — Task 3 三个 memo 都用 ✓
+- `useCallback` deps — `[]` for handleEditContent（chatInputRef 稳定）、`[lastUserIdx]` for handleScrollToUserMsg（依赖 lastUserIdx）✓
+
+**Inline 修正**：
+- spec 估算"~120 行变动"——实际：MessageList.tsx 约 110 行（+3 行 MessageView）≈ 115-120 行。OK 接受原估算。
+- 风险表里写 `handleScrollToUserMsg` 在 ChatWindow 中定义——Plan Task 3 step 3.1 第三段落实。一致。

--- a/docs/superpowers/plans/2026-06-01-p0-6-hooks-mount-effect.md
+++ b/docs/superpowers/plans/2026-06-01-p0-6-hooks-mount-effect.md
@@ -1,0 +1,236 @@
+# P0-6 hooks mount effect 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** mount effect 在 `session?.id` 变化时重跑 + 重置全部 session-scoped state + 用闭包守卫避免 stale `.then` 覆盖新 session。
+
+**Architecture:** `hooks/useAgentSession.ts` 单一文件改动。deps 从 `[]` 改为 `[session?.id]`；effect 入口加 early return 与 state reset 块；引入 `let cancelled = false; return () => { cancelled = true; };` 闭包守卫；保留 `eslint-disable`（useState 的 setter 引用稳定但 lint 不识别）。
+
+**Tech Stack:** React 19、TypeScript 5 (strict)、Next.js 16、`node --test`（无 React testing infra，无新增自动化测试）。无新依赖。
+
+**Spec:** `docs/superpowers/specs/2026-06-01-p0-6-hooks-mount-effect-design.md`
+
+---
+
+## File Structure
+
+| 文件 | 动作 | 职责 |
+|---|---|---|
+| `hooks/useAgentSession.ts` | 修改 | destructure 补 `setEntryIds` + 替换 mount effect（~30 行） |
+
+---
+
+## Task 1: destructure 补 `setEntryIds`
+
+**Files:**
+- Modify: `hooks/useAgentSession.ts:51-63`（`useSessionLoader` 解构块）
+
+- [ ] **Step 1.1: 检查当前 destructure 是否含 `setEntryIds`**
+
+Read `hooks/useAgentSession.ts` 第 51-63 行的 destructure 块。**注意：实施 P0-3 时已改过这文件，destructure 实际状态需重新读确认。**
+
+如果当前 destructure 已含 `setEntryIds` → 跳到 Task 2。
+
+如果不含 → 替换为：
+
+```typescript
+  const {
+    data, setData, loading, error, activeLeafId, setActiveLeafId,
+    messages, setMessages, entryIds, setEntryIds,
+    loadSession, loadContext,
+  } = useSessionLoader(isNew);
+```
+
+- [ ] **Step 1.2: tsc**
+
+Run: `node_modules/.bin/tsc --noEmit`
+Expected: 0 errors。
+
+（如跳过本 Task 即无此步骤。）
+
+---
+
+## Task 2: 替换 mount effect
+
+**Files:**
+- Modify: `hooks/useAgentSession.ts` (line 428-454 mount effect 块)
+
+- [ ] **Step 2.1: 替换 mount effect**
+
+In `hooks/useAgentSession.ts`，找到当前 mount effect 块（行号约 428-454），**整段替换为**：
+
+```typescript
+  // Load session on mount AND on session change.
+  //
+  // On session change, reset all session-scoped state to avoid bleed
+  // from a previous session. AppShell's sessionKey remount is kept
+  // as defense-in-depth (covers state in sub-hooks like
+  // useChatScroll / useAgentEvents that we can't reset from here).
+  //
+  // The cancelled flag is a closure guard: when session A→B, the
+  // effect's cleanup runs before the next effect call. Cleanup
+  // sets cancelled=true on the OLD closure; the OLD .then (still
+  // in flight) sees the flag and bails. Makes the effect
+  // self-sufficient even if AppShell's remount is later removed.
+  useEffect(() => {
+    if (!session) return;
+    const sid = session.id;
+    sessionIdRef.current = sid;
+    let cancelled = false;
+
+    // Reset session-scoped state. Ordered to mirror useState
+    // declarations above for readability.
+    setData(null);
+    setActiveLeafId(null);
+    setMessages([]);
+    setEntryIds([]);
+    setToolPreset("default");
+    setThinkingLevel("auto");
+    setAgentRunning(false);
+    setAgentPhase(null);
+    dispatch({ type: "reset" });   // streamState → {isStreaming:false, streamingMessage:null}
+    setRetryInfo(null);
+    setContextUsage(null);
+    setSystemPrompt(null);
+    setForkingEntryId(null);
+    setIsCompacting(false);
+    setCompactError(null);
+    setCurrentModelOverride(null);
+    setPendingModel(null);
+
+    loadSession(sid, true, true).then((loaded) => {
+      if (cancelled) return;  // ignore stale results from a previous session
+      const agentState = loaded?.agentState ?? null;
+      if (!agentState?.state?.thinkingLevel && loaded?.contextThinkingLevel && loaded.contextThinkingLevel !== "off") {
+        setThinkingLevel(loaded.contextThinkingLevel as ThinkingLevelOption);
+      }
+      if (agentState?.running) {
+        loadTools(sid);
+        if (agentState.state?.isStreaming) {
+          setAgentRunning(true);
+          setAgentPhase({ kind: "waiting_model" });
+          connectEvents(sid);
+        }
+      }
+      if (agentState?.state) {
+        if (agentState.state.isCompacting !== undefined) setIsCompacting(agentState.state.isCompacting);
+        if (agentState.state.contextUsage !== undefined) setContextUsage(agentState.state.contextUsage ?? null);
+        if (agentState.state.systemPrompt !== undefined) setSystemPrompt(agentState.state.systemPrompt ?? null);
+        if (agentState.state.thinkingLevel !== undefined) setThinkingLevel((agentState.state.thinkingLevel as ThinkingLevelOption) ?? "auto");
+      }
+    });
+
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session?.id]);
+```
+
+变更点：
+- 入口 `if (session)` → `if (!session) return;`（early return 风格）
+- deps `[]` → `[session?.id]`
+- 加 16 个 setter + 1 个 `dispatch({type:"reset"})` reset 块
+- 加 `let cancelled = false;` 局部变量 + 闭包
+- `.then` 开头加 `if (cancelled) return;` 守卫
+- 加 return cleanup 闭包 `return () => { cancelled = true; };`
+- 保留 `// eslint-disable-next-line react-hooks/exhaustive-deps`（useState 的 setter 引用稳定但 lint 不识别）
+- 注释解释 why cancelled 守卫 + 为什么保留 eslint-disable
+
+- [ ] **Step 2.2: tsc + lint**
+
+Run: `node_modules/.bin/tsc --noEmit`
+Expected: 0 errors。
+
+Run: `node_modules/.bin/eslint .`
+Expected: 0 errors（pre-existing `MessageView.tsx` warning 仍在但与本 PR 无关；不应有新 warning——`cancelled`、`agentState`、`loaded` 等局部变量都已使用，destructure 补的 `setEntryIds` 也被使用）。
+
+如果 lint 报 `cancelled` 或 `agentState` 之类的 unused——检查代码是否完全按上面粘贴。
+
+- [ ] **Step 2.3: 全量测试套件**
+
+Run: `node --test lib/*.test.ts electron/*.test.ts 'app/**/*.test.ts'`
+Expected: 37/37 pass。
+
+Run: `node --test hooks/agent-session/*.test.ts`
+Expected: 10/10 pass（main 新增的 10 个测试）。
+
+总计 47/47 pass。**0 regression**。
+
+- [ ] **Step 2.4: 提交**
+
+```bash
+git add hooks/useAgentSession.ts
+git commit -m "fix(useAgentSession): mount effect re-runs on session change with state reset
+
+The mount effect had empty deps and an eslint-disable comment, relying
+on AppShell's sessionKey remount to reset state on session change.
+That remount is fragile and implicit.
+
+Make the effect self-sufficient:
+- deps: [] → [session?.id]
+- Reset 16 session-scoped state setters before loadSession
+- dispatch({type:'reset'}) for streamState
+- 'cancelled' closure guard prevents stale .then from overwriting
+  new session's state if loadSession is in flight when session changes
+- destructure useSessionLoader now exposes setEntryIds (was missing)
+
+AppShell's sessionKey remount is kept as defense-in-depth — it
+covers internal refs in useChatScroll / useAgentEvents that
+cannot be reset from useAgentSession.
+
+eslint-disable is kept: useState setters are reference-stable but
+exhaustive-deps doesn't recognize them as such."
+```
+
+---
+
+## Task 3: Code review + push
+
+- [ ] **Step 3.1: 派 code reviewer**
+
+按 `superpowers:requesting-code-review` skill 派 general-purpose subagent 审查 P0-6 的 1 个 commit（`hooks/useAgentSession.ts`）。
+
+- [ ] **Step 3.2: 应用 review 修复（如有）**
+
+按 review 反馈修复 Critical / Important 问题。Minor 留给后续。
+
+- [ ] **Step 3.3: 重新跑测试（如有修改）**
+
+如 Step 3.2 改了代码，重跑全量测试套件确认无回归。
+
+- [ ] **Step 3.4: Push 到远端**
+
+```bash
+git push origin analysis/architecture-optimization-review
+```
+
+- [ ] **Step 3.5: 写 PR 描述草稿（手动验证清单）**
+
+P0-6 手动验证 4 条（切会话看无 bleed、并发切不抢 state、切完能正常发消息、tsc-lint）。
+
+---
+
+## Self-Review
+
+**1. Spec 覆盖**：
+- destructure 补 `setEntryIds` → Task 1 ✓
+- deps `[]` → `[session?.id]` → Task 2 step 2.1 ✓
+- 16 setters + dispatch reset → Task 2 step 2.1 ✓
+- `cancelled` 闭包守卫 → Task 2 step 2.1 ✓
+- 保留 `eslint-disable` + 注释 → Task 2 step 2.1 ✓
+- 早返回 `if (!session) return;` → Task 2 step 2.1 ✓
+- 注释解释 why → Task 2 step 2.1 ✓
+- 错误处理（与现有行为一致）✓
+- 测试策略（47 测试通过、手动验证 4 条）→ Task 2 step 2.3 + Task 3 ✓
+- 验证清单 → Task 2 step 2.2-2.3 ✓
+- 实施顺序（destructure → effect → verify → push）→ 3 tasks 顺序一致 ✓
+- PR 范围（1 文件、~30 行、1 commit）→ 实际 1 commit ✓
+
+**2. 占位符扫描**：无 TBD/TODO；所有代码块完整。
+
+**3. 类型一致性**：
+- `setEntryIds` 在 destructure 引入、在 reset 块使用、签名 `(value: string[]) => void` ✓
+- `dispatch({ type: "reset" })` 与 `streamReducer` 的 `case "reset"` 已支持 ✓
+- `connectEvents(sid)` 与 `useAgentEvents` 暴露签名一致 ✓
+- `loadSession(sid, showLoading, includeState)` 与 `useSessionLoader.loadSession` 一致 ✓
+
+无 inline 修正。

--- a/docs/superpowers/specs/2026-06-01-p0-1-jsonl-write-lock-design.md
+++ b/docs/superpowers/specs/2026-06-01-p0-1-jsonl-write-lock-design.md
@@ -1,0 +1,205 @@
+# P0-1 JSONL 写并发安全设计
+
+> 分支：`analysis/architecture-optimization-review` · 日期：2026-06-01 · 关联评审：`docs/architecture-review-2026-06-01.md` §1 P0-1
+
+## 背景
+
+`DELETE /api/sessions/[id]` 在删除父会话时会扫描同目录的 sibling `.jsonl` 文件，对每个 `parentSession === filePath` 的子文件做 `readFileSync → JSON.parse → mutate → writeFileSync` 级联重写。当前实现既无锁也非原子写：两个并发 DELETE 会交叉覆盖；reader 在写中间也可能读到撕裂的 JSONL。详见评审 doc P0-1 条目。
+
+## 目标
+
+DELETE 路径在并发场景下保证：
+
+- 同一文件的写操作串行化
+- 单次写对其他 reader 原子可见
+- 纯函数层可独立单测，覆盖级联改写的所有边界
+- 不引入新 npm 依赖，不动 GET/PATCH/其他路由
+
+## 非目标
+
+- 不做跨进程锁（Electron 单进程 + npm CLI 单进程，威胁模型不适用）
+- 不做 per-directory 锁（over-engineering）
+- 不异步化 `readFileSync`/`readdirSync`（保持现有同步风格）
+- 不引入 zod 做 JSON 解析校验（orthogonal 改进，留 P1-1）
+- 不修复 GET/PATCH 路径的潜在竞态（无级联，单文件风险低于 DELETE）
+
+## 方案概览
+
+抽两个新文件、改一个 route handler、加两个测试文件：
+
+- `lib/session-lock.ts`（新）：进程内文件级写锁，基于 `globalThis.__piWriteLocks` 的 promise chain
+- `lib/session-cascade.ts`（新）：纯函数 `rewriteChildHeader(content, oldParent, newParent) → { newContent, changed }`
+- `app/api/sessions/[id]/route.ts`（改）：DELETE 改用上面两个 + tmp+rename 原子写
+- `lib/session-lock.test.ts`（新）：锁原语并发测试
+- `lib/session-cascade.test.ts`（新）：纯函数单元测试
+
+## `lib/session-lock.ts`
+
+文件级写锁。Map 键用 `path.resolve` 归一化。同一路径的 `withFileLock` 调用串行执行；不同路径互不阻塞。
+
+```typescript
+export async function withFileLock<T>(
+  filePath: string,
+  fn: () => Promise<T>,
+): Promise<T>
+```
+
+实现要点：
+
+- `globalThis.__piWriteLocks: Map<string, Promise<unknown>>` —— 复用 CLAUDE.md 强调的 `globalThis` 模式，确保 Next.js 热重载安全
+- 每个调用把自己的 gate promise 接在前一个的 `.then` 上；前一个完成 → 当前获得锁
+- `finally` 释放自己的 gate，并在 map 仍指向自己时清理 entry（避免无意义累积）
+- 不支持同一路径重入（reentrancy 会死锁）。本 codebase 不会有调用方重入，文档明示即可
+
+## `lib/session-cascade.ts`
+
+纯函数。输入 child 文件的全文和父/新父路径，输出新全文和是否变更。**不碰 I/O。**
+
+```typescript
+export interface RewriteResult {
+  newContent: string;
+  changed: boolean;
+}
+
+export function rewriteChildHeader(
+  content: string,
+  oldParent: string,
+  newParent: string | null,
+): RewriteResult
+```
+
+行为：
+
+- 解析第一行 JSON；如果解析失败或 `type !== "session"` 或 `parentSession !== oldParent` → 返回 `{ newContent: content, changed: false }`
+- 否则把 `parentSession` 改为 `newParent`（`null` 时删除该键），重新序列化第一行，拼接剩余内容
+- 第一行之外的所有字节原样保留（包括尾部换行）
+
+## `app/api/sessions/[id]/route.ts` 的 DELETE 改写
+
+保持 async signature。同步部分（readFileSync、readdirSync）保留以匹配现有风格；所有写操作改为 `await withFileLock(..., () => atomicWriteFile(...))`。
+
+新流程：
+
+1. `resolveSessionPath(id)` → 缺失返回 404
+2. `readFileSync(parent)` 取第一行 JSON.parse，提取 grandparent（`parentSession ?? null`）。malformed 视为 grandparent 为 null
+3. `readdirSync(parent dir)` → 过滤出 sibling `.jsonl`
+4. 对每个 sibling：同步 `readFileSync` → `rewriteChildHeader` 判断 → 若 changed 则 `await withFileLock(child, () => atomicWriteFile(child, newContent))`
+5. `await withFileLock(parent, () => { try { unlinkSync(parent); } catch {} })` —— 即使 unlink 失败（race：已被删）也吞掉
+6. `invalidateSessionPathCache(id)` → 200
+
+`atomicWriteFile` 内联在 route 文件内（一次性 helper，不抽到 lib）：
+
+```typescript
+async function atomicWriteFile(p: string, content: string) {
+  const tmp = `${p}.tmp`;
+  await writeFile(tmp, content, "utf8");
+  try { await rename(tmp, p); }
+  catch (e) { try { await unlink(tmp); } catch {}; throw e; }
+}
+```
+
+## 数据流
+
+```
+DELETE /api/sessions/{id}
+  │
+  ├─ resolveSessionPath(id) ─────────────────── 404 if missing
+  │
+  ├─ readFileSync(parent) → first line → grandparent
+  │
+  ├─ readdirSync(dir) → siblings
+  │
+  ├─ for each sibling:
+  │    ├─ readFileSync(sibling)               (sync; 失败 skip)
+  │    ├─ rewriteChildHeader(content, parent, grandparent)  (pure)
+  │    └─ if changed:
+  │         └─ withFileLock(sibling, atomicWriteFile(sibling, newContent))
+  │
+  ├─ withFileLock(parent, unlinkSync(parent))   (吞 unlink 失败)
+  │
+  └─ invalidateSessionPathCache(id) → 200
+```
+
+## 错误处理
+
+| 失败点 | 行为 | 状态码 |
+|---|---|---|
+| `resolveSessionPath` 返 null | 404 | 404 |
+| `readdirSync` 失败 | 跳过 cascade，直接走 unlink | 200 |
+| 单个 child `readFileSync` 失败 | skip 该 child，继续处理其他 | 200 |
+| `rewriteChildHeader` 解析失败 | skip（视 malformed） | 200 |
+| `atomicWriteFile` 抛错 | 上抛外层 catch，**parent 不会被 unlink** | 500（半失败：children 已改写，parent 仍存在，可重试） |
+| `unlinkSync(parent)` 失败（race） | 吞掉，cascade 已完成 | 200 |
+| `withFileLock` 内部 fn 抛 | finally 释放锁，错误上抛 | 500 |
+
+**不做的**：级联回滚。半失败时已改写的 child 保留新 `parentSession`。重试时它们被 `rewriteChildHeader` 再次判断为"parentSession !== filePath"（filePath 还在），no-op。语义自洽。
+
+## 测试策略
+
+### `lib/session-cascade.test.ts`（纯函数单测，无 I/O）
+
+- rewrites child when parentSession matches oldParent
+- leaves child unchanged when parentSession is different
+- leaves child unchanged when header is malformed JSON
+- leaves child unchanged when type is not "session"
+- removes parentSession when newParent is null（key 被删，不是被设为 `null`）
+- preserves all other header fields
+- preserves rest of file content beyond first line
+- handles empty content
+- handles content without trailing newline
+
+### `lib/session-lock.test.ts`（锁原语并发测试）
+
+- serializes 100 concurrent calls on same path — 所有 fn 串行执行，每个 fn 看到正确的 `prev === next` 时序
+- does not block calls on different paths —— 用 `Promise.all` 跑两个不同 path，断言总耗时 < 两个串行执行的耗时之和
+- releases lock when fn throws —— 抛错后下一个调用能立即获得锁
+- cleanup: map entry removed after release —— finally 后 map 不再包含已完成的 entry
+
+### 不写 DELETE route 集成测试
+
+route 是上面两个已测单元的编排，加 sync I/O 的胶水。集成测试需要 mock 整个文件系统，价值低于成本。手动验证清单如下。
+
+### 手动验证清单（写进 PR description）
+
+- 删一个有子会话的父 → 验证子会话在 sidebar 重新挂到 grandparent
+- 同时打开两个浏览器 tab 登同一 cwd，分别删父和子 → 观察文件无损坏
+- 手动改坏一个 child jsonl 的第一行触发 cascade → 验证 DELETE 仍能完成（malformed child 被 skip，其他 child 正常改写）
+- 删一个没有 parentSession 的根会话（grandparent 为 null）→ 验证 child 的 parentSession 被移除（不是被设为 `null`）
+
+## 范围外（本次 P0-1 不做）
+
+- 异步化 sync I/O
+- 跨进程锁
+- per-directory 锁
+- JSON parse 用 zod 校验
+- GET/PATCH 路径的潜在竞态
+
+## 风险
+
+| 风险 | 缓解 |
+|---|---|
+| `${p}.tmp` 失败时残留 | 后续 atomicWrite 覆盖；用户可手动清理 |
+| 锁链内存泄漏 | finally 一定 release；hot-reload 全局重置 |
+| Windows rename 行为差异 | Node.js 在 Windows 上用 `MOVEFILE_REPLACE_EXISTING`，行为正确 |
+| withFileLock 重入死锁 | 文档明示不支持；codebase 无调用方重入 |
+
+## 验证清单
+
+- [ ] `node --test lib/session-lock.test.ts lib/session-cascade.test.ts` 通过
+- [ ] `npx tsc --noEmit` 通过
+- [ ] `npm run lint` 通过
+- [ ] 手动验证清单 4 条全部通过
+
+## 实施顺序
+
+1. 写 `lib/session-cascade.ts` 和 `lib/session-cascade.test.ts`（纯函数优先，TDD 干净）
+2. 写 `lib/session-lock.ts` 和 `lib/session-lock.test.ts`（同样 TDD）
+3. 改 `app/api/sessions/[id]/route.ts` 的 DELETE（最后一步，组合两个新模块）
+4. 跑验证清单
+
+## PR 范围
+
+- 3 个 src 文件新增/修改
+- 2 个测试文件新增
+- 总计 ~150 行 src + ~120 行测试
+- 一个 commit，一个 PR

--- a/docs/superpowers/specs/2026-06-01-p0-2-idle-timer-design.md
+++ b/docs/superpowers/specs/2026-06-01-p0-2-idle-timer-design.md
@@ -1,0 +1,173 @@
+# P0-2 idle timer 与 SSE heartbeat 解耦设计
+
+> 分支：`analysis/architecture-optimization-review` · 日期：2026-06-01 · 关联评审：`docs/architecture-review-2026-06-01.md` §1 P0-2
+
+## 背景
+
+`lib/rpc-manager.ts:50-53` 的 idle timer 只在 pi `subscribe` 回调收到事件时重置。`app/api/agent/[id]/events/route.ts:44-50` 的 SSE heartbeat 每 30s 发 `:\n\n` comment，不通过 `subscribe`，因此不重置 timer。当 agent 等 LLM 响应超过 10 分钟（Opus thinking、长时间工具执行）→ timer 到期 → wrapper 销毁 → SSE 断流 → 用户看到"连接已断开"。详见评审 doc P0-2 条目。
+
+## 目标
+
+- 长任务（> 10 分钟）下 SSE 仍能保持 wrapper 存活
+- 客户端真实断开时 wrapper 仍能被 idle timer 正常回收（无内存泄漏）
+- 不引入新 npm 依赖
+- 不重构 `AgentSessionWrapper`
+
+## 非目标
+
+- 不把 timer 从 10 min 改长（variant C，延后问题）
+- 不做 SSE 连接数驱动的双向 timer（variant B，scope 更大）
+- 不做 fork / compact 的测试覆盖（评审 §4 列了但属独立工作）
+- 不重构 `AgentSessionWrapper`
+- 不让 idle timeout 可配置
+
+## 方案概览（方案 A：heartbeat 重置 timer）
+
+最小改动：
+
+- `lib/rpc-manager.ts`：在 `AgentSessionWrapper` 上加公开方法 `keepAlive()`，调用现有的私有 `resetIdleTimer()`。
+- `app/api/agent/[id]/events/route.ts`：heartbeat 把 `session.keepAlive()` 放在 `enqueue` 成功的同一 try 块内 —— 仅当 heartbeat 成功到达客户端时才重置 timer。
+- `lib/rpc-manager.test.ts`（新文件）：3 个 fake-timer 测试覆盖核心不变量。
+
+## `lib/rpc-manager.ts`
+
+新增方法：
+
+```typescript
+/**
+ * Signal that this wrapper is still in use (e.g., SSE heartbeat).
+ * Resets the idle timer without emitting any events.
+ */
+keepAlive(): void {
+  this.resetIdleTimer();
+}
+```
+
+放在 `onDestroy` 之后、`send` 之前。无新逻辑，复用 `resetIdleTimer`。
+
+## `app/api/agent/[id]/events/route.ts`
+
+heartbeat 块改造：
+
+```typescript
+// before
+const heartbeat = setInterval(() => {
+  try {
+    controller.enqueue(new TextEncoder().encode(":\n\n"));
+  } catch {
+    // controller already closed
+  }
+}, 30_000);
+
+// after
+const heartbeat = setInterval(() => {
+  try {
+    controller.enqueue(new TextEncoder().encode(":\n\n"));
+    session.keepAlive();
+  } catch {
+    // controller already closed; do not call keepAlive so the idle
+    // timer can eventually destroy the wrapper (no orphan).
+  }
+}, 30_000);
+```
+
+**关键设计点**：`keepAlive` 放在 `enqueue` 之后、`try` 块内。如果客户端断开（enqueue 抛错），跳过 keepAlive，timer 正常到期 → wrapper 销毁。**不引入新 catch 逻辑**，复用现有的"controller already closed"分支。
+
+## 数据流
+
+```
+client opens SSE
+  │
+  ├─ server: subscribe to pi events
+  ├─ server: setInterval(30s) → heartbeat
+  │    each tick:
+  │      ├─ controller.enqueue(":\n\n")
+  │      │     └─ success → session.keepAlive() → resetIdleTimer()
+  │      └─ throw (client gone) → catch → no keepAlive → timer eventually fires → destroy
+  │
+  └─ on client disconnect / browser close:
+       req.signal.abort → cleanup() → clearInterval(heartbeat) + unsubscribe
+```
+
+## 错误处理
+
+| 场景 | 行为 |
+|---|---|
+| 客户端正常断开 | `req.signal.abort` → cleanup → heartbeat 停止 → idle timer 正常到期 |
+| 客户端静默消失（无 FIN） | enqueue 抛错 → 跳过 keepAlive → timer 正常到期 |
+| 服务端 pi 抛错 | `subscribe` 回调不会重新抛；不影响 timer |
+| `keepAlive()` 在已 destroy 的 wrapper 上调用 | `resetIdleTimer` 内部 `if (this.idleTimer) clearTimeout(this.idleTimer)` 安全（无 timer 时 clearTimeout 是 no-op） |
+
+## 测试策略
+
+### `lib/rpc-manager.test.ts`（新文件，3 个测试）
+
+用 `node:test` 的 `mock.timers` + 最小 `AgentSessionLike` stub：
+
+1. **wrapper is destroyed after 10 min of inactivity**
+   - `start()` 后 tick 9 min → 仍 alive
+   - 再 tick 1 min（10 min 累计）→ destroyed
+
+2. **keepAlive resets the idle timer**
+   - `start()` 后 tick 9 min → alive
+   - `keepAlive()` 调用
+   - 再 tick 9 min → 仍 alive
+   - 再 tick 1 min（10 min since keepAlive）→ destroyed
+
+3. **events reset the idle timer (regression)**
+   - 捕获 `subscribe` 回调
+   - tick 9 min → alive
+   - 触发回调（模拟 pi 事件）→ 重置
+   - 再 tick 9 min → alive
+   - 再 tick 1 min → destroyed
+
+### 不写 SSE route 的集成测试
+
+SSE route 是 Next.js route handler + ReadableStream，集成测试要 mock 大量东西。改动的核心逻辑是 heartbeat 内一行调用，价值低于成本。手动验证即可。
+
+### 手动验证清单（写进 PR description）
+
+- [ ] 启动 dev，浏览器发送消息触发 agent 运行；等 agent 进入 LLM 思考期；观察 DevTools Network 面板 SSE 收到 `:` comment frames；保持页面打开 > 10 分钟（用一个真正的长时间任务或简单的 "tell me a long story" prompt）；验证 wrapper 仍 alive（不会"连接已断开"）
+- [ ] 关闭浏览器 tab，验证 wrapper 在 ~10 分钟后被销毁（可通过 `globalThis.__piSessions` 引用计数间接观察，或在下一个请求时观察 wrapper 是新创建的还是复用的）
+
+## 范围外（本次 P0-2 不做）
+
+- variant B（SSE 连接数驱动双向 timer）
+- variant C（延长到 30 min）
+- fork / compact 测试覆盖
+- `AgentSessionWrapper` 重构
+- idle timeout 配置化
+- abort / cleanup 路径本身（依赖现有 `req.signal?.addEventListener("abort", cleanup)`）
+
+## 风险
+
+| 风险 | 缓解 |
+|---|---|
+| `mock.timers` 在某些 Node 版本不支持 | 项目用 Node 20.12+（`bin/pi-web.js` 已绕过 Node ≥ 20.12 的 npx.cmd CVE），`mock.timers` 在 Node 20+ 可用 |
+| `AgentSessionLike` stub 字段不全导致 wrapper 抛错 | 用 `as never` 强转；只在 `start()` 路径调用 `subscribe`，测试不触发其他方法 |
+| heartbeat 把 `keepAlive` 放 `try` 块内带来性能开销 | `try` 是无开销的，调用本身也只是 `clearTimeout` + `setTimeout`，可忽略 |
+| 用户开了多个 tab | 每个 tab 有独立 SSE + 独立 heartbeat，都调 `keepAlive`，timer 一直被重置 —— 这是预期行为，浪费 < 1 KB 内存 |
+
+## 验证清单
+
+- [ ] `node --test lib/rpc-manager.test.ts` 通过（3 tests）
+- [ ] `node --test lib/*.test.ts electron/*.test.ts 'app/**/*.test.ts'` 通过
+- [ ] `npx tsc --noEmit` 通过
+- [ ] `npm run lint` 通过
+- [ ] 手动验证 2 条通过
+
+## 实施顺序
+
+1. `lib/rpc-manager.test.ts` 写 3 个测试（先 fail，因 `keepAlive` 不存在）
+2. `lib/rpc-manager.ts` 加 `keepAlive()` 方法
+3. 跑 rpc-manager 测试 → pass
+4. `app/api/agent/[id]/events/route.ts` heartbeat 加 `session.keepAlive()`
+5. tsc + lint + 全量测试
+6. commit
+
+## PR 范围
+
+- 2 文件修改（`lib/rpc-manager.ts`、`app/api/agent/[id]/events/route.ts`）
+- 1 文件新增（`lib/rpc-manager.test.ts`）
+- 总计 ~70 行变动
+- 一个 commit，一个 PR

--- a/docs/superpowers/specs/2026-06-01-p0-3-fork-navigate-timing-design.md
+++ b/docs/superpowers/specs/2026-06-01-p0-3-fork-navigate-timing-design.md
@@ -1,0 +1,257 @@
+# P0-3 fork / navigate_tree 状态时序契约设计
+
+> 分支：`analysis/architecture-optimization-review` · 日期：2026-06-01 · 关联评审：`docs/architecture-review-2026-06-01.md` §1 P0-3
+
+## 背景
+
+`AgentSessionWrapper.send({type:"fork"})` 末尾 `this.destroy()` 立即触发 `onDestroyCallback → registry.delete(realSessionId)`，但 fork 产生的新 session id 此时还没在注册表里——要等 UI 收到响应、切换会话后由 `POST /api/agent/[newId]` 触发 `startRpcSession` 才注册。窗口期内对 newId 的请求会走"重新创建"路径，依赖隐式行为。
+
+`useAgentSession.handleNavigate` / `handleLeafChange` 把 `navigate_tree` 当 fire-and-forget（`.catch(() => {})`），UI 在 agent 响应前就 `setActiveLeafId(entryId)` + `loadContext(sid, entryId)`。如果 pi 的 `navigateTree` 返回 `{cancelled: true}`，UI 已显示新 leaf 但 agent 仍停留在旧 leaf，用户接下来发的消息会基于错误的"对话分支"。
+
+详见评审 doc P0-3 条目。
+
+## 目标
+
+- **fork**：返回时新 session id 已在注册表里，UI 切换后能直接命中
+- **navigate**：agent 拒绝时 UI 不更新，用户不看到"假"的 leaf
+- 不引入通用 `command_ack` 协议（over-engineering for 2 个命令）
+- 不引入新 npm 依赖
+
+## 非目标
+
+- 不改 fork 的文件 IO 路径（`SessionManager.create` / `createBranchedSession` / `cacheSessionPath` 内部逻辑）
+- 不改 POST `/api/agent/[id]` route handler
+- 不修 fork 失败时的部分回滚（接受新文件残留磁盘——下次 fork 可被覆盖）
+- 不引入 `command_ack` 通用协议
+- 不修 fork 核心逻辑的测试覆盖（评审 §4 列了但属独立工作，需要 mock `pi` 内部 API 是集成测试范畴）
+- 不引入 React testing infra（`useAgentSession` hook 的测试覆盖现状无法在 `node --test` 体系下做）
+
+## 方案概览
+
+两个改动，跨服务端/客户端：
+
+| 文件 | 改动 | 性质 |
+|---|---|---|
+| `lib/rpc-manager.ts` | `case "fork"` 增加 `startRpcSession` 预注册 | 服务端：建立契约 |
+| `hooks/useAgentSession.ts` | 抽 `navigateToLeaf` helper，await + check `cancelled` | 客户端：遵守契约 |
+
+## `lib/rpc-manager.ts` 的 fork case
+
+在现有 fork 实现末尾的 `this.destroy()` 之前插入预注册：
+
+```typescript
+case "fork": {
+  const entryId = command.entryId as string;
+  const sessionManager = this.inner.sessionManager;
+  const currentSessionFile = this.inner.sessionFile;
+
+  if (!sessionManager.isPersisted()) return { cancelled: true };
+  if (!currentSessionFile) throw new Error("Persisted session is missing a session file");
+
+  const entry = sessionManager.getEntry(entryId);
+  if (!entry) throw new Error("Invalid entry ID for forking");
+
+  const sessionDir = sessionManager.getSessionDir();
+  let newSessionFile: string;
+
+  if (!entry.parentId) {
+    const newManager = SessionManager.create(sessionManager.getCwd(), sessionDir);
+    newManager.newSession({ parentSession: currentSessionFile });
+    newSessionFile = newManager.getSessionFile() as string;
+  } else {
+    const sourceManager = SessionManager.open(currentSessionFile, sessionDir);
+    const forkedPath = sourceManager.createBranchedSession(entry.parentId);
+    if (!forkedPath) throw new Error("Failed to create forked session");
+    newSessionFile = forkedPath;
+  }
+
+  const newSessionId = SessionManager.open(newSessionFile, sessionDir).getSessionId();
+  cacheSessionPath(newSessionId, newSessionFile);
+
+  // Pre-register the new wrapper BEFORE destroying the old.
+  // Contract: by the time send() returns, newSessionId is in the registry.
+  // If startRpcSession throws, do NOT destroy — old wrapper stays usable,
+  // new file remains on disk (acceptable; next fork overwrites).
+  const newCwd = sessionManager.getHeader()?.cwd ?? process.cwd();
+  await startRpcSession(newSessionId, newSessionFile, newCwd);
+
+  this.destroy();
+  return { cancelled: false, newSessionId };
+}
+```
+
+变更点：
+- `cacheSessionPath` 之后、`this.destroy()` 之前，加 `startRpcSession` 预注册
+- `startRpcSession` 已在 `globalThis.__piStartLocks` 加锁，并发安全由锁保证
+
+## `hooks/useAgentSession.ts` 的 navigate
+
+抽出共享 helper，`handleNavigate` 和 `handleLeafChange` 都走它：
+
+```typescript
+const navigateToLeaf = useCallback(async (leafId: string | null) => {
+  if (!leafId) {
+    setActiveLeafId(null);
+    return;
+  }
+  const sid = sessionIdRef.current;
+  if (!sid) return;
+  try {
+    const result = await sendAgentCommand<{ cancelled?: boolean }>(sid, {
+      type: "navigate_tree",
+      targetId: leafId,
+    });
+    if (result?.cancelled) {
+      console.warn("navigate_tree cancelled:", leafId);
+      return;  // UI 不更新，BranchNavigator 视觉仍指向旧 leaf
+    }
+    setActiveLeafId(leafId);
+    await loadContext(sid, leafId);
+  } catch (e) {
+    console.error("navigate_tree failed:", e);
+  }
+}, [loadContext]);
+
+const handleNavigate = useCallback((entryId: string) => {
+  return navigateToLeaf(entryId);
+}, [navigateToLeaf]);
+
+const handleLeafChange = useCallback((leafId: string | null) => {
+  return navigateToLeaf(leafId);
+}, [navigateToLeaf]);
+```
+
+变更点：
+- `navigateToLeaf` 新增：`sendAgentCommand` 从 fire-and-forget 改为 `await`，并检查 `result.cancelled`
+- `setActiveLeafId` 和 `loadContext` 移到 `navigate_tree` 成功之后
+- 旧 `handleNavigate` / `handleLeafChange` 各自 inline 的 5-6 行实现替换为对 `navigateToLeaf` 的转发，签名不变（`useChatWindow` 的调用方无感）
+
+## 数据流
+
+### fork（轻量"先注册再销毁"变体）
+
+```
+UI: handleFork(entryId)
+  │
+  └─ POST /api/agent/[sid] { type: "fork", entryId }
+       │
+       └─ wrapper.send({type:"fork", entryId})  // 旧 wrapper
+            │
+            ├─ SessionManager.create/open + createBranchedSession
+            ├─ cacheSessionPath(newId, newFile)
+            ├─ ★ await startRpcSession(newId, newFile, cwd)  // 新 wrapper 在册
+            └─ this.destroy()                                 // 旧 wrapper 出册
+       
+       └─ return { cancelled: false, newId }
+  
+  └─ onSessionForked(newId)  // UI 切到新 session
+       │
+       └─ 新 chat mount: connectEvents(newId)  // SSE 路由 getRpcSession(newId) 命中
+```
+
+注册表状态时序：
+```
+[oldId: oldWrapper, newId: ∅]   ← 初始
+[oldId: oldWrapper, newId: ∅]   ← cacheSessionPath 后
+[oldId: oldWrapper, newId: newWrapper]   ← startRpcSession 后
+[oldId: ∅,        newId: newWrapper]   ← destroy 后
+```
+
+### navigate
+
+```
+UI: BranchNavigator click → onLeafChange(leafId)
+  │
+  └─ navigateToLeaf(leafId)
+       │
+       ├─ sendAgentCommand POST navigate_tree
+       │     │
+       │     └─ wrapper.send({type:"navigate_tree", targetId})
+       │          └─ inner.navigateTree(targetId, {})
+       │
+       ├─ if cancelled → console.warn, return（UI 不变）
+       └─ if not cancelled
+            ├─ setActiveLeafId(leafId)
+            └─ loadContext(sid, leafId)
+```
+
+## 错误处理
+
+| 场景 | 行为 | 客户端可见 |
+|---|---|---|
+| `startRpcSession` 预注册失败（pi 初始化抛错） | fork case 抛异常 → **不调** `this.destroy()` → 旧 wrapper 仍在册，新文件残留磁盘 | 500 + 旧 session 仍可用 |
+| `sendAgentCommand` 抛错（network / 500） | `navigateToLeaf` catch + log | UI 不变（无 toast） |
+| `navigate_tree` 返回 `{cancelled: true}` | `console.warn`，return | UI 不变（BranchNavigator 视觉仍指旧 leaf） |
+| 同一 sessionId 并发 fork | `startRpcSession` 锁串行化；第二次进 fork case 时旧 wrapper 已被第一次 destroy | 第二次 fork 走 500（不可达，但 safe） |
+
+## 测试策略
+
+### `lib/rpc-manager.test.ts`：加 1 个测试
+
+```typescript
+test("fork returns {cancelled: true} for non-persisted session", () => {
+  const inner = makeStubInner({
+    sessionManager: { isPersisted: () => false },
+    sessionFile: "stub.jsonl",
+  });
+  const w = new AgentSessionWrapper(inner);
+  w.start();
+  return w.send({ type: "fork", entryId: "x" }).then((result) => {
+    assert.deepEqual(result, { cancelled: true });
+  });
+});
+```
+
+这是评审 §4 列入的测试盲区（已有逻辑，无新加）。补这个测试不动新行为，只锁住既有契约。
+
+### 不测的部分
+
+- **fork 完整成功路径**：需要 mock `pi` 的 `SessionManager.open` / `createBranchedSession` / `cacheSessionPath` —— 集成测试范畴，本 PR 不做。
+- **navigate `useAgentSession` hook**：React hook 测试需要 React Testing Library + jsdom，项目用 `node --test` 没有这套基建。留给未来。
+
+### 手动验证清单（写进 PR description）
+
+- [ ] 启动 dev，浏览器创建会话、发送消息，fork 出子会话；UI 立即切换到子会话；DevTools Network 面板观察子会话的 SSE / loadSession / connectEvents 都正常返回（无 404 / "Session not found"）
+- [ ] 在 BranchNavigator 上点击当前 leaf 的不同分支；观察 UI 平滑切换；新 leaf 的消息历史正确显示
+- [ ] （如果能构造）尝试 navigate 到一个 pi 会拒绝的 entryId（例如已经在当前 leaf 的位置），观察 BranchNavigator 不切换、UI 不更新、console 出现 `navigate_tree cancelled: ...`
+
+## 范围外（本次 P0-3 不做）
+
+- `command_ack` 通用协议
+- fork 完整成功路径的自动化测试
+- React hook 测试基建
+- fork 失败时清理新文件（接受残留）
+- 同一 session 并发 fork 的处理（不实际可达）
+
+## 风险
+
+| 风险 | 缓解 |
+|---|---|
+| `startRpcSession` 预注册时 `createAgentSession` 抛错（旧 wrapper 销毁失败） | 抛错时**不**调 `this.destroy()`，旧 wrapper 保留；新文件残留磁盘可被下次 fork 覆盖 |
+| 预注册引入 ~100ms 延迟（pi 初始化） | fork 本来就是慢操作，~100ms 可忽略；UI 等待本来就有 |
+| 并发 fork 同一 session | `startRpcSession` 锁串行化；第二次进入时第一次的 destroy 已完成，第二次走 500 |
+| `navigateToLeaf` 增加 await 引入 ~50ms UI 延迟 | 用户点 BranchNavigator 后到 UI 切换本就 ~100ms（loadContext 也要 await），增量延迟不可感 |
+| `navigateToLeaf` 的 console.warn 在生产环境暴露 | 项目其他 handler 也是 `console.warn/error`（无 toast 基建），与项目风格一致 |
+
+## 验证清单
+
+- [ ] `node --test lib/*.test.ts electron/*.test.ts 'app/**/*.test.ts'` 通过
+- [ ] `npx tsc --noEmit` 通过
+- [ ] `npm run lint` 通过
+- [ ] 手动验证 3 条通过
+
+## 实施顺序
+
+1. `lib/rpc-manager.ts` fork case 插入 `startRpcSession` 预注册（~5 行）
+2. `lib/rpc-manager.test.ts` 加 1 个 fork cancelled 测试
+3. 跑 rpc-manager 测试 → pass
+4. `hooks/useAgentSession.ts` 抽 `navigateToLeaf`、改 `handleNavigate` / `handleLeafChange`
+5. tsc + lint + 全量测试
+6. commit
+
+## PR 范围
+
+- 2 文件修改（`lib/rpc-manager.ts`、`hooks/useAgentSession.ts`）
+- 1 文件修改（`lib/rpc-manager.test.ts` 加 1 个 fork cancelled 测试）
+- 总计 ~35 行变动（~5 行 rpc-manager + ~15 行 useAgentSession 抽 helper + ~15 行测试）
+- 一个 commit，一个 PR

--- a/docs/superpowers/specs/2026-06-01-p0-5-chatwindow-render-design.md
+++ b/docs/superpowers/specs/2026-06-01-p0-5-chatwindow-render-design.md
@@ -1,0 +1,328 @@
+# P0-5 ChatWindow 渲染性能优化设计
+
+> 分支：`analysis/architecture-optimization-review` · 日期：2026-06-01 · 关联评审：`docs/architecture-review-2026-06-01.md` §1 P0-5
+
+## 背景
+
+`components/ChatWindow.tsx:295-353` 把消息列表的渲染包在一个 IIFE 里，每次 ChatWindow render 都会：
+- 建 `toolResultsMap`（O(n)，new Map）
+- 反向扫描找 `lastUserIdx`（O(n)）
+- 对每条消息 forward scan 找下一个 user/assistant（O(n) per message → O(n²) worst case）
+- 用 `idx` 作 key（消息数组调整时整列 unmount/remount）
+
+长对话（100+ 消息）下：
+- 流式推送时，ChatWindow re-render 触发 O(n²) 的 forward scan
+- 任何 ChatWindow state 变化（输入框打字、滚动、useTheme 触发）都会让每条 `MessageView` 重新渲染
+- `MessageView` 没有 `React.memo` 包装
+
+详见评审 doc P0-5 条目。
+
+## 目标
+
+- 流式推送时 ChatWindow re-render 不触发 O(n²) 计算
+- ChatWindow 任意 state 变化（不涉及消息）时，**每条** `MessageView` 都不重新渲染
+- 消息数组调整时，**不**因 key 变化而整列 unmount/remount
+- 不引入新 npm 依赖
+
+## 非目标
+
+- 不引入虚拟滚动（`react-window` / `react-virtuoso`）—— 范围大、独立 P
+- 不重构 `MessageView` 内部（847 行、4 个子组件已自洽）
+- 不修 `FileViewer` 的 SyntaxHighlighter 性能
+- 不改 `entryIds` 生成逻辑
+- 不动 `MessageView` 的 props 接口（保持向后兼容）
+
+## 方案概览
+
+| 文件 | 动作 | 职责 |
+|---|---|---|
+| `components/MessageList.tsx` | 新建 | 消息列表子组件，包 `React.memo` |
+| `components/ChatWindow.tsx` | 修改 | useMemo 预计算 + 委托给 MessageList + useCallback 提取内联回调 |
+| `components/MessageView.tsx` | 修改 | 顶层 export 包 `React.memo` |
+
+## `components/MessageList.tsx`（新建）
+
+```typescript
+import React, { useMemo } from "react";
+import type { AgentMessage, ToolResultMessage } from "@/lib/types";
+import { MessageView } from "./MessageView.tsx";
+
+interface MessageListProps {
+  messages: AgentMessage[];
+  entryIds: string[];
+  toolResultsMap: Map<string, ToolResultMessage>;
+  nextUserIdx: number[];
+  nextAssistantIdx: number[];
+  isStreaming: boolean;
+  streamingMessage: Partial<AgentMessage> | null;
+  isNew: boolean;
+  agentRunning: boolean;
+  forkingEntryId: string | null;
+  onFork: (entryId: string) => void;
+  onNavigate: (entryId: string) => void;
+  onEditContent: (content: string) => void;
+  handleScrollToUserMsg: (idx: number) => void;
+  messageRefs: React.MutableRefObject<(HTMLDivElement | null)[]>;
+  lastUserIdx: number;
+  modelNames: Record<string, string>;
+}
+
+export const MessageList = React.memo(function MessageList({
+  messages, entryIds, toolResultsMap, nextUserIdx, nextAssistantIdx,
+  isStreaming, streamingMessage, isNew, agentRunning, forkingEntryId,
+  onFork, onNavigate, onEditContent, handleScrollToUserMsg, messageRefs,
+  lastUserIdx, modelNames,
+}: MessageListProps) {
+  let refIdx = 0;
+  return (
+    <>
+      {messages.map((msg, idx) => {
+        const isFirstUserMessage = idx === 0 && msg.role === "user";
+        const canFork = !agentRunning && !isNew && !isFirstUserMessage;
+        const canNavigate = !agentRunning;
+        const isUserOrAssistant = msg.role === "user" || msg.role === "assistant";
+        const showTimestamp = msg.role !== "assistant"
+          || nextUserIdx[idx] !== -1
+          || nextAssistantIdx[idx] === -1;
+        // Hide on the currently-streaming tail
+        const finalShowTimestamp = showTimestamp && !(isStreaming && idx === messages.length - 1);
+        const prevAssistantEntryId = msg.role === "user" && idx > 0 && messages[idx - 1].role === "assistant"
+          ? entryIds[idx - 1]
+          : undefined;
+        const prevTimestamp = idx > 0
+          ? (messages[idx - 1] as AgentMessage & { timestamp?: number }).timestamp
+          : undefined;
+
+        const view = (
+          <MessageView
+            key={entryIds[idx] ?? `idx-${idx}`}
+            message={msg}
+            toolResults={toolResultsMap}
+            modelNames={modelNames}
+            entryId={entryIds[idx]}
+            onFork={canFork ? onFork : undefined}
+            forking={forkingEntryId === entryIds[idx]}
+            onNavigate={canNavigate ? onNavigate : undefined}
+            prevAssistantEntryId={prevAssistantEntryId}
+            onEditContent={onEditContent}
+            showTimestamp={finalShowTimestamp}
+            prevTimestamp={prevTimestamp}
+          />
+        );
+
+        if (!isUserOrAssistant) return view;
+        const currentRefIdx = refIdx++;
+        return (
+          <div
+            key={entryIds[idx] ?? `idx-${idx}`}
+            ref={(el) => {
+              messageRefs.current[currentRefIdx] = el;
+              if (idx === lastUserIdx) handleScrollToUserMsg(idx);
+            }}
+          >
+            {view}
+          </div>
+        );
+      })}
+      {isStreaming && streamingMessage && (
+        <MessageView message={streamingMessage as AgentMessage} isStreaming modelNames={modelNames} />
+      )}
+    </>
+  );
+});
+```
+
+注：`handleScrollToUserMsg(idx)` 替代原 IIFE 的 `lastUserMsgRef.current = el` 写法——把 ref 收拢逻辑也搬过来。`handleScrollToUserMsg` 来自父级 `useCallback`，引用稳定。
+
+## `components/ChatWindow.tsx`（修改）
+
+### useMemo 预计算（替换原 IIFE 内的同义计算）
+
+```typescript
+const toolResultsMap = useMemo(() => {
+  const m = new Map<string, ToolResultMessage>();
+  for (const msg of messages) {
+    if (msg.role === "toolResult") {
+      m.set((msg as ToolResultMessage).toolCallId, msg as ToolResultMessage);
+    }
+  }
+  return m;
+}, [messages]);
+
+const { nextUserIdx, nextAssistantIdx, lastUserIdx } = useMemo(() => {
+  const nextUserIdx: number[] = new Array(messages.length).fill(-1);
+  const nextAssistantIdx: number[] = new Array(messages.length).fill(-1);
+  let lastUser = -1;
+  let lastAssistant = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === "user") {
+      nextUserIdx[i] = lastUser;
+      lastUser = i;
+    } else if (messages[i].role === "assistant") {
+      nextAssistantIdx[i] = lastAssistant;
+      lastAssistant = i;
+    }
+  }
+  return { nextUserIdx, nextAssistantIdx, lastUserIdx: lastUser };
+}, [messages]);
+```
+
+### useCallback 提取内联回调（`onEditContent`）
+
+原：
+```typescript
+onEditContent={(content) => chatInputRef?.current?.insertIfEmpty(content)}
+```
+
+改为：
+```typescript
+const handleEditContent = useCallback((content: string) => {
+  chatInputRef?.current?.insertIfEmpty(content);
+}, []);
+```
+
+注：`chatInputRef` 是 `useRef` 创建的 ref，引用稳定，因此 `useCallback` deps 用 `[]` 即可。
+
+### `handleScrollToUserMsg` useCallback
+
+```typescript
+const handleScrollToUserMsg = useCallback((idx: number) => {
+  if (idx === lastUserIdx) {
+    const container = scrollContainerRef.current;
+    const el = lastUserMsgRef.current;
+    if (container && el) {
+      const elAbsTop = el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
+      container.scrollTo({ top: elAbsTop - 16, behavior: "smooth" });
+    }
+  }
+}, [lastUserIdx]);
+```
+
+注：原 `scrollUserMsgToTop` 函数已存在，包成 useCallback 让 MessageList 的 `ref` 回调引用稳定。deps 是 `lastUserIdx`（如果 lastUserIdx 变了，handleScrollToUserMsg 引用变；这个变化是合理的——lastUserIdx 改变时 MessageList 重 render 是预期的）。
+
+### 替换 IIFE 为 MessageList 渲染
+
+原 IIFE（line 295-353）整段替换为：
+```typescript
+<MessageList
+  messages={messages}
+  entryIds={entryIds}
+  toolResultsMap={toolResultsMap}
+  nextUserIdx={nextUserIdx}
+  nextAssistantIdx={nextAssistantIdx}
+  isStreaming={streamState.isStreaming}
+  streamingMessage={streamState.streamingMessage}
+  isNew={isNew}
+  agentRunning={agentRunning}
+  forkingEntryId={forkingEntryId}
+  onFork={handleFork}
+  onNavigate={handleNavigate}
+  onEditContent={handleEditContent}
+  handleScrollToUserMsg={handleScrollToUserMsg}
+  messageRefs={messageRefs}
+  lastUserIdx={lastUserIdx}
+  modelNames={modelNames}
+/>
+```
+
+## `components/MessageView.tsx`（修改）
+
+找到顶层 export（line 68）：
+```typescript
+export function MessageView({ message, isStreaming, toolResults, modelNames, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp }: Props) {
+```
+
+改为：
+```typescript
+export const MessageView = React.memo(function MessageView({ message, isStreaming, toolResults, modelNames, entryId, onFork, forking, onNavigate, prevAssistantEntryId, onEditContent, showTimestamp, prevTimestamp }: Props) {
+  // ... 现有实现完全不动
+});
+```
+
+变更点：
+- `function` 改为 `const ... = React.memo(function ...)`
+- 函数体一字不动
+- 添加 `import React from "react"`（项目现有 import 中已有 `from "react"`，复用即可）
+
+## 数据流
+
+```
+ChatWindow re-renders
+  │
+  ├─ useMemo toolResultsMap  (deps: messages)  → 同引用除非 messages 变
+  ├─ useMemo nextUserIdx/nextAssistantIdx/lastUserIdx  (deps: messages)  → 同引用除非 messages 变
+  ├─ useCallback handleEditContent  (deps: [])  → 永远同引用
+  ├─ useCallback handleScrollToUserMsg  (deps: lastUserIdx)  → 引用在 lastUserIdx 变时变（合理）
+  │
+  └─ <MessageList props={...}>
+        │
+        └─ React.memo: 比较 props 引用
+             │
+             └─ 全等（messages 没变、callbacks 同引用）→ skip render
+                  │
+                  └─ 不等（messages 变了）→ render
+                        │
+                        └─ messages.map → <MessageView />
+                             │
+                             └─ React.memo: 比较 props 引用
+                                  │
+                                  └─ 全等（message 没变、toolResultsMap 同引用、onFork 同引用）→ skip render
+                                       │
+                                       └─ 不等 → render
+```
+
+## 错误处理
+
+无新增错误路径。这是纯性能重构，行为不变。
+
+## 测试策略
+
+- **不写自动化测试**：项目无 React testing infra（`node --test` 不能 mount React 组件）
+- **手动验证**（React Profiler）写进 PR description
+
+### 手动验证清单
+
+- [ ] 打开一个有 100+ 消息的会话；用 React DevTools Profiler 录制 ChatWindow
+- [ ] 在 chat input 打字（不应触发 `MessageList` / `MessageView` 渲染）
+- [ ] 滚动消息列表（不应触发）
+- [ ] 触发 stream 推送（流式消息应该实时更新；其他消息不应 re-render；forward scan 不应出现）
+- [ ] fork 一个会话，观察子会话的 MessageView 在切到子会话时不重新加载（cache 命中）
+
+## 范围外（本次 P0-5 不做）
+
+- 虚拟滚动
+- `MessageView` 内部重构
+- `FileViewer` SyntaxHighlighter 性能
+- `entryIds` 生成逻辑
+
+## 风险
+
+| 风险 | 缓解 |
+|---|---|
+| `React.memo(MessageView)` 按引用比较；`toolResultsMap` 若被绕过 useMemo 会失效 | code review 把关：ChatWindow 内的 `toolResultsMap` 必须始终是 useMemo 的返回值 |
+| 条件 `onFork`/`onNavigate` 引用稳定性依赖 `handleFork`/`handleNavigate` 是稳定引用 | 已在 P0-3 中将 `useAgentSession` 的对应 useCallback 依赖收敛；本次不修改 |
+| 抽出 MessageList 为独立文件增加模块数 | 117 行（按 spec），可接受 |
+| `handleScrollToUserMsg` deps 是 `lastUserIdx`——会随 lastUserIdx 变化重新创建 | 合理：lastUserIdx 改变说明消息列表变了，MessageList 重新 render 是预期的 |
+| `key={entryIds[idx] ?? 'idx-${idx}'}` 的 fallback 在 entryIds 缺失时回退到 `idx-` 形式 | 仍保持稳定（同 idx 同 fallback）；不是最优但是正确 |
+
+## 验证清单
+
+- [ ] `npx tsc --noEmit` 通过
+- [ ] `npm run lint` 通过
+- [ ] 全量测试套件（37 tests）通过
+- [ ] Profiler 手动验证 4 条通过
+
+## 实施顺序
+
+1. `components/MessageView.tsx` 顶层 export 包 `React.memo`（最小、独立、~3 行）
+2. `components/MessageList.tsx` 新建（~120 行）
+3. `components/ChatWindow.tsx` useMemo + useCallback + 替换 IIFE
+4. tsc + lint + 全量测试
+5. commit
+
+## PR 范围
+
+- 1 文件新建（`components/MessageList.tsx`）
+- 2 文件修改（`components/ChatWindow.tsx` 替换 IIFE、`components/MessageView.tsx` 包 React.memo）
+- 总计 ~120 行变动（~110 行新建 + ~10 行 ChatWindow + ~3 行 MessageView 顶部 export）
+- 一个 commit，一个 PR

--- a/docs/superpowers/specs/2026-06-01-p0-6-hooks-mount-effect-design.md
+++ b/docs/superpowers/specs/2026-06-01-p0-6-hooks-mount-effect-design.md
@@ -1,0 +1,238 @@
+# P0-6 hooks mount effect + eslint-disable 设计
+
+> 分支：`analysis/architecture-optimization-review` · 日期：2026-06-02 · 关联评审：`docs/architecture-review-2026-06-01.md` §1 P0-6
+
+## 背景
+
+`hooks/useAgentSession.ts:429-454` 的 mount effect 用了空 deps `[]` 和 `// eslint-disable-next-line react-hooks/exhaustive-deps`。当 `session` prop 从 A→B 变化时（组件未卸载）：
+
+- effect 不会重跑（旧 deps 是 `[]`）
+- A 的 SSE 连接不会被关闭（`cleanup` 只在 unmount 触发）
+- 新 `connectEvents(session.id)` 在 EventSource 已存在时不会自动重连——它只在 `eventSourceRef.current` 不为 null 时 close 旧的再开新的。但 effect 没重跑，所以新的 `connectEvents` 调用没发生
+
+AppShell 靠 `<ChatWindow key={sessionKey}>` 强制 remount 来掩盖这个 bug——session 切换时整个 `useAgentSession` 实例被销毁重建。这是**隐性契约**，未来加新 prop 必然踩坑。
+
+详见评审 doc P0-6 条目。
+
+## 目标
+
+- `session` prop 变化时（不 remount）mount effect 重跑
+- 旧的 SSE 在 effect 重跑时关闭
+- **不会**有 A 状态渗到 B 的"bleed"问题（包括消息、tree、agentRunning 等所有 session-scoped state）
+- 不会引入新 bug
+
+## 非目标
+
+- 不抽 `useSessionInit` hook（架构评审 §1 P0-6 推荐方案 A）
+- 不重构 `useSessionLoader.ts`（c1d68cd 已抽好）
+- 不动 `useAgentEvents` / `useChatScroll` 的内部 ref（那些 ref 没法从外部 reset）
+- **不**移除 AppShell 的 `sessionKey` remount（保留为 defense-in-depth，覆盖 `useChatScroll` 等子 hook 内部 state）
+- 不重构 `useSessionLoader.loadSession` 的 fetch 行为（不引入 `AbortController`——本次 effect 自带 `cancelled` 守卫足够）
+
+## 方案概览
+
+1 个文件 `hooks/useAgentSession.ts` 修改：
+
+- destructure 块加 `setEntryIds`（之前漏 destructure）
+- mount effect：
+  - deps 从 `[]` 改为 `[session?.id]`
+  - 加 `if (!session) return;` 早返回
+  - 加 16 个 setter 调用 + 1 个 `dispatch({type:"reset"})`，重置 session-scoped state
+  - 加 `let cancelled = false; return () => { cancelled = true; };` 守卫 stale `.then`
+  - 保留 `// eslint-disable-next-line react-hooks/exhaustive-deps`（useState 的 setter 引用稳定，但 `exhaustive-deps` lint 不识别）
+
+## `hooks/useAgentSession.ts` 的 destructure 块
+
+确认 line 51-63 的 `useSessionLoader` 解构包含 `setEntryIds`（这是用来在重置时清空 entryIds 的）。如果当前解构里没有 `setEntryIds`，把它补上：
+
+```typescript
+  const {
+    data, setData, loading, error, activeLeafId, setActiveLeafId,
+    messages, setMessages, entryIds, setEntryIds,
+    loadSession, loadContext,
+  } = useSessionLoader(isNew);
+```
+
+## `hooks/useAgentSession.ts` 的 mount effect
+
+替换前（line 429-454）：
+```typescript
+  // Load session on mount
+  useEffect(() => {
+    if (session) {
+      sessionIdRef.current = session.id;
+      loadSession(session.id, true, true).then((loaded) => {
+        const agentState = loaded?.agentState ?? null;
+        if (!agentState?.state?.thinkingLevel && loaded?.contextThinkingLevel && loaded.contextThinkingLevel !== "off") {
+          setThinkingLevel(loaded.contextThinkingLevel as ThinkingLevelOption);
+        }
+        if (agentState?.running) {
+          loadTools(session.id);
+          if (agentState.state?.isStreaming) {
+            setAgentRunning(true);
+            setAgentPhase({ kind: "waiting_model" });
+            connectEvents(session.id);
+          }
+        }
+        if (agentState?.state) {
+          if (agentState.state.isCompacting !== undefined) setIsCompacting(agentState.state.isCompacting);
+          if (agentState.state.contextUsage !== undefined) setContextUsage(agentState.state.contextUsage ?? null);
+          if (agentState.state.systemPrompt !== undefined) setSystemPrompt(agentState.state.systemPrompt ?? null);
+          if (agentState.state.thinkingLevel !== undefined) setThinkingLevel((agentState.state.thinkingLevel as ThinkingLevelOption) ?? "auto");
+        }
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+```
+
+替换为：
+```typescript
+  // Load session on mount AND on session change.
+  //
+  // On session change, reset all session-scoped state to avoid bleed
+  // from a previous session. AppShell's sessionKey remount is kept
+  // as defense-in-depth (it covers state in sub-hooks like
+  // useChatScroll / useAgentEvents that we can't reset from here).
+  //
+  // The cancelled flag is a closure guard: when session A→B, the
+  // effect's cleanup runs before the next effect call. Cleanup
+  // sets cancelled=true on the OLD closure; the OLD .then (still
+  // in flight) sees the flag and bails. This makes the effect
+  // self-sufficient even if AppShell's remount is later removed.
+  useEffect(() => {
+    if (!session) return;
+    const sid = session.id;
+    sessionIdRef.current = sid;
+    let cancelled = false;
+
+    // Reset session-scoped state. Ordered to mirror the useState
+    // declarations above for readability.
+    setData(null);
+    setActiveLeafId(null);
+    setMessages([]);
+    setEntryIds([]);
+    setToolPreset("default");
+    setThinkingLevel("auto");
+    setAgentRunning(false);
+    setAgentPhase(null);
+    dispatch({ type: "reset" });   // streamState → {isStreaming:false, streamingMessage:null}
+    setRetryInfo(null);
+    setContextUsage(null);
+    setSystemPrompt(null);
+    setForkingEntryId(null);
+    setIsCompacting(false);
+    setCompactError(null);
+    setCurrentModelOverride(null);
+    setPendingModel(null);
+
+    loadSession(sid, true, true).then((loaded) => {
+      if (cancelled) return;  // ignore stale results from a previous session
+      const agentState = loaded?.agentState ?? null;
+      if (!agentState?.state?.thinkingLevel && loaded?.contextThinkingLevel && loaded.contextThinkingLevel !== "off") {
+        setThinkingLevel(loaded.contextThinkingLevel as ThinkingLevelOption);
+      }
+      if (agentState?.running) {
+        loadTools(sid);
+        if (agentState.state?.isStreaming) {
+          setAgentRunning(true);
+          setAgentPhase({ kind: "waiting_model" });
+          connectEvents(sid);
+        }
+      }
+      if (agentState?.state) {
+        if (agentState.state.isCompacting !== undefined) setIsCompacting(agentState.state.isCompacting);
+        if (agentState.state.contextUsage !== undefined) setContextUsage(agentState.state.contextUsage ?? null);
+        if (agentState.state.systemPrompt !== undefined) setSystemPrompt(agentState.state.systemPrompt ?? null);
+        if (agentState.state.thinkingLevel !== undefined) setThinkingLevel((agentState.state.thinkingLevel as ThinkingLevelOption) ?? "auto");
+      }
+    });
+
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session?.id]);
+```
+
+## 数据流
+
+```
+session A → session B
+  │
+  ├─ AppShell bumps sessionKey → ChatWindow REMOUNTS
+  │    (新 useAgentSession 实例，初始空 state；本文 doc 不改这个)
+  │
+  └─ [防御性冗余 / 未来如果移除 remount] effect 重跑：
+       │
+       ├─ 旧 effect cleanup：cancelled = true（旧闭包）
+       ├─ 新 effect body：
+       │    ├─ 15 个 setter 重置 session-scoped state
+       │    ├─ loadSession(B, ..., true) → fetch
+       │    └─ .then 闭包（含 cancelled 检查）
+       │
+       ├─ Race 1: A 的 loadSession.fetch 还在飞
+       │    └─ A 的 .then 触发 cancelled 检查 → 旧闭包 cancelled=true → 早返回
+       │       （A 的 state setter 在 unmounted 实例上是 no-op）
+       │
+       └─ B 的 .then 触发 cancelled 检查 → 新闭包 cancelled=false → 应用 B 的 state
+```
+
+## 错误处理
+
+- `loadSession` 抛错：`.then` 没有 `.catch`，未处理错误会被 React 捕获并 console.error。**与现有行为一致**，本次不修
+- `connectEvents` 抛错：同样无 `.catch`，现有行为
+- `cancelled` 检查在 `.then` 开头：如果 A 的 `.then` 在 cancelled 设了 true 之后才被调度到执行，cancelled 检查能拦住
+
+## 测试策略
+
+**不写自动化测试**（项目无 React testing infra）。`node --test` 不支持 mount React 组件。
+
+### 手动验证清单（写进 PR description）
+
+- [ ] 启动 dev，浏览器创建 A 会话，发消息让它 running（agent 正在回复）
+- [ ] 切到 B 会话。观察：B 的消息列表立即是空的（不是 A 的 50 条），tree/leafId 重置，无 agentRunning 闪 A 的状态，无旧 SSE
+- [ ] 并发切：快速点 A→B→A（300ms 内），观察最后 A 的 state 正确（无 race 让 A 的 .then 覆盖 B 或反之）
+- [ ] 切完会话能正常发消息（agent 仍能接 prompt）
+
+### 自动化测试
+
+跑全量测试套件确认无回归：
+- `node --test lib/*.test.ts electron/*.test.ts 'app/**/*.test.ts'`
+- 跑 `node --test hooks/agent-session/*.test.ts`（10 个 main 新增测试）
+
+## 范围外（本次 P0-6 不做）
+
+- 抽 `useSessionInit` hook（评审 §1 P0-6 推荐方案 A 是"deps + reset"，不是抽 hook）
+- 重构 `useSessionLoader.loadSession` 加 `AbortController`
+- 移除 AppShell 的 `sessionKey` remount
+- 修改 `useChatScroll` / `useAgentEvents` 内部 ref 暴露
+- 重构 `useAgentSession.ts` 其他 effect
+
+## 风险
+
+| 风险 | 缓解 |
+|---|---|
+| `cancelled` 守卫对 `.then` 之外的失败路径无效 | A 的 useEffect 已被 cleanup（返回的函数），setter 在 unmounted 实例上是 no-op |
+| `useSessionLoader` 内部的 `loading` / `error` state 没 reset | 接受 ~100ms 闪烁（`loadSession` 立即设 `loading=true`、成功后清 error） |
+| `setToolPreset` 依赖 `toolPreset` 父 prop（来自 useState 还是父）| 检查依赖链；若 `toolPreset` 来自 useState（line 71），用 `setToolPreset` |
+| 保留 `eslint-disable` 是债务 | 加注释解释为什么；将来若换用 `useEffectEvent` 或 React 19 新 API，可消除 |
+| AppShell 移除 remount → bleed 回到 | 本次设计确保 self-sufficient；remount 移除是独立 PR |
+
+## 验证清单
+
+- [ ] `npx tsc --noEmit` 通过
+- [ ] `npm run lint` 通过
+- [ ] 全量测试套件（37 已有 + 10 main 新增 = 47）通过
+- [ ] 手动验证 4 条通过
+
+## 实施顺序
+
+1. 确认 `setEntryIds` 是否在 destructure 块里；若不在，添加
+2. 替换 mount effect（按上述代码块）
+3. tsc + lint + 全量测试
+4. commit
+
+## PR 范围
+
+- 1 文件修改（`hooks/useAgentSession.ts`）
+- ~30 行变动
+- 一个 commit，一个 PR

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -58,6 +58,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     messages,
     setMessages,
     entryIds,
+    setEntryIds,
     loadSession: loadSessionFromApi,
     loadContext,
   } = useSessionLoader(isNew);
@@ -425,33 +426,69 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     }
   }, [setToolPresetState]);
 
-  // Load session on mount
+  // Load session on mount AND on session change.
+  //
+  // On session change, reset all session-scoped state to avoid bleed
+  // from a previous session. AppShell's sessionKey remount is kept
+  // as defense-in-depth (covers state in sub-hooks like
+  // useChatScroll / useAgentEvents that we can't reset from here).
+  //
+  // The cancelled flag is a closure guard: when session A→B, the
+  // effect's cleanup runs before the next effect call. Cleanup
+  // sets cancelled=true on the OLD closure; the OLD .then (still
+  // in flight) sees the flag and bails. Makes the effect
+  // self-sufficient even if AppShell's remount is later removed.
   useEffect(() => {
-    if (session) {
-      sessionIdRef.current = session.id;
-      loadSession(session.id, true, true).then((loaded) => {
-        const agentState = loaded?.agentState ?? null;
-        if (!agentState?.state?.thinkingLevel && loaded?.contextThinkingLevel && loaded.contextThinkingLevel !== "off") {
-          setThinkingLevel(loaded.contextThinkingLevel as ThinkingLevelOption);
+    if (!session) return;
+    const sid = session.id;
+    sessionIdRef.current = sid;
+    let cancelled = false;
+
+    // Reset session-scoped state. Ordered to mirror useState
+    // declarations above for readability.
+    setData(null);
+    setActiveLeafId(null);
+    setMessages([]);
+    setEntryIds([]);
+    setToolPreset("default");
+    setThinkingLevel("auto");
+    setAgentRunning(false);
+    setAgentPhase(null);
+    dispatch({ type: "reset" });   // streamState → {isStreaming:false, streamingMessage:null}
+    setRetryInfo(null);
+    setContextUsage(null);
+    setSystemPrompt(null);
+    setForkingEntryId(null);
+    setIsCompacting(false);
+    setCompactError(null);
+    setCurrentModelOverride(null);
+    setPendingModel(null);
+
+    loadSessionFromApi(sid, true, true).then((loaded) => {
+      if (cancelled) return;  // ignore stale results from a previous session
+      const agentState = loaded?.agentState ?? null;
+      if (!agentState?.state?.thinkingLevel && loaded?.contextThinkingLevel && loaded.contextThinkingLevel !== "off") {
+        setThinkingLevel(loaded.contextThinkingLevel as ThinkingLevelOption);
+      }
+      if (agentState?.running) {
+        loadTools(sid);
+        if (agentState.state?.isStreaming) {
+          setAgentRunning(true);
+          setAgentPhase({ kind: "waiting_model" });
+          connectEvents(sid);
         }
-        if (agentState?.running) {
-          loadTools(session.id);
-          if (agentState.state?.isStreaming) {
-            setAgentRunning(true);
-            setAgentPhase({ kind: "waiting_model" });
-            connectEvents(session.id);
-          }
-        }
-        if (agentState?.state) {
-          if (agentState.state.isCompacting !== undefined) setIsCompacting(agentState.state.isCompacting);
-          if (agentState.state.contextUsage !== undefined) setContextUsage(agentState.state.contextUsage ?? null);
-          if (agentState.state.systemPrompt !== undefined) setSystemPrompt(agentState.state.systemPrompt ?? null);
-          if (agentState.state.thinkingLevel !== undefined) setThinkingLevel((agentState.state.thinkingLevel as ThinkingLevelOption) ?? "auto");
-        }
-      });
-    }
+      }
+      if (agentState?.state) {
+        if (agentState.state.isCompacting !== undefined) setIsCompacting(agentState.state.isCompacting);
+        if (agentState.state.contextUsage !== undefined) setContextUsage(agentState.state.contextUsage ?? null);
+        if (agentState.state.systemPrompt !== undefined) setSystemPrompt(agentState.state.systemPrompt ?? null);
+        if (agentState.state.thinkingLevel !== undefined) setThinkingLevel((agentState.state.thinkingLevel as ThinkingLevelOption) ?? "auto");
+      }
+    });
+
+    return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [session?.id]);
 
   useEffect(() => {
     onSystemPromptChange?.(systemPrompt);

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -428,23 +428,36 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     }
   }, [onSessionForked]);
 
-  const handleNavigate = useCallback(async (entryId: string) => {
+  const navigateToLeaf = useCallback(async (leafId: string | null) => {
+    if (!leafId) {
+      setActiveLeafId(null);
+      return;
+    }
     const sid = sessionIdRef.current;
     if (!sid) return;
-    sendAgentCommand(sid, { type: "navigate_tree", targetId: entryId }).catch(() => {});
-    setActiveLeafId(entryId);
-    await loadContext(sid, entryId);
-  }, [loadContext]);
-
-  const handleLeafChange = useCallback(async (leafId: string | null) => {
-    setActiveLeafId(leafId);
-    const sid = sessionIdRef.current;
-    if (!sid) return;
-    await loadContext(sid, leafId);
-    if (leafId) {
-      sendAgentCommand(sid, { type: "navigate_tree", targetId: leafId }).catch(() => {});
+    try {
+      const result = await sendAgentCommand<{ cancelled?: boolean }>(sid, {
+        type: "navigate_tree",
+        targetId: leafId,
+      });
+      if (result?.cancelled) {
+        console.warn("navigate_tree cancelled:", leafId);
+        return;
+      }
+      setActiveLeafId(leafId);
+      await loadContext(sid, leafId);
+    } catch (e) {
+      console.error("navigate_tree failed:", e);
     }
   }, [loadContext]);
+
+  const handleNavigate = useCallback((entryId: string) => {
+    return navigateToLeaf(entryId);
+  }, [navigateToLeaf]);
+
+  const handleLeafChange = useCallback((leafId: string | null) => {
+    return navigateToLeaf(leafId);
+  }, [navigateToLeaf]);
 
   const handleModelChange = useCallback(async (provider: string, modelId: string) => {
     if (isNew) {

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -112,7 +112,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const loadTools = useCallback(async (sid: string) => {
     try {
       const tools = await sendAgentCommand<ToolEntry[]>(sid, { type: "get_tools" });
-      if (tools) {
+      if (tools && sessionIdRef.current === sid) {
         const { getPresetFromTools } = await import("@/components/ToolPanel");
         setToolPresetState(getPresetFromTools(tools));
       }
@@ -444,8 +444,10 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     sessionIdRef.current = sid;
     let cancelled = false;
 
-    // Reset session-scoped state. Ordered to mirror useState
-    // declarations above for readability.
+    // Reset session-scoped state. Roughly follows useState
+    // declaration order above for legibility; the exact order
+    // has no functional impact since React batches these and
+    // none depend on each other.
     setData(null);
     setActiveLeafId(null);
     setMessages([]);
@@ -487,6 +489,9 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     });
 
     return () => { cancelled = true; };
+    // useState setters are reference-stable but exhaustive-deps
+    // doesn't recognize them as such; deps is intentionally
+    // [session?.id] only.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [session?.id]);
 

--- a/lib/normalize.ts
+++ b/lib/normalize.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage, AssistantMessage, ToolCallContent } from "./types";
+import type { AgentMessage, AssistantMessage, ToolCallContent } from "./types.ts";
 
 function isObject(val: unknown): val is Record<string, unknown> {
   return typeof val === "object" && val !== null && !Array.isArray(val);

--- a/lib/rpc-manager.test.ts
+++ b/lib/rpc-manager.test.ts
@@ -1,0 +1,90 @@
+import test, { mock } from "node:test";
+import assert from "node:assert/strict";
+import { AgentSessionWrapper } from "./rpc-manager.ts";
+
+type SubscribeFn = (cb: (event: unknown) => void) => () => void;
+
+function makeStubInner(overrides: { subscribe?: SubscribeFn } = {}) {
+  return {
+    sessionId: "stub",
+    sessionFile: "stub.jsonl",
+    isStreaming: false,
+    isCompacting: false,
+    autoCompactionEnabled: false,
+    autoRetryEnabled: false,
+    model: null,
+    getContextUsage: () => null,
+    agent: { state: { systemPrompt: "", thinkingLevel: "off" } },
+    sessionManager: null,
+    modelRegistry: null,
+    subscribe: overrides.subscribe ?? ((cb) => { void cb; return () => {}; }),
+  } as never;
+}
+
+test("wrapper is destroyed after 10 min of inactivity", () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  try {
+    const w = new AgentSessionWrapper(makeStubInner());
+    let destroyed = false;
+    w.onDestroy(() => { destroyed = true; });
+    w.start();
+
+    mock.timers.tick(9 * 60 * 1000);
+    assert.equal(destroyed, false, "should still be alive after 9 min");
+
+    mock.timers.tick(60 * 1000);
+    assert.equal(destroyed, true, "should be destroyed after 10 min");
+  } finally {
+    mock.timers.reset();
+  }
+});
+
+test("keepAlive resets the idle timer", () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  try {
+    const w = new AgentSessionWrapper(makeStubInner());
+    let destroyed = false;
+    w.onDestroy(() => { destroyed = true; });
+    w.start();
+
+    mock.timers.tick(9 * 60 * 1000);
+    assert.equal(destroyed, false);
+
+    w.keepAlive();
+
+    mock.timers.tick(9 * 60 * 1000);
+    assert.equal(destroyed, false, "should still be alive 9 min after keepAlive");
+
+    mock.timers.tick(60 * 1000);
+    assert.equal(destroyed, true, "should be destroyed 10 min after keepAlive");
+  } finally {
+    mock.timers.reset();
+  }
+});
+
+test("events reset the idle timer (regression)", () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  try {
+    let emittedCb: ((event: unknown) => void) | null = null;
+    const inner = makeStubInner({
+      subscribe: (cb) => { emittedCb = cb; return () => {}; },
+    });
+    const w = new AgentSessionWrapper(inner);
+    let destroyed = false;
+    w.onDestroy(() => { destroyed = true; });
+    w.start();
+
+    mock.timers.tick(9 * 60 * 1000);
+    assert.equal(destroyed, false);
+
+    emittedCb!({ type: "agent_start" });
+
+    mock.timers.tick(9 * 60 * 1000);
+    assert.equal(destroyed, false, "should still be alive 9 min after pi event");
+
+    mock.timers.tick(60 * 1000);
+    assert.equal(destroyed, true, "should be destroyed 10 min after last event");
+  } finally {
+    mock.timers.reset();
+  }
+});

--- a/lib/rpc-manager.test.ts
+++ b/lib/rpc-manager.test.ts
@@ -4,7 +4,10 @@ import { AgentSessionWrapper } from "./rpc-manager.ts";
 
 type SubscribeFn = (cb: (event: unknown) => void) => () => void;
 
-function makeStubInner(overrides: { subscribe?: SubscribeFn } = {}) {
+function makeStubInner(overrides: {
+  subscribe?: SubscribeFn;
+  sessionManager?: unknown;
+} = {}) {
   return {
     sessionId: "stub",
     sessionFile: "stub.jsonl",
@@ -15,7 +18,7 @@ function makeStubInner(overrides: { subscribe?: SubscribeFn } = {}) {
     model: null,
     getContextUsage: () => null,
     agent: { state: { systemPrompt: "", thinkingLevel: "off" } },
-    sessionManager: null,
+    sessionManager: overrides.sessionManager ?? null,
     modelRegistry: null,
     subscribe: overrides.subscribe ?? ((cb: (event: unknown) => void) => { void cb; return () => {}; }),
   } as never;
@@ -112,4 +115,14 @@ test("keepAlive is a no-op on a destroyed wrapper", () => {
   } finally {
     mock.timers.reset();
   }
+});
+
+test("fork returns {cancelled: true} for non-persisted session", async () => {
+  const inner = makeStubInner({
+    sessionManager: { isPersisted: () => false },
+  });
+  const w = new AgentSessionWrapper(inner);
+  w.start();
+  const result = await w.send({ type: "fork", entryId: "x" });
+  assert.deepEqual(result, { cancelled: true });
 });

--- a/lib/rpc-manager.test.ts
+++ b/lib/rpc-manager.test.ts
@@ -17,7 +17,7 @@ function makeStubInner(overrides: { subscribe?: SubscribeFn } = {}) {
     agent: { state: { systemPrompt: "", thinkingLevel: "off" } },
     sessionManager: null,
     modelRegistry: null,
-    subscribe: overrides.subscribe ?? ((cb) => { void cb; return () => {}; }),
+    subscribe: overrides.subscribe ?? ((cb: (event: unknown) => void) => { void cb; return () => {}; }),
   } as never;
 }
 

--- a/lib/rpc-manager.test.ts
+++ b/lib/rpc-manager.test.ts
@@ -88,3 +88,28 @@ test("events reset the idle timer (regression)", () => {
     mock.timers.reset();
   }
 });
+
+test("keepAlive is a no-op on a destroyed wrapper", () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  try {
+    const w = new AgentSessionWrapper(makeStubInner());
+    let destroyed = false;
+    w.onDestroy(() => { destroyed = true; });
+    w.start();
+
+    // Force destruction via idle timeout
+    mock.timers.tick(10 * 60 * 1000);
+    assert.equal(destroyed, true);
+
+    // keepAlive after destroy must not schedule a new timer or throw.
+    // If it scheduled a timer, ticking past 10 min would NOT cause
+    // observable harm (the timer's destroy() is idempotent), but the
+    // contract is: no-op on dead wrapper.
+    w.keepAlive();
+    mock.timers.tick(20 * 60 * 1000);
+    // Still only one onDestroy call (the original). No error thrown.
+    assert.equal(destroyed, true);
+  } finally {
+    mock.timers.reset();
+  }
+});

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -1,5 +1,5 @@
 import { createAgentSession, SessionManager } from "@earendil-works/pi-coding-agent";
-import { cacheSessionPath } from "./session-reader";
+import { cacheSessionPath } from "./session-reader.ts";
 import type { AgentSessionLike, ToolInfo } from "./pi-types";
 
 // ============================================================================
@@ -25,7 +25,11 @@ export class AgentSessionWrapper {
   private onDestroyCallback: (() => void) | null = null;
   private _alive = true;
 
-  constructor(public readonly inner: AgentSessionLike) {}
+  readonly inner: AgentSessionLike;
+
+  constructor(inner: AgentSessionLike) {
+    this.inner = inner;
+  }
 
   get sessionId(): string {
     return this.inner.sessionId;
@@ -62,6 +66,14 @@ export class AgentSessionWrapper {
 
   onDestroy(cb: () => void): void {
     this.onDestroyCallback = cb;
+  }
+
+  /**
+   * Signal that this wrapper is still in use (e.g., SSE heartbeat).
+   * Resets the idle timer without emitting any events.
+   */
+  keepAlive(): void {
+    this.resetIdleTimer();
   }
 
   async send(command: Record<string, unknown>): Promise<unknown> {

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -71,8 +71,10 @@ export class AgentSessionWrapper {
   /**
    * Signal that this wrapper is still in use (e.g., SSE heartbeat).
    * Resets the idle timer without emitting any events.
+   * No-op if the wrapper is already destroyed.
    */
   keepAlive(): void {
+    if (!this._alive) return;
     this.resetIdleTimer();
   }
 

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -153,6 +153,14 @@ export class AgentSessionWrapper {
 
         const newSessionId = SessionManager.open(newSessionFile, sessionDir).getSessionId();
         cacheSessionPath(newSessionId, newSessionFile);
+
+        // Pre-register the new wrapper BEFORE destroying the old.
+        // Contract: by the time send() returns, newSessionId is in the registry.
+        // If startRpcSession throws, do NOT destroy — old wrapper stays usable,
+        // new file remains on disk (acceptable; next fork overwrites).
+        const newCwd = sessionManager.getHeader()?.cwd ?? process.cwd();
+        await startRpcSession(newSessionId, newSessionFile, newCwd);
+
         this.destroy();
         return { cancelled: false, newSessionId };
       }

--- a/lib/session-cascade.test.ts
+++ b/lib/session-cascade.test.ts
@@ -1,0 +1,137 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { rewriteChildHeader } from "./session-cascade.ts";
+
+const sampleChild = (parent: string | undefined) => ({
+  type: "session",
+  version: 3,
+  id: "child-uuid",
+  timestamp: "2026-06-01T00:00:00Z",
+  cwd: "/tmp/test",
+  ...(parent !== undefined ? { parentSession: parent } : {}),
+});
+
+const format = (header: object) =>
+  JSON.stringify(header) + "\n" +
+  JSON.stringify({ type: "message", id: "m1", parentId: null, message: { role: "user", content: "hi" } }) + "\n";
+
+test("rewrites child when parentSession matches oldParent", () => {
+  const oldParent = "/sessions/parent.jsonl";
+  const newParent = "/sessions/grandparent.jsonl";
+  const content = format(sampleChild(oldParent));
+  const { newContent, changed } = rewriteChildHeader(content, oldParent, newParent);
+  assert.equal(changed, true);
+  const newHeader = JSON.parse(newContent.split("\n")[0]);
+  assert.equal(newHeader.parentSession, newParent);
+  assert.equal(newHeader.id, "child-uuid");
+});
+
+test("leaves child unchanged when parentSession is different", () => {
+  const content = format(sampleChild("/sessions/other.jsonl"));
+  const { newContent, changed } = rewriteChildHeader(
+    content,
+    "/sessions/parent.jsonl",
+    "/sessions/grandparent.jsonl",
+  );
+  assert.equal(changed, false);
+  assert.equal(newContent, content);
+});
+
+test("leaves child unchanged when header is malformed JSON", () => {
+  const content = "not json at all\n" + JSON.stringify({ type: "message" });
+  const { newContent, changed } = rewriteChildHeader(
+    content,
+    "/sessions/parent.jsonl",
+    "/sessions/grandparent.jsonl",
+  );
+  assert.equal(changed, false);
+  assert.equal(newContent, content);
+});
+
+test("leaves child unchanged when type is not 'session'", () => {
+  const content = JSON.stringify({ type: "message", id: "m1" }) + "\n";
+  const { newContent, changed } = rewriteChildHeader(
+    content,
+    "/sessions/parent.jsonl",
+    "/sessions/grandparent.jsonl",
+  );
+  assert.equal(changed, false);
+  assert.equal(newContent, content);
+});
+
+test("removes parentSession when newParent is null", () => {
+  const oldParent = "/sessions/parent.jsonl";
+  const content = format(sampleChild(oldParent));
+  const { newContent, changed } = rewriteChildHeader(content, oldParent, null);
+  assert.equal(changed, true);
+  const newHeader = JSON.parse(newContent.split("\n")[0]);
+  assert.equal("parentSession" in newHeader, false);
+  assert.equal(newHeader.id, "child-uuid");
+});
+
+test("preserves all other header fields", () => {
+  const header = {
+    type: "session",
+    version: 3,
+    id: "child-uuid",
+    timestamp: "2026-06-01T00:00:00Z",
+    cwd: "/tmp/test",
+    customField: "preserved",
+    nested: { a: 1, b: 2 },
+    parentSession: "/sessions/parent.jsonl",
+  };
+  const content = JSON.stringify(header) + "\n";
+  const { newContent, changed } = rewriteChildHeader(
+    content,
+    "/sessions/parent.jsonl",
+    "/sessions/grandparent.jsonl",
+  );
+  assert.equal(changed, true);
+  const newHeader = JSON.parse(newContent.split("\n")[0]);
+  assert.equal(newHeader.customField, "preserved");
+  assert.deepEqual(newHeader.nested, { a: 1, b: 2 });
+});
+
+test("preserves rest of file content beyond first line", () => {
+  const line1 = JSON.stringify(sampleChild("/sessions/parent.jsonl"));
+  const line2 = JSON.stringify({ type: "message", id: "m1", parentId: null, message: { role: "user", content: "hi" } });
+  const line3 = JSON.stringify({ type: "message", id: "m2", parentId: "m1", message: { role: "assistant", content: [] } });
+  const content = line1 + "\n" + line2 + "\n" + line3 + "\n";
+  const { newContent, changed } = rewriteChildHeader(
+    content,
+    "/sessions/parent.jsonl",
+    "/sessions/grandparent.jsonl",
+  );
+  assert.equal(changed, true);
+  const lines = newContent.split("\n");
+  assert.equal(JSON.parse(lines[0]).parentSession, "/sessions/grandparent.jsonl");
+  assert.equal(lines[1], line2);
+  assert.equal(lines[2], line3);
+  assert.equal(lines[3], "");
+});
+
+test("handles empty content", () => {
+  const { newContent, changed } = rewriteChildHeader(
+    "",
+    "/sessions/parent.jsonl",
+    "/sessions/grandparent.jsonl",
+  );
+  assert.equal(changed, false);
+  assert.equal(newContent, "");
+});
+
+test("handles content without trailing newline", () => {
+  const line1 = JSON.stringify(sampleChild("/sessions/parent.jsonl"));
+  const line2 = JSON.stringify({ type: "message", id: "m1" });
+  const content = line1 + "\n" + line2;
+  const { newContent, changed } = rewriteChildHeader(
+    content,
+    "/sessions/parent.jsonl",
+    "/sessions/grandparent.jsonl",
+  );
+  assert.equal(changed, true);
+  const lines = newContent.split("\n");
+  assert.equal(lines.length, 2);
+  assert.equal(JSON.parse(lines[0]).parentSession, "/sessions/grandparent.jsonl");
+  assert.equal(lines[1], line2);
+});

--- a/lib/session-cascade.test.ts
+++ b/lib/session-cascade.test.ts
@@ -59,6 +59,28 @@ test("leaves child unchanged when type is not 'session'", () => {
   assert.equal(newContent, content);
 });
 
+test("leaves child unchanged when header is valid JSON null", () => {
+  const content = "null\n" + JSON.stringify({ type: "message", id: "m1" });
+  const { newContent, changed } = rewriteChildHeader(
+    content,
+    "/sessions/parent.jsonl",
+    "/sessions/grandparent.jsonl",
+  );
+  assert.equal(changed, false);
+  assert.equal(newContent, content);
+});
+
+test("leaves child unchanged when header is a JSON array", () => {
+  const content = "[1, 2, 3]\n";
+  const { newContent, changed } = rewriteChildHeader(
+    content,
+    "/sessions/parent.jsonl",
+    "/sessions/grandparent.jsonl",
+  );
+  assert.equal(changed, false);
+  assert.equal(newContent, content);
+});
+
 test("removes parentSession when newParent is null", () => {
   const oldParent = "/sessions/parent.jsonl";
   const content = format(sampleChild(oldParent));

--- a/lib/session-cascade.ts
+++ b/lib/session-cascade.ts
@@ -1,0 +1,46 @@
+export interface RewriteResult {
+  newContent: string;
+  changed: boolean;
+}
+
+/**
+ * Pure function: decide whether to rewrite a child session file's first-line
+ * header to change its `parentSession` from `oldParent` to `newParent`.
+ *
+ * - If the first line is malformed JSON, type is not "session", or
+ *   parentSession doesn't match oldParent, returns { newContent: content,
+ *   changed: false }.
+ * - If newParent is null, removes the parentSession key from the header
+ *   (not sets it to null).
+ * - Preserves all other header fields and all content beyond the first line.
+ */
+export function rewriteChildHeader(
+  content: string,
+  oldParent: string,
+  newParent: string | null,
+): RewriteResult {
+  if (content.length === 0) return { newContent: content, changed: false };
+
+  const newlineIdx = content.indexOf("\n");
+  const firstLineRaw = newlineIdx === -1 ? content : content.slice(0, newlineIdx);
+  const rest = newlineIdx === -1 ? "" : content.slice(newlineIdx);
+
+  let header: Record<string, unknown>;
+  try {
+    header = JSON.parse(firstLineRaw) as Record<string, unknown>;
+  } catch {
+    return { newContent: content, changed: false };
+  }
+
+  if (header.type !== "session" || header.parentSession !== oldParent) {
+    return { newContent: content, changed: false };
+  }
+
+  if (newParent === null) {
+    delete header.parentSession;
+  } else {
+    header.parentSession = newParent;
+  }
+
+  return { newContent: JSON.stringify(header) + rest, changed: true };
+}

--- a/lib/session-cascade.ts
+++ b/lib/session-cascade.ts
@@ -25,22 +25,29 @@ export function rewriteChildHeader(
   const firstLineRaw = newlineIdx === -1 ? content : content.slice(0, newlineIdx);
   const rest = newlineIdx === -1 ? "" : content.slice(newlineIdx);
 
-  let header: Record<string, unknown>;
+  let header: unknown;
   try {
-    header = JSON.parse(firstLineRaw) as Record<string, unknown>;
+    header = JSON.parse(firstLineRaw);
   } catch {
     return { newContent: content, changed: false };
   }
 
-  if (header.type !== "session" || header.parentSession !== oldParent) {
+  // JSON.parse can succeed on primitives (null, "foo", 123) and arrays;
+  // guard before any property access to avoid TypeError.
+  if (header === null || typeof header !== "object" || Array.isArray(header)) {
+    return { newContent: content, changed: false };
+  }
+  const objHeader = header as Record<string, unknown>;
+
+  if (objHeader.type !== "session" || objHeader.parentSession !== oldParent) {
     return { newContent: content, changed: false };
   }
 
   if (newParent === null) {
-    delete header.parentSession;
+    delete objHeader.parentSession;
   } else {
-    header.parentSession = newParent;
+    objHeader.parentSession = newParent;
   }
 
-  return { newContent: JSON.stringify(header) + rest, changed: true };
+  return { newContent: JSON.stringify(objHeader) + rest, changed: true };
 }

--- a/lib/session-lock.test.ts
+++ b/lib/session-lock.test.ts
@@ -4,7 +4,6 @@ import path from "node:path";
 import { withFileLock } from "./session-lock.ts";
 
 declare global {
-  // eslint-disable-next-line no-var
   var __piWriteLocks: Map<string, Promise<unknown>> | undefined;
 }
 

--- a/lib/session-lock.test.ts
+++ b/lib/session-lock.test.ts
@@ -1,0 +1,69 @@
+import test, { beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { withFileLock } from "./session-lock.ts";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __piWriteLocks: Map<string, Promise<unknown>> | undefined;
+}
+
+beforeEach(() => {
+  globalThis.__piWriteLocks = undefined;
+});
+
+test("serializes 100 concurrent calls on same path", async () => {
+  const target = path.resolve("/tmp/lock-test-A");
+  const order: number[] = [];
+  const tasks = Array.from({ length: 100 }, (_, i) =>
+    withFileLock(target, async () => {
+      const prev = order[order.length - 1] ?? -1;
+      assert.equal(i, prev + 1, `task ${i} ran out of order (prev was ${prev})`);
+      order.push(i);
+      await new Promise((r) => setImmediate(r));
+    }),
+  );
+  await Promise.all(tasks);
+  assert.equal(order.length, 100);
+  assert.equal(order[0], 0);
+  assert.equal(order[99], 99);
+});
+
+test("does not block calls on different paths", async () => {
+  const a = path.resolve("/tmp/lock-test-B");
+  const b = path.resolve("/tmp/lock-test-C");
+  const start = Date.now();
+  await Promise.all([
+    withFileLock(a, async () => {
+      await new Promise((r) => setTimeout(r, 100));
+    }),
+    withFileLock(b, async () => {
+      await new Promise((r) => setTimeout(r, 100));
+    }),
+  ]);
+  const elapsed = Date.now() - start;
+  assert.ok(elapsed < 180, `expected < 180ms, got ${elapsed}ms`);
+});
+
+test("releases lock when fn throws", async () => {
+  const target = path.resolve("/tmp/lock-test-D");
+  await assert.rejects(
+    withFileLock(target, async () => {
+      throw new Error("intentional");
+    }),
+    /intentional/,
+  );
+  const start = Date.now();
+  await withFileLock(target, async () => {});
+  const elapsed = Date.now() - start;
+  assert.ok(elapsed < 50, `lock not released: ${elapsed}ms wait`);
+});
+
+test("cleans up map entry after release", async () => {
+  const target = path.resolve("/tmp/lock-test-E");
+  await withFileLock(target, async () => {});
+  const map = globalThis.__piWriteLocks;
+  if (map !== undefined) {
+    assert.equal(map.has(target), false, "map should not contain entry after release");
+  }
+});

--- a/lib/session-lock.test.ts
+++ b/lib/session-lock.test.ts
@@ -61,8 +61,9 @@ test("releases lock when fn throws", async () => {
 test("cleans up map entry after release", async () => {
   const target = path.resolve("/tmp/lock-test-E");
   await withFileLock(target, async () => {});
-  const map = globalThis.__piWriteLocks;
-  if (map !== undefined) {
-    assert.equal(map.has(target), false, "map should not contain entry after release");
-  }
+  assert.equal(
+    globalThis.__piWriteLocks?.has(target),
+    false,
+    "map should not contain entry after release",
+  );
 });

--- a/lib/session-lock.ts
+++ b/lib/session-lock.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 
 declare global {
-  // eslint-disable-next-line no-var
   var __piWriteLocks: Map<string, Promise<unknown>> | undefined;
 }
 

--- a/lib/session-lock.ts
+++ b/lib/session-lock.ts
@@ -1,0 +1,42 @@
+import path from "node:path";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __piWriteLocks: Map<string, Promise<unknown>> | undefined;
+}
+
+/**
+ * Acquire a process-level write lock on a file path, run `fn`, then release.
+ *
+ * - Per-file granularity: different paths do not block each other.
+ * - Reentrancy NOT supported: calling withFileLock(samePath) inside a fn
+ *   holding the lock will deadlock.
+ * - Map entry is cleaned up after release if no later caller has chained on.
+ * - globalThis is used to survive Next.js hot reloads (matches the
+ *   __piSessions / __piStartLocks pattern in lib/rpc-manager.ts).
+ */
+export async function withFileLock<T>(
+  filePath: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const key = path.resolve(filePath);
+  const locks = (globalThis.__piWriteLocks ??= new Map<string, Promise<unknown>>());
+
+  const prev = locks.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const ourEntry = prev.then(() => gate);
+  locks.set(key, ourEntry);
+
+  try {
+    await prev;
+    return await fn();
+  } finally {
+    release();
+    if (locks.get(key) === ourEntry) {
+      locks.delete(key);
+    }
+  }
+}

--- a/lib/session-reader.ts
+++ b/lib/session-reader.ts
@@ -1,7 +1,7 @@
 import { SessionManager, buildSessionContext as piBuildSessionContext, getAgentDir } from "@earendil-works/pi-coding-agent";
-import type { SessionEntry, SessionInfo, SessionContext, SessionTreeNode, AssistantMessage } from "./types";
+import type { SessionEntry, SessionInfo, SessionContext, SessionTreeNode, AssistantMessage } from "./types.ts";
 import type { SessionEntry as PiSessionEntry, SessionInfo as PiSessionInfo } from "@earendil-works/pi-coding-agent";
-import { normalizeToolCalls } from "./normalize";
+import { normalizeToolCalls } from "./normalize.ts";
 
 export { getAgentDir };
 


### PR DESCRIPTION
## Summary

Five P0 fixes from `docs/architecture-review-2026-06-01.md` §1:

- **P0-1** — DELETE cascade reparent under per-file lock + tmp+rename atomic write. Fixes silent header corruption on concurrent DELETE.
- **P0-2** — `keepAlive()` on successful SSE heartbeat. Prevents long-running agents (Opus thinking) from being killed by the 10-min idle timer.
- **P0-3** — Pre-register new wrapper before destroying old in fork; await + cancelled-check on `navigate_tree`. Makes session-change contracts explicit instead of relying on AppShell's implicit `sessionKey` remount.
- **P0-5** — Extract `MessageList` with `React.memo`; pre-compute `nextUserIdx`/`nextAssistantIdx` via `useMemo`. Eliminates O(n²) forward scan on stream pushes and per-message re-renders on unrelated state changes.
- **P0-6** — Mount effect re-runs on `session?.id` change with full session-scoped state reset + `cancelled` closure guard.

P0-4 (dev mode env passthrough) was intentionally skipped per the §5 schedule.

## Verification

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` 0 errors (1 pre-existing `MessageView.tsx:620` warning, unrelated)
- [x] `node --test lib/*.test.ts electron/*.test.ts 'app/**/*.test.ts'` — 37/37 pass
- [x] `node --test hooks/agent-session/*.test.ts` — 10/10 pass
- [x] Code review passed for every P0 (subagent reviews on each)

## Manual test plan

- [ ] **P0-1**: delete a parent session → child sessions re-attach to grandparent; run two concurrent DELETEs in two tabs, observe no header corruption
- [ ] **P0-2**: trigger a long thinking task → wrapper stays alive past 10 min; close tab → wrapper destroyed after 10 min
- [ ] **P0-3**: fork a session → new session is immediately usable (no 404 / "Session not found"); click a different branch in BranchNavigator → UI updates cleanly
- [ ] **P0-5**: open 100+ message session; type in chat input; React Profiler shows no `MessageView` re-renders; streaming update doesn't trigger forward scan
- [ ] **P0-6**: rapidly switch sessions (A→B→A within ~300ms); observe no stale state bleed (messages / agentRunning / SSE all reset cleanly); final state matches the last-selected session

## Notes

- The merge commit (`8353b08`) integrates main's `c1d68cd` useAgentSession refactor (split into `hooks/agent-session/*` submodules). P0-3 and P0-6 conflict resolution kept our `navigateToLeaf` and `mount effect` work in the new file structure.
- The project's test command `lib/*.test.ts electron/*.test.ts 'app/**/*.test.ts'` does not include `hooks/**/*.test.ts`, so the 10 main-added tests are run only when explicitly invoked. Tracked as a follow-up.
- All P0 implementation specs + plans are committed on the branch under `docs/superpowers/specs/` and `docs/superpowers/plans/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed idle timer reset during long-running operations to prevent premature session termination
  * Improved session deletion to safely handle concurrent operations
  * Fixed fork/navigate timing to prevent UI state inconsistencies
  * Reduced unnecessary message re-renders for improved performance

* **Tests**
  * Added test coverage for session management and timeout behavior

* **Documentation**
  * Added comprehensive architecture review and implementation guidance for priority improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->