### PR TITLE
ci: add PR walkthrough previews and stabilize checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     name: lint · typecheck · test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: "npm"
@@ -41,10 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-typecheck-test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: "npm"
@@ -70,10 +70,10 @@ jobs:
     name: test (windows)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: "npm"

--- a/.github/workflows/pr-walkthrough-publish.yml
+++ b/.github/workflows/pr-walkthrough-publish.yml
@@ -1,0 +1,129 @@
+name: Publish PR Walkthrough
+
+on:
+  workflow_run:
+    workflows: [PR Walkthrough]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: Existing PR Walkthrough run ID containing the artifact.
+        required: true
+        type: string
+      pr_number:
+        description: PR number to comment on.
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  actions: read
+
+concurrency:
+  group: pr-walkthrough-publish-${{ github.event.workflow_run.id || inputs.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish walkthrough and comment
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve source run and PR
+        id: context
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_RUN_ID: ${{ inputs.run_id }}
+          DISPATCH_PR_NUMBER: ${{ inputs.pr_number }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          WORKFLOW_RUN_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            run_id="$DISPATCH_RUN_ID"
+            pr_number="$DISPATCH_PR_NUMBER"
+          else
+            run_id="$WORKFLOW_RUN_ID"
+            pr_number="$WORKFLOW_RUN_PR_NUMBER"
+          fi
+
+          if [ -z "$run_id" ] || [ -z "$pr_number" ]; then
+            echo "Could not resolve run_id and pr_number." >&2
+            exit 1
+          fi
+
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=pr-walkthrough-$pr_number" >> "$GITHUB_OUTPUT"
+          echo "walkthrough_url=https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY#*/}/pr-walkthrough/pr-$pr_number/" >> "$GITHUB_OUTPUT"
+
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Download walkthrough artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p .warp/pr-walkthrough
+          gh run download "${{ steps.context.outputs.run_id }}" \
+            --name "${{ steps.context.outputs.artifact_name }}" \
+            --dir .warp/pr-walkthrough
+
+      - name: Check whether publishing is needed
+        id: publish
+        run: |
+          if [ -f .warp/pr-walkthrough/SKIPPED.md ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            cat .warp/pr-walkthrough/SKIPPED.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            test -f .warp/pr-walkthrough/index.html
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish walkthrough preview
+        if: steps.publish.outputs.enabled == 'true'
+        uses: peaceiris/actions-gh-pages@v4.1.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: .warp/pr-walkthrough
+          destination_dir: pr-walkthrough/pr-${{ steps.context.outputs.pr_number }}
+          keep_files: true
+
+      - name: Comment with live walkthrough URL
+        if: steps.publish.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+          WALKTHROUGH_URL: ${{ steps.context.outputs.walkthrough_url }}
+        run: |
+          marker="<!-- pr-walkthrough-preview -->"
+          body_file="$RUNNER_TEMP/pr-walkthrough-comment.md"
+          cat > "$body_file" <<EOF
+          $marker
+          ## PR Walkthrough Visualizer
+
+          View the generated PR walkthrough visualizer:
+
+          $WALKTHROUGH_URL
+
+          _Updated by the Publish PR Walkthrough workflow for run $GITHUB_RUN_ID._
+          EOF
+
+          body="$(cat "$body_file")"
+
+          existing_comment_id="$(
+            gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+              --jq ".[] | select(.user.type == \"Bot\" and (.body | contains(\"$marker\"))) | .id" \
+              | tail -n 1
+          )"
+
+          if [ -n "$existing_comment_id" ]; then
+            gh api \
+              --method PATCH \
+              "repos/$GITHUB_REPOSITORY/issues/comments/$existing_comment_id" \
+              -f body="$body"
+          else
+            gh pr comment "$PR_NUMBER" --body-file "$body_file"
+          fi

--- a/.github/workflows/pr-walkthrough.yml
+++ b/.github/workflows/pr-walkthrough.yml
@@ -1,0 +1,94 @@
+name: PR Walkthrough
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to visualize when running this workflow manually.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+  actions: read
+
+concurrency:
+  group: pr-walkthrough-${{ github.event.pull_request.number || inputs.pr_number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate:
+    name: Generate walkthrough
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR number
+        id: pr
+        env:
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          pr_number="${EVENT_PR_NUMBER:-$INPUT_PR_NUMBER}"
+          if [ -z "$pr_number" ]; then
+            echo "This workflow needs a pull_request trigger or workflow_dispatch pr_number." >&2
+            exit 1
+          fi
+          echo "number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Check out PR head
+        uses: actions/checkout@v7
+        with:
+          ref: refs/pull/${{ steps.pr.outputs.number }}/head
+          fetch-depth: 0
+
+      - name: Check walkthrough configuration
+        id: config
+        env:
+          WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
+        run: |
+          mkdir -p .warp/pr-walkthrough
+          if [ -z "$WARP_API_KEY" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            cat > .warp/pr-walkthrough/SKIPPED.md <<'EOF'
+          PR walkthrough generation was skipped because the `WARP_API_KEY` repository secret is not configured.
+          EOF
+            echo "::warning::PR walkthrough skipped: configure the WARP_API_KEY repository secret to enable previews."
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate PR walkthrough with Oz
+        if: steps.config.outputs.enabled == 'true'
+        uses: warpdotdev/oz-agent-action@v1.0.28
+        with:
+          skill: warpdotdev/common-skills:pr-walkthrough
+          name: PR walkthrough for #${{ steps.pr.outputs.number }}
+          share: team
+          warp_api_key: ${{ secrets.WARP_API_KEY }}
+          prompt: |
+            Generate a static interactive D3 PR walkthrough for PR #${{ steps.pr.outputs.number }} in ${{ github.repository }}.
+
+            Requirements:
+            - Use the checked-out repository as the PR head.
+            - Use GitHub PR metadata, diff, files, and existing PR review comments when available.
+            - Create the self-contained visualizer at `.warp/pr-walkthrough/index.html`.
+            - Run the skill's D3 canvas validator before finishing.
+            - Do not commit, push, create branches, create PRs, or post GitHub comments.
+            - Leave all generated files in `.warp/pr-walkthrough/` for the workflow to upload.
+
+      - name: Verify generated visualizer exists
+        if: steps.config.outputs.enabled == 'true'
+        run: |
+          test -f .warp/pr-walkthrough/index.html
+          grep -q 'window.PR_WALKTHROUGH_D3_DATA' .warp/pr-walkthrough/index.html
+
+      - name: Upload walkthrough artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-walkthrough-${{ steps.pr.outputs.number }}
+          path: .warp/pr-walkthrough
+          if-no-files-found: error
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://github.com/Chasen-Liao/pi-agent-desktop">
-    <img src="public/logo.png" alt="Pi Agent Desktop Logo" width="128" height="128" style="border-radius: 28px; border: 1px solid rgba(0,0,0,0.08); box-shadow: 0 4px 16px rgba(0,0,0,0.08);" />
+    <img src="https://raw.githubusercontent.com/Chasen-Liao/pi-agent-desktop/main/public/logo.png" alt="Pi Agent Desktop Logo" width="128" height="128" style="border-radius: 28px; border: 1px solid rgba(0,0,0,0.08); box-shadow: 0 4px 16px rgba(0,0,0,0.08);" />
   </a>
 
   # Pi Agent Desktop
@@ -14,7 +14,7 @@
 
   ---
 
-  ![Pi Agent Desktop Demo](public/pi.gif)
+  ![Pi Agent Desktop Demo](https://raw.githubusercontent.com/Chasen-Liao/pi-agent-desktop/main/public/pi.gif)
 
   ---
 </div>
@@ -100,9 +100,12 @@ lib/
 - **打包**：electron-builder (NSIS)
 - **通信**：SSE (Server-Sent Events) 实时流式传输
 
-## 界面截图
+## CI
 
-![Pi Agent Desktop Interface](image-2.png)
+- `CI` 在 pull request 和 `main` push 上运行 lint、类型检查、测试和 Next.js 构建。
+- `PR Walkthrough` 会生成 PR 可视化预览；需要在仓库 Secrets 中配置 `WARP_API_KEY`。
+- 未配置密钥时，walkthrough 会安全跳过并在 Actions 摘要中说明，不会让普通 CI 失败。
+- `Publish PR Walkthrough` 需要将 GitHub Pages 发布源设置为 `gh-pages` 分支的根目录。
 
 ## 致谢
 

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -608,7 +608,7 @@ export async function startRpcSession(
       : SessionManager.create(cwd, undefined);
 
     const storedMode = findLastAgentMode(sessionManager.getEntries() as never);
-    let agentMode: AgentMode = isAgentMode(opts.agentMode)
+    const agentMode: AgentMode = isAgentMode(opts.agentMode)
       ? opts.agentMode
       : (storedMode ?? desktop.defaultAgentMode);
     let toolPreset: ToolPreset = isToolPreset(opts.toolPreset)


### PR DESCRIPTION
## Summary

- Add the two PR Walkthrough workflows from `warpdotdev-demos/pr-walkthrough-ci`.
- Generate and publish a static PR walkthrough to GitHub Pages with a sticky PR comment.
- Make missing `WARP_API_KEY` a successful, clearly marked skip instead of a failed workflow.
- Upgrade the existing CI actions to the current Node 24-compatible majors.
- Fix the `prefer-const` error that was failing the lint job.
- Replace broken README image references with stable raw URLs and remove the missing `image-2.png` reference.

## Validation

- `npm run lint -- --quiet`
- `npx tsc --noEmit`
- `npm test` (349 tests, 347 passed, 2 skipped)
- `npm run build`
- Workflow YAML parsing and `git diff --check`

## Setup note

Add the `WARP_API_KEY` repository secret to enable generated previews. GitHub Pages should publish from the `gh-pages` branch root. Until the secret is configured, the walkthrough workflow succeeds with a skip summary and does not publish a preview.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated PR walkthrough generation and publishing, including live GitHub Pages links and PR comments.
  * Added support for manual walkthrough reruns and artifact-based publishing.
* **Documentation**
  * Updated README assets and added CI, walkthrough configuration, and deployment guidance.
* **Chores**
  * Updated CI tooling actions for linting, testing, and builds.
  * Simplified internal session configuration without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->