### PR TITLE
ci: add GitHub Actions PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,112 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-typecheck-test:
+    name: lint · typecheck · test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Test
+        run: |
+          node --test \
+            app/api/health/route.test.ts \
+            lib/api-error.test.ts \
+            lib/custom-path-selection.test.ts \
+            lib/normalize.test.ts \
+            lib/rpc-manager.test.ts \
+            lib/session-cascade.test.ts \
+            lib/session-lock.test.ts \
+            lib/slash-commands.test.ts \
+            hooks/agent-session/agent-phase.test.ts \
+            hooks/agent-session/session-stats.test.ts \
+            hooks/agent-session/stream-state.test.ts
+
+  build:
+    name: build (next.js)
+    runs-on: ubuntu-latest
+    needs: lint-typecheck-test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Next.js standalone
+        run: npm run build
+
+      - name: Upload standalone output
+        uses: actions/upload-artifact@v4
+        with:
+          name: next-standalone
+          path: |
+            .next/standalone
+            .next/static
+            public
+          if-no-files-found: error
+          retention-days: 7
+
+  test-windows:
+    name: test (windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test (Windows)
+        shell: bash
+        run: |
+          node --test \
+            app/api/health/route.test.ts \
+            lib/api-error.test.ts \
+            lib/custom-path-selection.test.ts \
+            lib/normalize.test.ts \
+            lib/rpc-manager.test.ts \
+            lib/session-cascade.test.ts \
+            lib/session-lock.test.ts \
+            lib/slash-commands.test.ts \
+            hooks/agent-session/agent-phase.test.ts \
+            hooks/agent-session/session-stats.test.ts \
+            hooks/agent-session/stream-state.test.ts \
+            electron/process-tree.test.ts \
+            electron/server-wait.test.ts \
+            electron/startup-failure.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,9 @@ jobs:
         run: npx tsc --noEmit
 
       - name: Test
+        timeout-minutes: 5
         run: |
-          node --test \
+          node --test --test-force-exit \
             app/api/health/route.test.ts \
             lib/api-error.test.ts \
             lib/custom-path-selection.test.ts \
@@ -93,9 +94,10 @@ jobs:
         run: npm ci
 
       - name: Test (Windows)
+        timeout-minutes: 10
         shell: bash
         run: |
-          node --test \
+          node --test --test-force-exit \
             app/api/health/route.test.ts \
             lib/api-error.test.ts \
             lib/custom-path-selection.test.ts \


### PR DESCRIPTION
## Summary
添加 `.github/workflows/ci.yml`，给 PR 自动跑 lint / typecheck / test / build。

## Jobs
- **`lint-typecheck-test`** (ubuntu-latest): `npm ci` → `npm run lint` → `npx tsc --noEmit` → `node --test` on `lib/` `hooks/agent-session/` `app/api/health/`。主要反馈回路。
- **`build`** (ubuntu-latest, depends on lint-typecheck-test): `npm run build`，把 `.next/standalone` + `.next/static` + `public/` 上传为 artifact (retention 7d)，方便后续 `npm run dist` 调试。
- **`test-windows`** (windows-latest): 重跑 unit tests + `electron/` 测试，捕获 Windows 进程树相关的回归。

## Triggers
- `pull_request` to `main`
- `push` to `main`

## 决策点
- **Node 24**：本地开发用的版本，与 Next.js 16 的最低要求一致。
- **不跑 `npm run dist` / `npm run pack`**：依赖平台打包（NSIS / dmg / deb），在 PR 检查里跑会浪费 runner 时间，而且真正的 release 构建在 tag push 时单独跑更合适。
- **不缓存 `~/.npm`** 的额外策略**：用 `actions/setup-node@v4` 自带的 `cache: "npm"` 已经够用。
- **`concurrency.cancel-in-progress: true`**：快速 follow-up push 不需要等前一个 run 跑完。

## 已知未覆盖
- 1 个 pre-existing 警告 (`MessageView.tsx:620` `isRunning` unused)，未触及。
- `electron/process-tree.test.ts` 在 Linux 上一直 fail（依赖 Unix `posix_spawn` 语义），所以仅在 windows job 里跑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated CI/CD workflow to run linting, type checking, and tests on pull requests and pushes to main; includes build artifact generation across Linux and Windows environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->