### PR TITLE
Fix cwd URL state and Electron env filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## 下载安装
 
-前往 [Releases](https://github.com/agegr/pi-agent-desktop/releases) 页面下载最新版安装程序。
+前往 [Releases](https://github.com/Chasen-Liao/pi-agent-desktop/releases) 页面下载最新版安装程序。
 
 Windows 用户下载 `Pi-Agent-Desktop-Setup-x.x.x.exe`，运行即可安装。
 

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -158,15 +158,10 @@ export function AppShell() {
   const [activeCwd, setActiveCwd] = useState<string | null>(null);
   // True once the initial ?session= URL param has been resolved (or confirmed absent)
   const [initialSessionRestored, setInitialSessionRestored] = useState<boolean>(() => !searchParams.get("session"));
-  // Suppresses sessionKey bump in handleCwdChange during the initial URL restore
-  const suppressCwdBumpRef = useRef(false);
 
   const handleCwdChange = useCallback((cwd: string | null) => {
     setActiveCwd(cwd);
-    // Skip if cwd is null (initial mount) or during the initial URL restore.
-    if (!cwd || suppressCwdBumpRef.current) return;
-    // Close any session that belongs to a different cwd — it no longer
-    // matches the selected project directory.
+    if (!cwd) return;
     setSelectedSession((prev) => {
       if (prev && prev.cwd !== cwd) return null;
       return prev;
@@ -185,16 +180,11 @@ export function AppShell() {
 
   const handleSelectSession = useCallback((session: SessionInfo, isRestore = false) => {
     setNewSessionCwd(null);
+    setActiveCwd(session.cwd);
     setSelectedSession(session);
     setSessionKey((k) => k + 1);
     setSystemPrompt(null);
     setInitialSessionRestored(true);
-    if (isRestore) {
-      // Suppress the redundant sessionKey bump that would come from the
-      // onCwdChange effect firing after setSelectedCwd in the sidebar
-      suppressCwdBumpRef.current = true;
-      setTimeout(() => { suppressCwdBumpRef.current = false; }, 0);
-    }
     // Skip router.replace when restoring from URL — the param is already correct
     // and calling replace in production Next.js triggers a Suspense remount loop
     if (!isRestore) {
@@ -353,7 +343,7 @@ export function AppShell() {
         onInitialRestoreDone={handleInitialRestoreDone}
         refreshKey={refreshKey}
         onSessionDeleted={handleSessionDeleted}
-        selectedCwd={selectedSession?.cwd ?? newSessionCwd ?? null}
+        selectedCwd={activeCwd ?? selectedSession?.cwd ?? newSessionCwd ?? null}
         onCwdChange={handleCwdChange}
         onOpenFile={handleOpenFile}
         explorerRefreshKey={explorerRefreshKey}

--- a/components/SessionSidebar.tsx
+++ b/components/SessionSidebar.tsx
@@ -218,7 +218,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
   const [allSessions, setAllSessions] = useState<SessionInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [selectedCwd, setSelectedCwd] = useState<string | null>(null);
+  const selectedCwd = selectedCwdProp ?? null;
   const [homeDir, setHomeDir] = useState<string>("");
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [customPathOpen, setCustomPathOpen] = useState(false);
@@ -270,10 +270,6 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
 
   const restoredRef = useRef(false);
 
-  useEffect(() => {
-    onCwdChange?.(selectedCwd);
-  }, [selectedCwd, onCwdChange]);
-
   // Auto-select cwd and restore session from URL on first load
   useEffect(() => {
     if (allSessions.length === 0) return;
@@ -284,7 +280,6 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
         restoredRef.current = true;
         const target = allSessions.find((s) => s.id === initialSessionId);
         if (target) {
-          setSelectedCwd(target.cwd);
           onSelectSession(target, true);
           return;
         }
@@ -292,9 +287,9 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
         onInitialRestoreDone?.();
       }
       const cwds = getRecentCwds(allSessions);
-      if (cwds.length > 0) setSelectedCwd(cwds[0]);
+      if (cwds.length > 0) onCwdChange?.(cwds[0]);
     }
-  }, [allSessions, selectedCwd, initialSessionId, onSelectSession, onInitialRestoreDone]);
+  }, [allSessions, selectedCwd, initialSessionId, onCwdChange, onSelectSession, onInitialRestoreDone]);
 
   const handleCustomPath = useCallback(async () => {
     setCustomPathOpen(true);
@@ -303,7 +298,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
       const selectedPath = await pickDirectoryFromHost();
       const { nextCwd, shouldClose } = resolveCustomPathSelection(selectedCwd, selectedPath);
       if (nextCwd !== selectedCwd) {
-        setSelectedCwd(nextCwd);
+        onCwdChange?.(nextCwd);
       }
       if (shouldClose) {
         setCustomPathOpen(false);
@@ -314,7 +309,7 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
       setCustomPathOpen(false);
       setDropdownOpen(false);
     }
-  }, [selectedCwd]);
+  }, [selectedCwd, onCwdChange]);
 
   const handleDefaultCwd = useCallback(async () => {
     try {
@@ -322,13 +317,15 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
       const data = await res.json() as { cwd?: string; error?: string };
       if (data.cwd) {
         setCwdPickerError(null);
-        setSelectedCwd(data.cwd);
+        if (data.cwd !== selectedCwd) {
+          onCwdChange?.(data.cwd);
+        }
         setDropdownOpen(false);
       }
     } catch {
       // ignore
     }
-  }, []);
+  }, [selectedCwd, onCwdChange]);
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -509,7 +506,9 @@ export function SessionSidebar({ selectedSessionId, onSelectSession, onNewSessio
                 <button
                   key={cwd}
                   onClick={() => {
-                    setSelectedCwd(cwd);
+                    if (cwd !== selectedCwd) {
+                      onCwdChange?.(cwd);
+                    }
                     setCwdPickerError(null);
                     setCustomPathOpen(false);
                     setDropdownOpen(false);

--- a/docs/architecture-review-2026-06-01.md
+++ b/docs/architecture-review-2026-06-01.md
@@ -1,7 +1,7 @@
 # Pi Agent Desktop 架构优化评审
 
 > 分支：`analysis/architecture-optimization-review` · 初评日期：2026-06-01 · P0 基准提交：`1a33476`（P0 实施后合入 main：`36af38c`，v0.7.6）
-> 最新更新：2026-06-02 · 评审负责人：chasen
+> 最新更新：2026-06-03 · 评审负责人：chasen
 >
 > 本文档是对当前架构的深度扫描结果，按"必改 / 应该改 / 锦上添花"分级。每条发现都给出位置、问题、修复方向、严重性。所有行号以 P0 基准提交为准，文件后续修改后会漂移。
 >
@@ -520,4 +520,4 @@ const allCodingToolNames = ["read", "bash", "edit", "write", "grep", "find", "ls
   - 遗留 follow-up #6：客户端未消费 `x-request-id` 响应头。
 - **2026-06-02** 更新本评审文档，记录 P1-1 实施结果（修改见本文件 §0 / §2 P1-1 / §4 / §5 / §5.1 / §8）。
 
-**当前分支**：`main` · **HEAD**：`7e97e2a`。**下一阶段**候选：P1-4（URL 状态去 `suppressCwdBumpRef`）/ P1-6（Next.js 启动失败自动恢复）/ P1-7（electron-builder extraResources 自动化）。
+**当前分支**：`main` · **HEAD**：`ca1ef17`。**下一阶段**候选：P1-4（URL 状态去 `suppressCwdBumpRef`）/ P1-6（Next.js 启动失败自动恢复）/ P1-7（electron-builder extraResources 自动化）。

--- a/docs/p1-followup-review-2026-06-03.md
+++ b/docs/p1-followup-review-2026-06-03.md
@@ -1,0 +1,500 @@
+# P1 剩余项复核 — 2026-06-03
+
+> 基线：`main` @ `ca1ef17`（v0.7.7）· 复核日期：2026-06-03 · 复核人：chasen
+>
+> 上一次完整评审：`docs/architecture-review-2026-06-01.md`（HEAD `7e97e2a`，v0.7.6）。
+> 本文是它的 **P1 专项复核**——逐项用 Read/Grep 在当前 `main` 上重新核对位置、问题是否仍成立、修复方向是否需要更新，并指出 P0 重构（P0-5 / P0-6 / P0-3）造成的行号漂移。
+>
+> **范围**：P1-2 至 P1-10（P1-1 已合入 PR #2，§2 见原评审）。
+>
+> **方法**：每个 P1 项用 2-3 个 Read/Grep 复核当前代码；不重跑测试或启动 dev server。
+>
+> **图例**：🟢 仍成立 · 🟡 仍成立但需调整（行号 / 上下文漂移）· 🔴 已不需要 / 被新代码吸收 · ✅ 已完成（不在本范围）
+
+---
+
+## 0. 摘要
+
+| 项 | 标题 | 06-01 状态 | 06-03 复核 | 主要变化 |
+|---|---|---|---|---|
+| P1-2 | SSE `JSON.parse` 静默吞 | 🟡 | 🟡 | 文件从 `hooks/useAgentSession.ts:226-228` 移到 `hooks/agent-session/use-agent-events.ts:35-42`（P0-6 重构）；catch 块仍是 `/* ignore */` |
+| P1-3 | FileViewer 大文件无虚拟滚动 | 🟡 | 🟢 | 位置未漂（`components/FileViewer.tsx:815-838`）；项目仍未引入 `@tanstack/react-virtual` |
+| P1-4 | URL ↔ React 状态用 `suppressCwdBumpRef` 互抑制 | 🟡 | 🟢 | 位置漂到 `components/AppShell.tsx:162, 167, 195-196`；问题性质未变 |
+| P1-5 | 端口扫描 TOCTOU 竞争 | 🟡 | 🟢 | 位置漂到 `electron/main.ts:107-152`（`findFreePort` 整段）；竞争窗口 140→145 |
+| P1-6 | Next.js 进程崩溃无自动恢复 | 🟡 | 🟢 | 位置漂到 `electron/main.ts:196-213`（`handleNextProcessExit`）；行为未变 |
+| P1-7 | `electron-builder.yml` `extraResources` 手写 | 🟡 | 🟢 | 列表 19 项（`electron-builder.yml:17-49`）原样保留；只多了对 `node_modules` 整体的第二项 `extraResources`（55-58），但前 19 项依然手写 |
+| P1-8 | `startup.html` CSP `script-src 'unsafe-inline'` | 🟡 | 🟢 | 位置漂到 `electron/startup.html:5`（head meta）；内联脚本仍在 131-155 |
+| P1-9 | `SKILLS_API_URL` 改 env 后变 SSRF | 🟡 | 🟢 | 位置漂到 `app/api/skills/search/route.ts:11`（`SEARCH_API_BASE`）+ `:65`（fetch）；无 allowlist |
+| P1-10 | 派生值未 memo | 🟡 | 🟢 | 位置漂到 `hooks/useAgentSession.ts:101`（`currentModel`）、`:104`（`sessionStats` → `calculateSessionStats(messages)`）；仍无 `useMemo` 包裹 |
+
+**结论**：9 个 P1 项**全部仍成立**，且都因为 P0 重构而需要重新核对行号。无新增风险，无 P1 范围"自然解决"的项。
+
+**推荐的实施批次**（按收益 / 工作量 / 互相阻塞）：
+
+1. **P1-4 + P0-4 合批**：URL 状态去 `suppressCwdBumpRef` + 5 处 env 透传白名单化（已确认 2 处主进程，详见 §10）。
+2. **P1-7 + follow-up #1（electron-updater 缺模块）**：一起改 `electron-builder.yml` 资源复制策略。
+3. **P1-6**：Next.js 进程 supervisor，独立小改动。
+4. **P1-10**：低风险高收益，单独一个 PR。
+5. **P1-2 / P1-8 / P1-9**：安全 / 可观测性补丁，可与 P2-1（pino）一起做。
+6. **P1-3 / P1-5**：前端性能 / 启动 race，独立处理。
+
+---
+
+## 1. P1-2. SSE `JSON.parse` 失败被静默吞掉
+
+**位置**：`hooks/agent-session/use-agent-events.ts:35-42`
+
+> 06-01 评审时位于 `hooks/useAgentSession.ts:226-228`。P0-6 重构（`c1d68cd`）把 SSE handler 拆出到独立 hook 文件，代码形态未变。
+
+**当前代码**：
+```ts
+// hooks/agent-session/use-agent-events.ts:35-42
+es.onmessage = (e) => {
+  try {
+    const event = JSON.parse(e.data) as AgentEvent;
+    handleAgentEventRef.current?.(event);
+  } catch {
+    // ignore
+  }
+};
+```
+
+**问题**：pi 后端任何一次返回非 JSON（HTML 错误页、proxy 拦截、序列化中途断开）都会被静默丢弃，UI 表现为"agent 卡住但无错误"。Dev 环境用户只能看到 console 里 `// ignore` 后面没有 stack。
+
+**修复方向**（与 06-01 评审一致，未变）：
+- dev 模式至少 `console.warn("[SSE] malformed event", e.data, err)`，附 stack。
+- prod 环境走 P2-1 的 `pino` 通道（结构化 `level: "warn", kind: "sse.malformed", raw: e.data.slice(0, 200), requestId }`）。
+- 可选：把 `requestId` 从事件里提取（如果 pi 端有），用于跨进程 trace。
+
+**额外建议**：拆 SSE handler 时也拆错误处理——把 `onerror` 里的 `reconnectTimer` 逻辑也走 `logError`/`logWarn`，目前 `:43-52` 也是 `//` 注释，dev 不可见。
+
+---
+
+## 2. P1-3. `FileViewer` 大文件无虚拟滚动
+
+**位置**：`components/FileViewer.tsx:815-838`（`SyntaxHighlighter` 渲染块），文件总长 843 行。
+
+**当前代码**（节选）：
+```tsx
+// components/FileViewer.tsx:815-838
+<SyntaxHighlighter
+  language={data.language === "text" ? "plaintext" : data.language}
+  style={isDark ? ayuDarkSyntaxTheme : ayuLightSyntaxTheme}
+  showLineNumbers
+  ...
+>
+  {data.content}
+</SyntaxHighlighter>
+```
+
+**问题**：
+- `SyntaxHighlighter` 全量渲染：5000 行文件每次 React render 重新 tokenize + 主题应用 + DOM 挂载，Tab 切换或 theme 切换会卡几百 ms。
+- 没有任何文件大小 / 行数判断——即便用户打开一个 5MB 的日志也是直接全量。
+- 项目里**没有** `@tanstack/react-virtual` 依赖（`package.json` 已确认）。
+
+**修复方向**（与 06-01 一致，未变）：
+- 行数 > 1000 启用虚拟滚动（`@tanstack/react-virtual`），把行切成固定行高的 `LineRow`，`useVirtualizer` 渲染可见窗口。
+- 文件 > 256KB 给"以原始文本查看"选项，跳过高亮。
+- 难度在于 `react-syntax-highlighter` 的 tokenize 输出和虚拟滚动的对齐——可以只对纯文本 / markdown 启用虚拟滚动（无 tokenize），对代码高亮保持原样但加"折叠到顶部 N 行"。
+
+**验证建议**：用 1k / 5k / 20k 行的 `node_modules/typescript/lib/typescript.d.ts`（ts 声明文件）做基准，肉眼对比切换延迟。
+
+---
+
+## 3. P1-4. URL 状态 ↔ React 状态用 `suppressCwdBumpRef` 互相抑制
+
+**位置**：`components/AppShell.tsx:162, 167, 195-196`（`suppressCwdBumpRef` 定义 + 三处使用）
+
+> 06-01 评审时为 `components/AppShell.tsx:164-184`、`components/SessionSidebar.tsx:254-259`。P0-5 期间小幅调整过数字，但模式未变。
+
+**当前代码**：
+```tsx
+// AppShell.tsx:161-162
+// Suppresses sessionKey bump in handleCwdChange during the initial URL restore
+const suppressCwdBumpRef = useRef(false);
+
+// AppShell.tsx:164-167
+const handleCwdChange = useCallback((cwd: string | null) => {
+  setActiveCwd(cwd);
+  // Skip if cwd is null (initial mount) or during the initial URL restore.
+  if (!cwd || suppressCwdBumpRef.current) return;
+  ...
+
+// AppShell.tsx:195-196
+suppressCwdBumpRef.current = true;
+setTimeout(() => { suppressCwdBumpRef.current = false; }, 0);
+```
+
+**问题**（与 06-01 一致）：
+- 典型"打补丁式状态同步"——Sidebar 的 `setSelectedCwd` → `onCwdChange` effect（`SessionSidebar.tsx:274-275`）→ AppShell `handleCwdChange` → `router.replace` → URL 变 → Sidebar 重新 render → `setSelectedCwd` 再次触发。`suppressCwdBumpRef` 是给这个循环贴的胶带。
+- `setTimeout(..., 0)` 是 hack：依赖 microtask 调度顺序保证 setState 提交后再清旗。任何升级到 React 18+ concurrent 模式都可能破坏。
+- AppShell 已经 import 了 `useSearchParams`（`:4, :25`），但**没有**用作 single source of truth——仍然是双向状态。
+
+**修复方向**（与 06-01 一致）：
+- AppShell 作为 URL 的 **single source of truth**：
+  - 维护 `activeCwd: string | null`，**只**由 `useSearchParams` 派生的 effect 写入。
+  - `router.replace(\`?cwd=${encodeURIComponent(cwd)}\`)` 写入 URL，effect 读 URL 推 state。
+- Sidebar 只发 action（`onCwdChange` 回调），不读 URL。
+- `SessionSidebar` 的 `selectedCwd` 内部 state 改用 `useSyncExternalStore` 模式或直接改为受控组件（接 `selectedCwdProp`）。
+- 删除 `suppressCwdBumpRef` + `setTimeout` + `if (suppressRef.current) return` 全部三处。
+
+**额外建议**：把 P0-4 合并到这个 PR 处理——`AppShell` 重构过程中会触碰 `router.replace`，顺手把 2 处 env 透传白名单化（`main.ts:165, 180-185`），详见 §10。
+
+---
+
+## 4. P1-5. 端口扫描 TOCTOU 竞争
+
+**位置**：`electron/main.ts:107-152`（`isPortReachable` + `reservePort` + `findFreePort`）
+
+> 06-01 评审时为 `electron/main.ts:136-152`。函数结构未变，但 `isPortReachable` / `reservePort` 略有调整。
+
+**当前代码**（关键竞争窗口）：
+```ts
+// main.ts:140-148（findFreePort 主循环）
+if (await isPortReachable(port)) {     // ← L140: 检查通过
+  continue;
+}
+try {
+  return await reservePort(port);      // ← L145: 真去 listen（无原子保证）
+} catch {
+  // Try next port.
+}
+```
+
+**问题**（与 06-01 一致）：
+- `isPortReachable` 用 `net.connect` 试连（成功=被占用），`reservePort` 用 `net.createServer().listen` 抢端口。两者之间有窗口，另一进程可能在 `connect → end` 之后、`listen` 之前抢走。
+- 实际触发概率低（dev 模式 30141 端口冲突少见），但 v0.7.7 用户基数增长后预计会出现。
+
+**修复方向**（与 06-01 一致）：
+- 跳过 `isPortReachable`——直接 `reservePort`，成功即代表端口可用，失败换下一个。
+- 优化后的 `findFreePort`：
+  ```ts
+  for (let attempt = 0; attempt <= maxAttempts; attempt += 1) {
+    const port = startPort + attempt;
+    try { return await reservePort(port); } catch { /* next */ }
+  }
+  ```
+- 可选：连续 N 次失败后扩到 30142-30152，而不是直接抛错（用户提示"端口全忙，请关闭其他 dev server"）。
+
+**测试建议**：mock `net.createServer` 在 `listen` callback 之前抛 EADDRINUSE，断言循环换到下一个端口。当前 `electron/server-wait.test.ts` 已有部分覆盖，需补 race 场景。
+
+---
+
+## 5. P1-6. 启动后 Next.js 进程崩溃无自动恢复
+
+**位置**：`electron/main.ts:196-213`（`handleNextProcessExit`）
+
+> 06-01 评审时为 `electron/main.ts:205-213`。函数体未变。
+
+**当前代码**：
+```ts
+// main.ts:196-213
+function handleNextProcessExit(label: string, code: number | null, signal: NodeJS.Signals | null) {
+  logInfo(`${label} exited`, { code, signal, serverState, isQuitting });
+
+  if (isQuitting || serverState === "stopped") {
+    return;
+  }
+
+  nextProcess = null;
+
+  if (serverState === "starting") {
+    serverState = "stopped";
+    showStartupState("error", "本地服务启动失败");
+    return;
+  }
+
+  serverState = "stopped";
+  showStartupState("stopped", "本地服务进程已退出");
+}
+```
+
+**问题**（与 06-01 一致）：
+- 启动后任何时刻进程退出都只是 `serverState = "stopped"` + 改 `startup.html` 的提示。生产环境短暂端口冲突让用户必须手动重启整个 app。
+- 状态机缺少 `supervised` 阶段，错误恢复逻辑分散在 `startup-failure.ts`（仅分析不恢复）。
+
+**修复方向**（与 06-01 一致）：
+- 引入 supervisor 状态机：`starting → ready → supervised`：
+  - `ready` 期间首次成功 `loadURL` 后切到 `supervised`。
+  - `supervised` 状态下 `handleNextProcessExit` 触发指数退避重试（1s / 2s / 4s / 8s / 16s，封顶 30s），最多 3 次。
+  - 重试用完切回 `error` 状态 + 弹"重试"按钮（前端 `startup.html` 改 hash）。
+- 重试时复用已分配的 `activePort`（用户期望端口不变）。
+
+**测试建议**：mock `proc.on("exit", ...)` 触发，断言 `findFreePort` + `startNextServer` 被再次调用，端口不变。`electron/startup-failure.test.ts` 可扩展。
+
+---
+
+## 6. P1-7. `electron-builder.yml` 的 `extraResources` 列表手工维护
+
+**位置**：`electron-builder.yml:17-49`（19 个手写包），`:55-58`（`.next/standalone/node_modules` 整体复制作为第二项）
+
+> 06-01 评审时为 `electron-builder.yml:50-56`。列表前移是因为 06-02 加了 `electron-updater` 自动更新模块。但手写包列表原样保留——follow-up #1（`electron-updater` 启动 30s 报 `Cannot find module`）就是因为列表不全。
+
+**当前代码**（节选）：
+```yaml
+# electron-builder.yml:17-49
+extraResources:
+  - from: node_modules/electron-updater
+    to: app/node_modules/electron-updater
+  - from: node_modules/builder-util-runtime
+    to: app/node_modules/builder-util-runtime
+  - from: node_modules/fs-extra
+    to: app/node_modules/fs-extra
+  ...  # 共 19 个手写条目
+  - from: node_modules/ms
+    to: app/node_modules/ms
+  - from: .next/standalone
+    to: standalone
+    filter: ["**/*", "!node_modules/**/*"]
+  - from: .next/standalone/node_modules
+    to: standalone/node_modules
+  - from: .next/static
+    to: standalone/.next/static
+  - from: public
+    to: standalone/public
+```
+
+**问题**（与 06-01 一致，但**更严重**）：
+- 19 个 npm 包手写，漏一个就 `Cannot find module`。`electron-updater` 升级、新增 `diff` 类依赖等都会让列表过时。
+- 当前额外问题：`.next/standalone` 复制时**显式排除** `node_modules`（`:14` 的 `filter: ["**/*", "!node_modules/**/*"]`），然后又把整个 `node_modules` 作为第二项复制——**这俩冲突**，第二项会**覆盖**第一项的目录结构。
+- follow-up #1 提到的 `electron-updater` 30s `Cannot find module` 即是此问题：依赖图里还有 `debug`、`sax`、`ms` 等传递依赖，目前都在 19 项列表里手工维护。
+
+**修复方向**（与 06-01 一致）：
+```yaml
+extraResources:
+  - from: .next/standalone
+    to: standalone
+    filter: ["**/*", "!node_modules/**/*"]
+  - from: .next/standalone/node_modules
+    to: standalone/node_modules
+  - from: .next/static
+    to: standalone/.next/static
+  - from: public
+    to: standalone/public
+  # 不再手写 electron-updater 的传递依赖
+```
+让 electron-builder 自己解析整个 `standalone/node_modules` 树，删掉 19 项手写列表。
+
+**额外建议**：
+- 引入 `asarUnpack` 处理 `logs/` / `config/` 等可写目录。
+- 加 `scripts/check-resources.js` 启动时校验 `process.resourcesPath/standalone/node_modules/electron-updater` 存在，缺则提示"打包资源不完整"。
+
+**风险**：从 `electron-packager --ignore` 切回 `electron-builder` 是大改动，建议**先**用 `electron-builder` 跑 dry-run（不实际生成 installer，只生成目录）验证 `extraResources` 树完整，再切 release pipeline。
+
+---
+
+## 7. P1-8. `startup.html` 的 CSP 是 `script-src 'unsafe-inline'`
+
+**位置**：`electron/startup.html:5`（CSP meta），`:131-155`（内联脚本）
+
+> 06-01 评审时为 `electron/startup.html:133`。meta 标签移到 head 顶部。
+
+**当前代码**：
+```html
+<!-- startup.html:5 -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline';" />
+...
+<!-- startup.html:131-155 -->
+<script>
+  (function () {
+    var params = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+    var state = params.get("state");
+    var message = params.get("message");
+    ...
+  })();
+</script>
+```
+
+**问题**（与 06-01 一致）：
+- CSP 允许内联脚本。当前 IIFE 用 `textContent`（安全）写文案，没有 `innerHTML` / `eval` / `Function(...)`，但纵深不足——任何后续"加个动态状态"的需求（用 `innerHTML` 显示详细错误）会引入 XSS。
+- `style-src 'unsafe-inline'` 同理——目前用 `:root { ... }` 静态 CSS，未来加 dynamic style 会同样踩坑。
+- 加载方式是 `loadFile`（`file://` 协议），CORS 不严格，相对 `protocol: file` 的 `script-src 'self'` 实测有效。
+
+**修复方向**（与 06-01 一致）：
+- 拆出 `startup.js`：在 `electron/startup.html` 同目录放 `startup.js`，IIFE 内容挪过去。
+- CSP 改为 `script-src 'self'; style-src 'self'`，内联 `<style>` 用 `<link rel="stylesheet" href="startup.css">` 替换。
+- 同步更新 `electron-builder.yml` 的 `files` 列表把 `startup.html` + `startup.js` + `startup.css` 一起打包。
+
+---
+
+## 8. P1-9. `SKILLS_API_URL` 改 env 后可能变 SSRF
+
+**位置**：`app/api/skills/search/route.ts:11`（`SEARCH_API_BASE`）、`:65`（fetch）
+
+> 06-01 评审时为 `:63`。代码略有重构（加 `parseLimit` / `formatInstalls` 等辅助函数），env 读取位置前移。
+
+**当前代码**：
+```ts
+// route.ts:11
+const SEARCH_API_BASE = process.env.SKILLS_API_URL || "https://skills.sh";
+...
+// route.ts:63-66
+async function searchSkillsApi(query: string, limit: number): Promise<SkillSearchResult[]> {
+  const url = `${SEARCH_API_BASE}/api/search?q=${encodeURIComponent(query)}&limit=${limit}`;
+  const res = await fetch(url, { cache: "no-store" });
+  if (!res.ok) throw new Error(`skills.sh search failed: HTTP ${res.status}`);
+  ...
+}
+```
+
+**问题**（与 06-01 一致）：
+- `SKILLS_API_URL` 默认是 `https://skills.sh`，但 env 变量没有校验。攻击者通过某种途径修改（共享电脑、CI 注入、`dotenv` 误提交）会变成任意 URL → SSRF。
+- 即便目标是公网，攻击者可以指向 `http://localhost:30141/api/...` 探测内网（next dev 端口也是 localhost），或指向 `http://169.254.169.254/...`（云元数据端点）。
+- `fetch` 走 Next.js server runtime，DNS 解析 + TCP 连接都在服务端。
+
+**修复方向**（与 06-01 一致）：
+- 启动时校验 env：
+  ```ts
+  const ALLOWED_HOSTS = ["skills.sh", "staging.skills.sh"];
+  const parsed = new URL(SEARCH_API_BASE);
+  if (parsed.protocol !== "https:" || !ALLOWED_HOSTS.includes(parsed.hostname)) {
+    throw new Error(`Invalid SKILLS_API_URL: ${SEARCH_API_BASE}`);
+  }
+  ```
+- 抛错时机放在模块加载时（`route.ts` 顶部），让 `npm run dev` 启动直接 fail-fast。
+- 同步修 `app/api/skills/install/route.ts`（如果有类似的 env 读取）。
+
+---
+
+## 9. P1-10. 派生值未 memo
+
+**位置**：`hooks/useAgentSession.ts:101`（`currentModel`）、`:104`（`sessionStats`）
+
+> 06-01 评审时为 `:131, 134-149`。P0-6 重构后行号前移。
+
+**当前代码**：
+```ts
+// useAgentSession.ts:101
+const currentModel = currentModelOverride ?? data?.context.model ?? pendingModel ?? null;
+// useAgentSession.ts:104
+const sessionStats = calculateSessionStats(messages);
+```
+
+**调用方**（`:539`）：
+```ts
+return { ..., isCompacting, compactError, currentModel, displayModel, sessionStats, ... };
+```
+
+**问题**（与 06-01 一致）：
+- `currentModel` 是 3 个值的 `??` 链，每次 render 都新建对象引用——`React.memo` 包裹的子组件（如果有）拿到的 prop 引用每次都变，memo 失效。
+- `sessionStats = calculateSessionStats(messages)` 遍历整个 messages 数组计算 token 统计，每次 render 重新算。
+- 整个组件本身没被 `React.memo` 包裹，但返回的 `currentModel` / `sessionStats` 给 `MessageList` / `ChatWindow` 用——`MessageList` 是 P0-5 期间提取的，可能下游有 prop 依赖。
+
+**修复方向**（与 06-01 一致）：
+- `currentModel` 包 `useMemo`：
+  ```ts
+  const currentModel = useMemo(
+    () => currentModelOverride ?? data?.context.model ?? pendingModel ?? null,
+    [currentModelOverride, data?.context.model, pendingModel],
+  );
+  ```
+- `sessionStats` 包 `useMemo`：
+  ```ts
+  const sessionStats = useMemo(() => calculateSessionStats(messages), [messages]);
+  ```
+- `displayModel = isNew ? newSessionModel : currentModel` 也是派生，可一起 memo。
+- `currentModel` 的 dep `data?.context.model` 是对象读取，TS 不会自动 narrow 为稳定引用——可能需要 `data?.context?.model` 或在 `data` 变化时整体 invalidate。
+
+**测试建议**：用 React Profiler 跑 P0-5 留下的 1000 消息场景（如果补了测试），断言 memo 后 render 次数下降。当前无回归测试。
+
+---
+
+## 10. P0-4 / P1-4 合批建议 — env 透传白名单化
+
+**位置**：`electron/main.ts:165`（dev spawn）、`:180-185`（packaged spawn）
+
+> 06-01 评审推测"5 处 env 透传"，本次复核**确认 2 处**在主进程。其他 3 处（electron-builder / 测试 / Electron 自身 env）不在主进程 spawn 路径上，不属于"运行时透传"风险。
+
+**当前代码**：
+```ts
+// main.ts:165（dev spawn next dev）
+env: { ...process.env, PORT: String(port) },
+
+// main.ts:180-185（packaged spawn standalone server.js）
+env: {
+  ...process.env,
+  ELECTRON_RUN_AS_NODE: "1",
+  PORT: String(port),
+  HOSTNAME: "127.0.0.1",
+},
+```
+
+**风险**（与 06-01 一致）：
+- `ELECTRON_*`、`npm_config_*`、`VSCODE_*` 等 Electron 内部 env 暴露给 Next.js dev server，可能影响 dev 行为（比如 `npm_config_*` 会被 Next.js telemetry 模块读取）。
+- 用户环境里的 `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` 在 dev 模式是**需要的**（pi-coding-agent 读），不能简单剥掉。
+
+**修复方向**（与 06-01 一致）：
+```ts
+// main.ts:165（dev spawn）
+const env: NodeJS.ProcessEnv = {
+  PATH: process.env.PATH,
+  NODE_ENV: process.env.NODE_ENV ?? "development",
+  PORT: String(port),
+  NEXT_TELEMETRY_DISABLED: "1",
+  ...pickApiKeys(process.env),  // ANTHROPIC_API_KEY, OPENAI_API_KEY, pi 需要的其他
+};
+
+// main.ts:180-185（packaged spawn）
+const env: NodeJS.ProcessEnv = {
+  PATH: process.env.PATH,
+  NODE_ENV: process.env.NODE_ENV ?? "production",
+  PORT: String(port),
+  HOSTNAME: "127.0.0.1",
+  ELECTRON_RUN_AS_NODE: "1",
+  ...pickApiKeys(process.env),
+};
+```
+
+**实施细节**：
+- `pickApiKeys(env)` 是单文件工具函数，定义在 `electron/main.ts` 顶部：
+  ```ts
+  function pickApiKeys(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+    const keys = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "PI_*"];  // 根据 pi-coding-agent 实际读取的 env
+    const out: NodeJS.ProcessEnv = {};
+    for (const k of keys) {
+      if (k.endsWith("*")) {
+        const prefix = k.slice(0, -1);
+        for (const [ek, ev] of Object.entries(env)) {
+          if (ek.startsWith(prefix)) out[ek] = ev;
+        }
+      } else if (env[k]) {
+        out[k] = env[k];
+      }
+    }
+    return out;
+  }
+  ```
+- 同步修 `electron/server-wait.ts` / `electron/process-tree.ts` 如果有 spawn 调用。
+
+**测试**：用 `process.env` 注入 `ELECTRON_TEST_VAR=evil` + `ANTHROPIC_API_KEY=sk-...` 然后 spawn，断言子进程 `process.env.ELECTRON_TEST_VAR === undefined` + `ANTHROPIC_API_KEY` 保留。
+
+---
+
+## 11. 与 follow-up 的关系
+
+| follow-up | 涉及 P1 | 关系 | 建议合并 |
+|---|---|---|---|
+| #1 `electron-updater` 30s 报 `Cannot find module` | P1-7 | 直接因手写列表不全导致 | 合 P1-7 一个 PR |
+| #2 `node --test` glob 未覆盖 `hooks/**` | — | P0-6 留的测试覆盖盲区，独立修 | 单 PR |
+| #3 Windows .exe 需手工拷贝 `.next/static/` | P1-7 | electron-packager 不复制 static | 合 P1-7 一个 PR |
+| #4 P0-5 性能回归测试未补 | P1-10 | 同属 React 渲染优化 | 一起加 React Profiler 快照 |
+| #5 P0-4 dev env 透传 | P1-4 | 完全合批 | 合 P1-4 一个 PR |
+| #6 P1-1 客户端未消费 `x-request-id` | — | P1-1 留的 API 客户端补丁 | 单独修 `lib/agent-client.ts` |
+
+---
+
+## 12. 评审方法
+
+- **9 个 P1 项**全部用 Read 或 Grep 在 `ca1ef17` 上重新核对（行号 / 代码形态 / 修复方向是否仍适用）。
+- **目录结构**确认：`hooks/agent-session/*`（P0-6 拆出）、`components/MessageList.tsx` + `components/MessageView.tsx`（P0-5 拆出）。
+- **依赖确认**：`package.json` grep — `husky` / `lint-staged` / `@tanstack/react-virtual` 均无。
+- **未跑**：`npm test` / `npm run build` / 启动 dev server——纯静态复核。
+- **行号基准**：所有行号以 `ca1ef17` 为准，CI 后可能漂 1-2 行。
+
+## 13. 实施日志（2026-06-03）
+
+- **2026-06-03** 形成本复核文档（`docs/p1-followup-review-2026-06-03.md`）。
+- **2026-06-03** 切换工作树到 `main` 时发现过期 worktree 注册 `D:/orca/pi-agent-desktop/main`（路径已不存在），执行 `git worktree prune` 清理。
+- **2026-06-03** 删除 `feature/p1-1-api-error-handling` 本地与远程分支（P1-1 全部工作已合入 main，PR #2）。
+
+**当前分支**：`main` · **HEAD**：`ca1ef17`（v0.7.7）· **下一阶段**推荐：P1-4 + P0-4 合批（URL 状态去 `suppressCwdBumpRef` + env 透传白名单化），独立小改动且能解掉 follow-up #5。

--- a/docs/superpowers/plans/2026-06-03-p1-4-p0-4-state-and-env.md
+++ b/docs/superpowers/plans/2026-06-03-p1-4-p0-4-state-and-env.md
@@ -1,0 +1,532 @@
+# P1-4 + P0-4 URL 状态单一来源 + env 透传白名单化
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 移除 `suppressCwdBumpRef` hack，让 URL 成为 cwd/session 状态的单一来源；同时把 Electron 主进程的 env 透传改为白名单模式，避免泄露敏感环境变量。
+
+**Architecture:**
+- AppShell 从 `useSearchParams` 派生 `activeCwd` 和 `selectedSession`，不再维护独立 state
+- Sidebar 只发 action（调用 `router.replace`），不读 URL
+- `electron/main.ts` 的 `startNextServer` 用 `pickApiKeys()` 工具函数过滤 env
+
+**Tech Stack:** React 19、Next.js 16、TypeScript 5、Electron 36、`node --test`
+
+**Spec:** `docs/p1-followup-review-2026-06-03.md` §3（P1-4）+ §10（P0-4）
+
+---
+
+## File Structure
+
+| 文件 | 动作 | 职责 |
+|---|---|---|
+| `electron/main.ts` | 修改 | 添加 `pickApiKeys()` + 替换 2 处 spawn env |
+| `electron/main.test.ts` | 新建 | 测试 `pickApiKeys` |
+| `components/AppShell.tsx` | 修改 | 删除 `suppressCwdBumpRef` + 重构 URL 状态管理 |
+| `components/SessionSidebar.tsx` | 修改 | 改为受控组件模式 |
+
+---
+
+## Task 1: 添加 `pickApiKeys` 工具函数
+
+**Files:**
+- Modify: `electron/main.ts:12-30`（state 区块后添加）
+
+- [ ] **Step 1.1: 添加 `pickApiKeys` 函数**
+
+在 `electron/main.ts` 的 state 区块后（约第 30 行）添加：
+
+```typescript
+// ---------------------------------------------------------------------------
+// Environment filtering
+// ---------------------------------------------------------------------------
+const ENV_ALLOWLIST = [
+  "PATH",
+  "NODE_ENV",
+  "HOME",
+  "USERPROFILE",
+  "TEMP",
+  "TMP",
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_AI_API_KEY",
+];
+
+const ENV_PREFIX_ALLOWLIST = ["PI_"];
+
+function pickApiKeys(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const out: NodeJS.ProcessEnv = {};
+  for (const [k, v] of Object.entries(env)) {
+    if (ENV_ALLOWLIST.includes(k)) {
+      out[k] = v;
+    } else if (ENV_PREFIX_ALLOWLIST.some((p) => k.startsWith(p))) {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+```
+
+- [ ] **Step 1.2: tsc**
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors。
+
+- [ ] **Step 1.3: 提交**
+
+```bash
+git add electron/main.ts
+git commit -m "feat(electron): add pickApiKeys env filter utility
+
+Prepares for P0-4 env allowlist — currently unused, will be wired
+in the next commit."
+```
+
+---
+
+## Task 2: 测试 `pickApiKeys`
+
+**Files:**
+- Create: `electron/main.test.ts`
+
+- [ ] **Step 2.1: 写测试文件**
+
+```typescript
+import test, { describe } from "node:test";
+import assert from "node:assert/strict";
+
+// We can't import pickApiKeys directly since it's not exported.
+// Test the logic by reimplementing the filter here and verifying behavior.
+// In production, we'll rely on integration tests (spawn + check child env).
+
+const ENV_ALLOWLIST = [
+  "PATH",
+  "NODE_ENV",
+  "HOME",
+  "USERPROFILE",
+  "TEMP",
+  "TMP",
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_AI_API_KEY",
+];
+
+const ENV_PREFIX_ALLOWLIST = ["PI_"];
+
+function pickApiKeys(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const out: NodeJS.ProcessEnv = {};
+  for (const [k, v] of Object.entries(env)) {
+    if (ENV_ALLOWLIST.includes(k)) {
+      out[k] = v;
+    } else if (ENV_PREFIX_ALLOWLIST.some((p) => k.startsWith(p))) {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+describe("pickApiKeys", () => {
+  test("passes through allowlisted keys", () => {
+    const env = {
+      PATH: "/usr/bin",
+      NODE_ENV: "development",
+      ANTHROPIC_API_KEY: "sk-ant-xxx",
+      OPENAI_API_KEY: "sk-xxx",
+    };
+    const result = pickApiKeys(env);
+    assert.equal(result.PATH, "/usr/bin");
+    assert.equal(result.NODE_ENV, "development");
+    assert.equal(result.ANTHROPIC_API_KEY, "sk-ant-xxx");
+    assert.equal(result.OPENAI_API_KEY, "sk-xxx");
+  });
+
+  test("passes through PI_ prefixed keys", () => {
+    const env = {
+      PI_CUSTOM_VAR: "value",
+      PI_ANOTHER: "another",
+    };
+    const result = pickApiKeys(env);
+    assert.equal(result.PI_CUSTOM_VAR, "value");
+    assert.equal(result.PI_ANOTHER, "another");
+  });
+
+  test("filters out non-allowlisted keys", () => {
+    const env = {
+      PATH: "/usr/bin",
+      ELECTRON_RUN_AS_NODE: "1",
+      npm_config_registry: "https://registry.npmjs.org",
+      VSCODE_GIT_IPC_HANDLE: "/tmp/vscode-git.sock",
+      SECRET_TOKEN: "should-not-pass",
+    };
+    const result = pickApiKeys(env);
+    assert.equal(result.PATH, "/usr/bin");
+    assert.equal(result.ELECTRON_RUN_AS_NODE, undefined);
+    assert.equal(result.npm_config_registry, undefined);
+    assert.equal(result.VSCODE_GIT_IPC_HANDLE, undefined);
+    assert.equal(result.SECRET_TOKEN, undefined);
+  });
+
+  test("handles empty env", () => {
+    const result = pickApiKeys({});
+    assert.deepEqual(result, {});
+  });
+});
+```
+
+- [ ] **Step 2.2: 运行测试**
+
+Run: `node --test electron/main.test.ts`
+Expected: 4/4 pass。
+
+- [ ] **Step 2.3: 提交**
+
+```bash
+git add electron/main.test.ts
+git commit -m "test(electron): add pickApiKeys unit tests
+
+Tests the env filtering logic that will be used for spawn calls."
+```
+
+---
+
+## Task 3: 替换 spawn env 为白名单模式
+
+**Files:**
+- Modify: `electron/main.ts:160-185`（`startNextServer` 函数）
+
+- [ ] **Step 3.1: 替换 dev spawn env**
+
+找到 `electron/main.ts` 中的 dev spawn 调用（约第 163-167 行）：
+
+```typescript
+// 旧代码
+const proc = spawn("node", [nextBin, "dev", "-p", String(port)], {
+  cwd: app.getAppPath(),
+  env: { ...process.env, PORT: String(port) },
+  stdio: "pipe",
+});
+```
+
+替换为：
+
+```typescript
+const proc = spawn("node", [nextBin, "dev", "-p", String(port)], {
+  cwd: app.getAppPath(),
+  env: {
+    ...pickApiKeys(process.env),
+    NODE_ENV: process.env.NODE_ENV ?? "development",
+    PORT: String(port),
+    NEXT_TELEMETRY_DISABLED: "1",
+  },
+  stdio: "pipe",
+});
+```
+
+- [ ] **Step 3.2: 替换 packaged spawn env**
+
+找到 packaged spawn 调用（约第 178-185 行）：
+
+```typescript
+// 旧代码
+const proc = spawn(process.execPath, [serverScript], {
+  cwd: standaloneDir,
+  env: {
+    ...process.env,
+    ELECTRON_RUN_AS_NODE: "1",
+    PORT: String(port),
+    HOSTNAME: "127.0.0.1",
+  },
+  stdio: "pipe",
+});
+```
+
+替换为：
+
+```typescript
+const proc = spawn(process.execPath, [serverScript], {
+  cwd: standaloneDir,
+  env: {
+    ...pickApiKeys(process.env),
+    NODE_ENV: process.env.NODE_ENV ?? "production",
+    ELECTRON_RUN_AS_NODE: "1",
+    PORT: String(port),
+    HOSTNAME: "127.0.0.1",
+  },
+  stdio: "pipe",
+});
+```
+
+- [ ] **Step 3.3: tsc + lint**
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors。
+
+Run: `npm run lint`
+Expected: 0 errors。
+
+- [ ] **Step 3.4: 全量测试**
+
+Run: `node --test electron/*.test.ts`
+Expected: 全部通过。
+
+- [ ] **Step 3.5: 提交**
+
+```bash
+git add electron/main.ts
+git commit -m "fix(electron): use env allowlist for Next.js spawn
+
+Replaces \`...process.env\` with \`pickApiKeys(process.env)\` in both
+dev and packaged spawn paths. This prevents leaking Electron-internal
+env vars (ELECTRON_*, npm_config_*, VSCODE_*) to the Next.js server.
+
+API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.) and PI_* prefixed
+vars are explicitly allowlisted for pi-coding-agent.
+
+Fixes P0-4 from architecture review."
+```
+
+---
+
+## Task 4: 重构 AppShell URL 状态管理
+
+**Files:**
+- Modify: `components/AppShell.tsx`
+
+- [ ] **Step 4.1: 删除 `suppressCwdBumpRef` 定义**
+
+删除第 161-162 行：
+
+```typescript
+// 删除这两行
+// Suppresses sessionKey bump in handleCwdChange during the initial URL restore
+const suppressCwdBumpRef = useRef(false);
+```
+
+- [ ] **Step 4.2: 简化 `handleCwdChange`**
+
+找到 `handleCwdChange`（约第 164-184 行），删除 `suppressCwdBumpRef.current` 检查：
+
+```typescript
+const handleCwdChange = useCallback((cwd: string | null) => {
+  setActiveCwd(cwd);
+  if (!cwd) return;
+  setSelectedSession((prev) => {
+    if (prev && prev.cwd !== cwd) return null;
+    return prev;
+  });
+  setNewSessionCwd((prev) => {
+    if (prev && prev !== cwd) return null;
+    return prev;
+  });
+  setSessionKey((k) => k + 1);
+  setBranchTree([]);
+  setBranchActiveLeafId(null);
+  setSystemPrompt(null);
+  setActiveTopPanel(null);
+  router.replace("/", { scroll: false });
+}, [router]);
+```
+
+- [ ] **Step 4.3: 简化 `handleSelectSession`**
+
+找到 `handleSelectSession`（约第 186-203 行），删除 `suppressCwdBumpRef` 相关代码：
+
+```typescript
+const handleSelectSession = useCallback((session: SessionInfo, isRestore = false) => {
+  setNewSessionCwd(null);
+  setSelectedSession(session);
+  setSessionKey((k) => k + 1);
+  setSystemPrompt(null);
+  setInitialSessionRestored(true);
+  if (!isRestore) {
+    router.replace(`?session=${encodeURIComponent(session.id)}`, { scroll: false });
+  }
+}, [router]);
+```
+
+- [ ] **Step 4.4: tsc**
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors。
+
+- [ ] **Step 4.5: 提交**
+
+```bash
+git add components/AppShell.tsx
+git commit -m "refactor(AppShell): remove suppressCwdBumpRef hack
+
+The ref was a band-aid for a state sync loop between Sidebar's
+selectedCwd and AppShell's activeCwd. With the simplified flow:
+- handleCwdChange no longer checks suppressCwdBumpRef
+- handleSelectSession no longer sets/clears the ref with setTimeout
+
+This is step 1 of P1-4. The full fix (URL as single source of truth)
+requires further refactoring in SessionSidebar."
+```
+
+---
+
+## Task 5: SessionSidebar 改为受控组件
+
+**Files:**
+- Modify: `components/SessionSidebar.tsx`
+
+- [ ] **Step 5.1: 移除内部 `selectedCwd` state**
+
+找到第 221 行的 state 定义：
+
+```typescript
+// 删除这行
+const [selectedCwd, setSelectedCwd] = useState<string | null>(null);
+```
+
+改为使用 prop：
+
+```typescript
+const selectedCwd = selectedCwdProp;
+```
+
+- [ ] **Step 5.2: 把 `setSelectedCwd` 调用改为 `onCwdChange`**
+
+搜索 `setSelectedCwd` 的所有调用点，改为调用 `onCwdChange`：
+
+第 287 行（restore session）：
+```typescript
+// 旧：setSelectedCwd(target.cwd);
+onCwdChange?.(target.cwd);
+```
+
+第 295 行（auto-select cwd）：
+```typescript
+// 旧：if (cwds.length > 0) setSelectedCwd(cwds[0]);
+if (cwds.length > 0) onCwdChange?.(cwds[0]);
+```
+
+第 306 行（handleCustomPath）：
+```typescript
+// 旧：setSelectedCwd(nextCwd);
+onCwdChange?.(nextCwd);
+```
+
+第 325 行（handleDefaultCwd）：
+```typescript
+// 旧：setSelectedCwd(data.cwd);
+onCwdChange?.(data.cwd);
+```
+
+第 512 行（cwd dropdown）：
+```typescript
+// 旧：setSelectedCwd(cwd);
+onCwdChange?.(cwd);
+```
+
+- [ ] **Step 5.3: 删除 effect 中的 `onCwdChange` 调用**
+
+删除第 273-275 行的 effect（不再需要，因为现在是受控组件）：
+
+```typescript
+// 删除这个 effect
+useEffect(() => {
+  onCwdChange?.(selectedCwd);
+}, [selectedCwd, onCwdChange]);
+```
+
+- [ ] **Step 5.4: tsc + lint**
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors。
+
+Run: `npm run lint`
+Expected: 0 errors。
+
+- [ ] **Step 5.5: 全量测试**
+
+Run: `node --test lib/*.test.ts electron/*.test.ts 'app/**/*.test.ts' hooks/agent-session/*.test.ts`
+Expected: 全部通过。
+
+- [ ] **Step 5.6: 提交**
+
+```bash
+git add components/SessionSidebar.tsx
+git commit -m "refactor(SessionSidebar): convert to controlled component
+
+SessionSidebar no longer maintains internal selectedCwd state.
+Instead, it uses selectedCwdProp directly and calls onCwdChange
+for all cwd changes.
+
+This eliminates the state sync loop that required suppressCwdBumpRef:
+- Parent (AppShell) owns activeCwd state
+- Child (SessionSidebar) receives it as prop and reports changes
+- No more bidirectional state sync
+
+Completes P1-4 fix."
+```
+
+---
+
+## Task 6: 手动验证
+
+- [ ] **Step 6.1: 启动 dev 模式**
+
+Run: `npm run dev`
+
+- [ ] **Step 6.2: 验证 URL 状态**
+
+1. 打开 http://localhost:30141
+2. 选择一个项目目录 → URL 应保持 `/`
+3. 选择一个 session → URL 应变为 `/?session=xxx`
+4. 刷新页面 → session 应正确恢复
+5. 切换项目目录 → URL 应变回 `/`，session 应清除
+
+- [ ] **Step 6.3: 验证 Electron 模式**
+
+Run: `npm run dev:electron`
+
+1. 启动应正常（env 白名单不影响 Next.js 启动）
+2. 基本功能正常
+
+- [ ] **Step 6.4: 检查 console 无错误**
+
+浏览器 console 和 Electron devtools 应无 React 相关错误。
+
+---
+
+## Task 7: Code review + push
+
+- [ ] **Step 7.1: 派 code reviewer**
+
+按 `superpowers:requesting-code-review` skill 审查本分支的 6 个 commit。
+
+- [ ] **Step 7.2: 应用 review 修复（如有）**
+
+按 review 反馈修复 Critical / Important 问题。
+
+- [ ] **Step 7.3: 重新跑测试（如有修改）**
+
+如 Step 7.2 改了代码，重跑全量测试确认无回归。
+
+- [ ] **Step 7.4: Push**
+
+```bash
+git push -u origin feature/p1-4-p0-4-state-and-env
+```
+
+---
+
+## Self-Review
+
+**1. Spec 覆盖**：
+- P0-4 env 透传白名单化 → Task 1-3 ✓
+- P1-4 删除 `suppressCwdBumpRef` → Task 4 ✓
+- P1-4 SessionSidebar 受控组件 → Task 5 ✓
+- 手动验证 → Task 6 ✓
+
+**2. 占位符扫描**：无 TBD/TODO；所有代码块完整。
+
+**3. 类型一致性**：
+- `pickApiKeys` 签名 `(env: NodeJS.ProcessEnv) => NodeJS.ProcessEnv` ✓
+- `selectedCwdProp` 类型 `string | null` 与原 `selectedCwd` state 一致 ✓
+- `onCwdChange` 签名 `(cwd: string | null) => void` ✓
+
+无 inline 修正。

--- a/electron/env-filter.ts
+++ b/electron/env-filter.ts
@@ -1,0 +1,27 @@
+const ENV_ALLOWLIST = [
+  "PATH",
+  "Path",
+  "NODE_ENV",
+  "HOME",
+  "USERPROFILE",
+  "TEMP",
+  "TMP",
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_AI_API_KEY",
+];
+
+const ENV_PREFIX_ALLOWLIST = ["PI_"];
+
+export function pickApiKeys(env: Record<string, string | undefined>): Record<string, string | undefined> {
+  const out: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(env)) {
+    if (ENV_ALLOWLIST.includes(k)) {
+      out[k] = v;
+    } else if (ENV_PREFIX_ALLOWLIST.some((p) => k.startsWith(p))) {
+      out[k] = v;
+    }
+  }
+  return out;
+}

--- a/electron/main.test.ts
+++ b/electron/main.test.ts
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { pickApiKeys } from "./env-filter.ts";
+
+test("pickApiKeys keeps allowlisted keys", () => {
+  const env = {
+    PATH: "/usr/bin",
+    NODE_ENV: "production",
+    ANTHROPIC_API_KEY: "anthropic",
+    OPENAI_API_KEY: "openai",
+    SECRET_TOKEN: "secret",
+  };
+
+  assert.deepEqual(pickApiKeys(env), {
+    PATH: "/usr/bin",
+    NODE_ENV: "production",
+    ANTHROPIC_API_KEY: "anthropic",
+    OPENAI_API_KEY: "openai",
+  });
+});
+
+test("pickApiKeys keeps Windows Path key", () => {
+  const env = {
+    Path: "C:/Windows/System32",
+    SECRET_TOKEN: "secret",
+  };
+
+  assert.deepEqual(pickApiKeys(env), {
+    Path: "C:/Windows/System32",
+  });
+});
+
+test("pickApiKeys keeps PI-prefixed keys", () => {
+  const env = {
+    PI_API_BASE_URL: "http://localhost:1234",
+    PI_PROFILE: "dev",
+    SECRET_TOKEN: "secret",
+  };
+
+  assert.deepEqual(pickApiKeys(env), {
+    PI_API_BASE_URL: "http://localhost:1234",
+    PI_PROFILE: "dev",
+  });
+});
+
+test("pickApiKeys filters disallowed keys", () => {
+  const env = {
+    ELECTRON_RUN_AS_NODE: "1",
+    npm_config_registry: "https://registry.npmjs.org/",
+    VSCODE_GIT_IPC_HANDLE: "pipe",
+    SECRET_TOKEN: "secret",
+  };
+
+  assert.deepEqual(pickApiKeys(env), {});
+});
+
+test("pickApiKeys returns empty object for empty env", () => {
+  assert.deepEqual(pickApiKeys({}), {});
+});

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -8,6 +8,7 @@ import { createTray } from "./tray";
 import { getStartupFailureDisposition } from "./startup-failure";
 import { waitForNextServerReady } from "./server-wait";
 import { killProcessTree } from "./process-tree";
+import { pickApiKeys } from "./env-filter";
 
 // ---------------------------------------------------------------------------
 // State
@@ -162,7 +163,12 @@ function startNextServer(port: number): ChildProcess {
     const nextBin = require.resolve("next/dist/bin/next", { paths: [app.getAppPath()] });
     const proc = spawn("node", [nextBin, "dev", "-p", String(port)], {
       cwd: app.getAppPath(),
-      env: { ...process.env, PORT: String(port) },
+      env: {
+        ...pickApiKeys(process.env),
+        NODE_ENV: process.env.NODE_ENV ?? "development",
+        PORT: String(port),
+        NEXT_TELEMETRY_DISABLED: "1",
+      },
       stdio: "pipe",
     });
     proc.stdout?.on("data", (d: Buffer) => logInfo(`[Next] ${d.toString().trim()}`));
@@ -178,7 +184,8 @@ function startNextServer(port: number): ChildProcess {
   const proc = spawn(process.execPath, [serverScript], {
     cwd: standaloneDir,
     env: {
-      ...process.env,
+      ...pickApiKeys(process.env),
+      NODE_ENV: process.env.NODE_ENV ?? "production",
       ELECTRON_RUN_AS_NODE: "1",
       PORT: String(port),
       HOSTNAME: "127.0.0.1",


### PR DESCRIPTION
## Summary
- Replace Electron child-process `...process.env` passthrough with an explicit allowlist for required API keys, `PI_*`, and runtime essentials.
- Convert `SessionSidebar` cwd selection to a controlled prop/callback flow and remove the `suppressCwdBumpRef` restore hack in `AppShell`.
- Add unit coverage for env filtering, including Windows `Path` and filtered Electron/npm/VS Code/private env variables.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint` (passes with existing `components/MessageView.tsx:620` warning)
- [x] `node --test electron/*.test.ts`
- [x] `node --test lib/*.test.ts electron/*.test.ts 'app/**/*.test.ts' hooks/agent-session/*.test.ts`
- [x] `npm run dev` + `GET /api/health` and `/` respond successfully
- [x] `npm run dev:electron` build/start path exercised; first run hit existing Next dev lock, rerun exited 0 after stopping the dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated download instructions to direct users to the correct release location.

* **Bug Fixes**
  * Improved environment variable handling for enhanced security and stability during application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->