### PR TITLE
feat(ltm): project-scoped long-term memory (SQLite + tools + API)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,13 +52,14 @@ CodeGraph provides MCP (Model Context Protocol) tools for efficient symbol searc
 - **浏览历史**（只读）：`GET /api/sessions/*` → `lib/session-reader.ts` 直接解析 `.jsonl`，**不创建** AgentSession
 - **SSE 流**：`GET /api/agent/[id]/events` —— 30s 心跳，单向推送
 - **UI 主入口**：`app/page.tsx` → `components/AppShell.tsx` → `components/ChatWindow.tsx` → `hooks/useAgentSession.ts`
+- **长期记忆 LTM**：`lib/ltm` · API `/api/memory/*` · tools `memory_save` / `memory_recall` / `memory_forget`（设计见 [docs/superpowers/specs/2026-08-03-long-term-memory-design.md](docs/superpowers/specs/2026-08-03-long-term-memory-design.md)）
 
 ### 顶层目录速查
 
 | 目录 | 用途 |
 |---|---|
-| `app/api/` | 33 条 API 路由（agent / sessions / files / models / skills / auth / health / mcp / extensions / trust / desktop-settings） |
-| `lib/` | 服务端库：`rpc-manager` / `session-reader` / `approval-policy` / `extension-ui-bridge` / `mcp-config` / `session-export` / `session-branch-clone` 等 |
+| `app/api/` | API 路由（agent / sessions / files / models / skills / auth / health / mcp / extensions / trust / desktop-settings / **memory**） |
+| `lib/` | 服务端库：`rpc-manager` / `session-reader` / `approval-policy` / `extension-ui-bridge` / `mcp-config` / `session-export` / `session-branch-clone` / **`ltm`** 等 |
 | `components/` | 24 个顶层组件（含 `McpConfigModal` / `SessionExportModal` / `ExtensionsConfigModal` / `ProjectTrustDialog` / `ExtensionUiDialog` / `AgentModeSelector` 等） |
 | `hooks/` | 6 个顶层 hook + `agent-session/` 子目录下 8 个拆分 hook |
 | `electron/` | 主进程 `main.ts` + `preload.ts` / `tray.ts` + 7 个辅助模块 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,15 +64,16 @@ CodeGraph provides MCP (Model Context Protocol) tools for efficient symbol searc
 | `hooks/` | 6 个顶层 hook + `agent-session/` 子目录下 8 个拆分 hook |
 | `electron/` | 主进程 `main.ts` + `preload.ts` / `tray.ts` + 7 个辅助模块 |
 | `bin/pi-web.js` | CLI 入口（`npm i -g` / `npx`） |
-### 五个必须存 `globalThis` 的原因
+### 必须存 `globalThis` 的原因
 
-Next.js HMR 会丢弃模块级变量，因此以下五个必须挂在 `globalThis` 上：
+Next.js HMR 会丢弃模块级变量，因此会话与 LTM 相关状态必须挂在 `globalThis` 上：
 
 - `globalThis.__piSessions` — `Map<sessionId, AgentSessionWrapper>` 活跃会话注册表（[lib/rpc-manager.ts](lib/rpc-manager.ts)）
 - `globalThis.__piSessionPathCache` — `sessionId → .jsonl` 路径缓存（[lib/session-reader.ts](lib/session-reader.ts)）
 - `globalThis.__piStartLocks` — 并发启动共享 Promise 锁（[lib/rpc-manager.ts](lib/rpc-manager.ts)）
 - `globalThis.__piWriteLocks` — per-file 写入锁（[lib/session-lock.ts](lib/session-lock.ts)）
 - `globalThis.__piAllowedRootsCache` — 文件访问白名单缓存（5s TTL）（[lib/allowed-roots.ts](lib/allowed-roots.ts)）
+- `globalThis.__piLtmService` — 长期记忆 `MemoryService` 单例（[lib/ltm/service.ts](lib/ltm/service.ts)）
 
 ---
 
@@ -100,7 +101,11 @@ Pi SDK 存 `{id, name, arguments}`，前端用 `{toolCallId, toolName, input}`�
 
 ### 5. Electron 打包大小 & Next.js NFT 套娃陷阱
 
-Frontend 依赖必须放 `devDependencies`（否则 electron-builder 盲目打包进 app.asar）。`next.config.ts` 必须加上 `outputFileTracingExcludes: { "/": ["release/**/*", ".git/**/*"] }` 防止 NFT 把旧安装包拉进 build，造成指数级套娃膨胀。详见 [ARCHITECTURE.md §14.12](docs/ARCHITECTURE.md#1412-electron-打包大小--nextjs-nft-套娃陷阱)。
+Frontend 依赖必须放 `devDependencies`（否则 electron-builder 盲目打包进 app.asar）。`next.config.ts` 必须加上 `outputFileTracingExcludes` 防止 NFT 把旧安装包拉进 build。详见 [ARCHITECTURE.md](docs/ARCHITECTURE.md)。
+
+### 6. Next 16 Turbopack standalone 必须补齐 turbo runtime
+
+`build:standalone` = `next build && node scripts/ensure-standalone-next-runtimes.mjs`。缺省会导致安装包卡在启动页（`app-route-turbo.runtime.prod.js` missing）。详见 [ARCHITECTURE.md §14.10b](docs/ARCHITECTURE.md#1410b-next-16-turbopack-standalone-缺-app-route-runtime2026-08-03)。
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ npm run dist
 - **会话 Branching & Cloning**：支持从会话节点分叉新分支 (`/api/sessions/[id]/branch`) 或全量 Clone 到目标目录 (`/api/sessions/[id]/clone`)。
 - **会话导出 (HTML/MD)**：支持将会话流式或静态导出为独立的 HTML（含语法高亮）或 Markdown 文件 (`/api/sessions/[id]/export`)。
 - **AgentMode `.jsonl` 持久化**：在模式切换时向 Session `.jsonl` 追加 `desktop_agent_mode` Custom Entry，Session 重载时自动恢复历史模式。
+- **长期记忆 LTM（v0.7.19）**：项目级 SQLite 记忆库 `lib/ltm`；工具 `memory_save` / `memory_recall` / `memory_forget`；API `/api/memory/*`；`agent_end` 与 compact 前自动 observe。设计见 [docs/superpowers/specs/2026-08-03-long-term-memory-design.md](docs/superpowers/specs/2026-08-03-long-term-memory-design.md)；会话记忆基线见 [docs/memory-architecture.html](docs/memory-architecture.html)。
 
 ## 高层架构
 
@@ -78,8 +79,8 @@ npm run dist
 
 | 目录 | 用途 |
 |---|---|
-| `app/api/` | 33 条 API 路由（agent / sessions / files / models / skills / auth / health / mcp / extensions / trust / desktop-settings） |
-| `lib/` | 服务端库：`rpc-manager` / `session-reader` / `approval-policy` / `extension-ui-bridge` / `mcp-config` / `session-export` / `session-branch-clone` 等 |
+| `app/api/` | **38** 条 API 路由（含 **memory** 5 条；另有 agent / sessions / files / models / skills / auth / health / mcp / extensions / trust / desktop-settings 等） |
+| `lib/` | 服务端库：`rpc-manager` / `session-reader` / **`ltm/`** / `approval-policy` / `extension-ui-bridge` / `mcp-config` / `session-export` / `session-branch-clone` 等 |
 | `components/` | 24 个顶层组件（含 `McpConfigModal` / `SessionExportModal` / `ExtensionsConfigModal` / `ProjectTrustDialog` / `ExtensionUiDialog` / `AgentModeSelector` 等） |
 | `hooks/` | 6 个顶层 hook + `agent-session/` 子目录下 8 个拆分 hook |
 | `electron/` | 主进程 `main.ts` + `preload.ts` / `tray.ts` + 7 个辅助模块 |
@@ -87,7 +88,8 @@ npm run dist
 
 ### 三条最常踩坑的设计决策
 
-- **活跃 session 注册表必须存 `globalThis`**：Next.js HMR 会丢弃模块级变量；五个 globalThis 变量必须挂在 globalThis 上：`__piSessions`（活跃会话注册表）/ `__piSessionPathCache`（路径缓存）/ `__piStartLocks`（并发启动锁）/ `__piWriteLocks`（per-file 写入锁）/ `__piAllowedRootsCache`（文件访问白名单 5s TTL）。详见 [AGENTS.md](AGENTS.md#五个必须存-globalthis-的原因) 与 [docs/ARCHITECTURE.md §14.1](docs/ARCHITECTURE.md)。
+- **活跃 session 注册表必须存 `globalThis`**：Next.js HMR 会丢弃模块级变量；至少：`__piSessions` / `__piSessionPathCache` / `__piStartLocks` / `__piWriteLocks` / `__piAllowedRootsCache`；LTM 另有 `__piLtmService`（见 `lib/ltm/service.ts`）。详见 [AGENTS.md](AGENTS.md#五个必须存-globalthis-的原因) 与 [docs/ARCHITECTURE.md §14.1](docs/ARCHITECTURE.md)。
+- **Electron 打包 + Next 16 Turbopack**：`next build` 后必须跑 `scripts/ensure-standalone-next-runtimes.mjs`，否则 standalone 缺 `app-route-turbo.runtime.prod.js`，桌面端会卡在启动页。
 - **两种分支不要混淆**：**Fork / Branch** = 跨文件新 `.jsonl`（`POST /api/sessions/[id]/branch` 或 `POST /api/agent/[id]` with `{type:"fork"}`）；**会话内分支** = 同文件 `navigate_tree` + `GET /api/sessions/[id]/context?leafId=`。
 - **Fork 后必须立即销毁旧 wrapper**：Fork 在文件层通过 `SessionManager.createBranchedSession()`（或首条消息前的 `SessionManager.create()`）创建新 `.jsonl`，再用 `startRpcSession()` 构造全新 AgentSession 实例；旧 wrapper 不再会被请求到，立即 `destroy()` 可及时释放资源（而非等 10 分钟 idle 超时）。详见 [docs/ARCHITECTURE.md §14.2](docs/ARCHITECTURE.md#142-fork-的执行顺序预注册--销毁旧-wrapper)。
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - **会话分叉与克隆** — API/UI 支持从任意节点 Branch 及 Clone 会话到新目录
 - **会话导出** — 一键导出为 HTML / Markdown 格式
 - **AgentMode 持久化** — 自动写入 `.jsonl` 自定义 `desktop_agent_mode` 节点，重载恢复历史模式
+- **长期记忆 LTM** — 项目级 SQLite 记忆（`memory_save` / `memory_recall` / `memory_forget`），跨会话检索；`agent_end` 与 compact 前自动观察写入
 - **会话内分支** — 回退到任意节点继续对话，在同一文件内创建分支
 - **分支导航器** — 可视化切换同一会话内的各个分支
 - **模型切换** — 对话中途随时切换模型
@@ -77,6 +78,7 @@ app/
   api/
     sessions/      # 读取会话文件
     agent/         # 发送命令、SSE 事件流
+    memory/        # 长期记忆 recall / remember / forget / stats / health
     files/         # 文件内容读取
     models/        # 可用模型列表与默认模型
     models-config/ # 读写 models.json
@@ -87,10 +89,13 @@ components/        # UI 组件
 electron/          # Electron 主进程
 hooks/             # React Hooks（会话管理、面板布局等）
 lib/
+  ltm/               # 长期记忆（SQLite + MemoryService + hooks）
   session-reader.ts  # 解析 .jsonl 会话文件
   rpc-manager.ts     # 管理 AgentSession 生命周期
   normalize.ts       # 规范化 toolCall 字段名
   types.ts
+scripts/
+  ensure-standalone-next-runtimes.mjs  # 打包后补齐 Turbopack runtime
 ```
 
 ## 技术栈

--- a/app/api/memory/forget/route.ts
+++ b/app/api/memory/forget/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { errorMessage, getRequestId, logApiError } from "@/lib/api-error";
+import { isLtmDisabledError, LTM_DISABLED, parseForgetBody } from "@/lib/ltm/http";
+import { getMemoryService } from "@/lib/ltm/service";
+
+export const dynamic = "force-dynamic";
+
+/** POST /api/memory/forget — body: { cwd, memoryIds?, observationIds? } */
+export async function POST(req: Request) {
+  const requestId = getRequestId(req);
+  try {
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return NextResponse.json(
+        { error: "JSON body is required" },
+        { status: 400, headers: { "x-request-id": requestId } }
+      );
+    }
+
+    const parsed = parseForgetBody(body);
+    if (!parsed.ok) {
+      return NextResponse.json(
+        { error: parsed.error },
+        { status: 400, headers: { "x-request-id": requestId } }
+      );
+    }
+
+    const service = getMemoryService();
+    if (!service.isEnabled()) {
+      return NextResponse.json(
+        { error: LTM_DISABLED },
+        { status: 503, headers: { "x-request-id": requestId } }
+      );
+    }
+
+    const { cwd, memoryIds, observationIds } = parsed.value;
+    const result = await service.forgetFromCwd(cwd, {
+      ...(memoryIds !== undefined ? { memoryIds } : {}),
+      ...(observationIds !== undefined ? { observationIds } : {}),
+    });
+    return NextResponse.json(result, { headers: { "x-request-id": requestId } });
+  } catch (error) {
+    if (isLtmDisabledError(error)) {
+      return NextResponse.json(
+        { error: LTM_DISABLED },
+        { status: 503, headers: { "x-request-id": requestId } }
+      );
+    }
+    logApiError({
+      route: "/api/memory/forget",
+      method: "POST",
+      requestId,
+      error,
+    });
+    return NextResponse.json(
+      { error: errorMessage(error) },
+      { status: 500, headers: { "x-request-id": requestId } }
+    );
+  }
+}

--- a/app/api/memory/health/route.ts
+++ b/app/api/memory/health/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { errorMessage, getRequestId, logApiError } from "@/lib/api-error";
+import { getMemoryService } from "@/lib/ltm/service";
+
+export const dynamic = "force-dynamic";
+
+/** GET /api/memory/health */
+export async function GET(req: Request) {
+  const requestId = getRequestId(req);
+  try {
+    const service = getMemoryService();
+    const health = await service.health();
+    return NextResponse.json(
+      {
+        ...health,
+        enabled: service.isEnabled(),
+      },
+      { headers: { "x-request-id": requestId } }
+    );
+  } catch (error) {
+    logApiError({ route: "/api/memory/health", method: "GET", requestId, error });
+    return NextResponse.json(
+      { error: errorMessage(error) },
+      { status: 500, headers: { "x-request-id": requestId } }
+    );
+  }
+}

--- a/app/api/memory/recall/route.ts
+++ b/app/api/memory/recall/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { errorMessage, getRequestId, logApiError } from "@/lib/api-error";
+import { isLtmDisabledError, LTM_DISABLED, parseRecallQuery } from "@/lib/ltm/http";
+import { getMemoryService } from "@/lib/ltm/service";
+
+export const dynamic = "force-dynamic";
+
+/** GET /api/memory/recall?cwd=&q=&limit? */
+export async function GET(req: Request) {
+  const requestId = getRequestId(req);
+  try {
+    const parsed = parseRecallQuery(new URL(req.url));
+    if (!parsed.ok) {
+      return NextResponse.json(
+        { error: parsed.error },
+        { status: 400, headers: { "x-request-id": requestId } }
+      );
+    }
+
+    const service = getMemoryService();
+    if (!service.isEnabled()) {
+      return NextResponse.json(
+        { error: LTM_DISABLED },
+        { status: 503, headers: { "x-request-id": requestId } }
+      );
+    }
+
+    const { cwd, query, limit } = parsed.value;
+    const hits = await service.recallFromCwd(cwd, {
+      query,
+      ...(limit !== undefined ? { limit } : {}),
+    });
+    return NextResponse.json(
+      { hits },
+      { headers: { "x-request-id": requestId } }
+    );
+  } catch (error) {
+    if (isLtmDisabledError(error)) {
+      return NextResponse.json(
+        { error: LTM_DISABLED },
+        { status: 503, headers: { "x-request-id": requestId } }
+      );
+    }
+    logApiError({ route: "/api/memory/recall", method: "GET", requestId, error });
+    return NextResponse.json(
+      { error: errorMessage(error) },
+      { status: 500, headers: { "x-request-id": requestId } }
+    );
+  }
+}

--- a/app/api/memory/remember/route.ts
+++ b/app/api/memory/remember/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { errorMessage, getRequestId, logApiError } from "@/lib/api-error";
+import { isLtmDisabledError, LTM_DISABLED, parseRememberBody } from "@/lib/ltm/http";
+import { getMemoryService } from "@/lib/ltm/service";
+
+export const dynamic = "force-dynamic";
+
+/** POST /api/memory/remember — body: { cwd, content, type?, concepts?, files? } */
+export async function POST(req: Request) {
+  const requestId = getRequestId(req);
+  try {
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return NextResponse.json(
+        { error: "JSON body is required" },
+        { status: 400, headers: { "x-request-id": requestId } }
+      );
+    }
+
+    const parsed = parseRememberBody(body);
+    if (!parsed.ok) {
+      return NextResponse.json(
+        { error: parsed.error },
+        { status: 400, headers: { "x-request-id": requestId } }
+      );
+    }
+
+    const service = getMemoryService();
+    if (!service.isEnabled()) {
+      return NextResponse.json(
+        { error: LTM_DISABLED },
+        { status: 503, headers: { "x-request-id": requestId } }
+      );
+    }
+
+    const { cwd, content, type, concepts, files } = parsed.value;
+    const result = await service.rememberFromCwd(cwd, {
+      content,
+      ...(type !== undefined ? { type } : {}),
+      ...(concepts !== undefined ? { concepts } : {}),
+      ...(files !== undefined ? { files } : {}),
+    });
+    return NextResponse.json(result, { headers: { "x-request-id": requestId } });
+  } catch (error) {
+    if (isLtmDisabledError(error)) {
+      return NextResponse.json(
+        { error: LTM_DISABLED },
+        { status: 503, headers: { "x-request-id": requestId } }
+      );
+    }
+    logApiError({
+      route: "/api/memory/remember",
+      method: "POST",
+      requestId,
+      error,
+    });
+    return NextResponse.json(
+      { error: errorMessage(error) },
+      { status: 500, headers: { "x-request-id": requestId } }
+    );
+  }
+}

--- a/app/api/memory/stats/route.ts
+++ b/app/api/memory/stats/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { errorMessage, getRequestId, logApiError } from "@/lib/api-error";
+import { isLtmDisabledError, LTM_DISABLED, parseStatsQuery } from "@/lib/ltm/http";
+import { getMemoryService } from "@/lib/ltm/service";
+
+export const dynamic = "force-dynamic";
+
+/** GET /api/memory/stats?cwd= */
+export async function GET(req: Request) {
+  const requestId = getRequestId(req);
+  try {
+    const parsed = parseStatsQuery(new URL(req.url));
+    if (!parsed.ok) {
+      return NextResponse.json(
+        { error: parsed.error },
+        { status: 400, headers: { "x-request-id": requestId } }
+      );
+    }
+
+    const service = getMemoryService();
+    if (!service.isEnabled()) {
+      return NextResponse.json(
+        { error: LTM_DISABLED },
+        { status: 503, headers: { "x-request-id": requestId } }
+      );
+    }
+
+    const stats = await service.statsFromCwd(parsed.value.cwd);
+    return NextResponse.json(stats, { headers: { "x-request-id": requestId } });
+  } catch (error) {
+    if (isLtmDisabledError(error)) {
+      return NextResponse.json(
+        { error: LTM_DISABLED },
+        { status: 503, headers: { "x-request-id": requestId } }
+      );
+    }
+    logApiError({ route: "/api/memory/stats", method: "GET", requestId, error });
+    return NextResponse.json(
+      { error: errorMessage(error) },
+      { status: 500, headers: { "x-request-id": requestId } }
+    );
+  }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -491,7 +491,7 @@ components/models-config/     模型配置弹窗的子组件
 
 ## 12. API 路由清单
 
-> 共 **33 条** route.ts（CodeGraph 索引统计）。
+> 共 **38** 条 `route.ts`（2026-08-03 文件系统盘点：含 LTM 5 条）。
 
 ### Agent 会话交互（3 条）
 
@@ -500,6 +500,18 @@ components/models-config/     模型配置弹窗的子组件
 | `app/api/agent/new/route.ts` | POST | 创建新会话并发送首条消息 |
 | `app/api/agent/[id]/route.ts` | GET / POST | GET 状态；POST 任意命令（prompt / abort / fork / navigate_tree / set_model / compact / get_tools / set_agent_mode / extension_ui_response） |
 | `app/api/agent/[id]/events/route.ts` | GET | SSE 事件流（30s 心跳，支持 extension_ui_request / extension_ui_notify） |
+
+### 长期记忆 LTM（5 条）
+
+| 路由 | 方法 | 用途 |
+|---|---|---|
+| `app/api/memory/health/route.ts` | GET | LTM 后端健康（`backend` / `enabled`） |
+| `app/api/memory/recall/route.ts` | GET | `?cwd=&q=&limit=` 项目级检索 |
+| `app/api/memory/remember/route.ts` | POST | 显式写入 memory（`cwd` + `content` + 可选 type） |
+| `app/api/memory/forget/route.ts` | POST | 按 id 删除 memory / observation |
+| `app/api/memory/stats/route.ts` | GET | `?cwd=` 项目记忆计数 |
+
+实现与工具面见 `lib/ltm/`、`lib/desktop-ltm-extension.ts`；会话 JSONL 仍为独立 episodic 日志。可视化基线：[memory-architecture.html](./memory-architecture.html)；设计：[superpowers/specs/2026-08-03-long-term-memory-design.md](./superpowers/specs/2026-08-03-long-term-memory-design.md)。
 
 ### 会话浏览、分叉与导出（7 条）
 
@@ -708,6 +720,20 @@ serverExternalPackages: [
 ```
 
 把两个 pi 包设为 server external，避免 webpack 打包它们（它们依赖 Node 原生模块）。
+
+### 14.10b Next 16 Turbopack standalone 缺 app-route runtime（2026-08-03）
+
+`next build`（Turbopack）的 NFT 可能**不**把
+
+`next/dist/compiled/next-server/app-route-turbo.runtime.prod.js`
+
+拷进 `.next/standalone`。打包后 Electron 子进程能起 `server.js`，但加载任意 App Route（含 `/api/health` 路径上的依赖）时报 `Cannot find module ...app-route-turbo.runtime.prod.js`，窗口一直停在启动页。
+
+**修复**：`package.json` 的 `build:standalone` 在 `next build` 后运行
+
+`node scripts/ensure-standalone-next-runtimes.mjs`
+
+将所有 `*turbo*.runtime.prod.js` 从 `node_modules/next/.../next-server` 复制进 standalone。不要删掉该步骤。
 
 ### 14.11 安全文件访问：allowed-roots 鉴权模型
 

--- a/docs/memory-architecture.html
+++ b/docs/memory-architecture.html
@@ -1,0 +1,1261 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Pi Agent · 记忆架构深度解析</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
+
+  :root {
+    --bg: #0a0e1a;
+    --bg2: #111827;
+    --bg3: #1a2235;
+    --bg4: #243049;
+    --accent: #6366f1;
+    --accent2: #8b5cf6;
+    --accent3: #a78bfa;
+    --cyan: #22d3ee;
+    --green: #34d399;
+    --amber: #fbbf24;
+    --rose: #fb7185;
+    --sky: #38bdf8;
+    --orange: #fb923c;
+    --text: #e2e8f0;
+    --text2: #94a3b8;
+    --text3: #64748b;
+    --border: rgba(99,102,241,0.2);
+    --border2: rgba(148,163,184,0.12);
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+
+  body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    overflow-x: hidden;
+    line-height: 1.7;
+  }
+
+  ::-webkit-scrollbar { width: 6px; }
+  ::-webkit-scrollbar-track { background: var(--bg); }
+  ::-webkit-scrollbar-thumb { background: var(--accent); border-radius: 3px; }
+
+  /* ── Nav ── */
+  nav {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 100;
+    background: rgba(10,14,26,0.85);
+    backdrop-filter: blur(20px);
+    border-bottom: 1px solid var(--border);
+    padding: 0 1.5rem;
+    display: flex; align-items: center; height: 52px; gap: 1.5rem;
+  }
+  nav .logo {
+    font-weight: 800; font-size: 0.95rem; white-space: nowrap;
+    background: linear-gradient(135deg, var(--cyan), var(--accent2));
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+  }
+  nav .links { display: flex; gap: 0.15rem; flex-wrap: nowrap; overflow-x: auto; }
+  nav .links a {
+    color: var(--text2); text-decoration: none; font-size: 0.75rem;
+    padding: 0.3rem 0.6rem; border-radius: 6px; transition: all 0.2s;
+    font-weight: 500; white-space: nowrap;
+  }
+  nav .links a:hover { color: var(--text); background: rgba(99,102,241,0.15); }
+
+  /* ── Sections ── */
+  section {
+    position: relative; z-index: 1;
+    padding: 5rem 1.5rem 3rem;
+    display: flex; flex-direction: column; align-items: center;
+  }
+  .section-inner { max-width: 1080px; width: 100%; }
+
+  .section-tag {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem; color: var(--cyan);
+    letter-spacing: 0.15em; text-transform: uppercase;
+    margin-bottom: 0.6rem;
+  }
+  .section-title {
+    font-size: 2.1rem; font-weight: 800;
+    letter-spacing: -0.03em; line-height: 1.2;
+    margin-bottom: 1rem;
+  }
+  .section-desc {
+    font-size: 1rem; color: var(--text2);
+    max-width: 720px; line-height: 1.8; margin-bottom: 2.2rem;
+  }
+
+  /* ── Hero ── */
+  #hero {
+    min-height: 92vh; justify-content: center; text-align: center;
+    padding-top: 6rem;
+  }
+  #hero .glow {
+    position: absolute; width: 560px; height: 560px; border-radius: 50%;
+    background: radial-gradient(circle, rgba(34,211,238,0.12) 0%, transparent 70%);
+    top: 45%; left: 50%; transform: translate(-50%, -50%);
+    pointer-events: none;
+  }
+  .hero-badge {
+    display: inline-flex; align-items: center; gap: 0.5rem;
+    background: rgba(34,211,238,0.08); border: 1px solid rgba(34,211,238,0.25);
+    border-radius: 999px; padding: 0.35rem 1rem;
+    font-size: 0.78rem; color: var(--cyan); font-weight: 600;
+    margin-bottom: 1.5rem; font-family: 'JetBrains Mono', monospace;
+  }
+  .hero-title {
+    font-size: clamp(2.2rem, 5vw, 3.4rem); font-weight: 900;
+    letter-spacing: -0.04em; line-height: 1.1; margin-bottom: 1.2rem;
+  }
+  .hero-title span {
+    background: linear-gradient(135deg, var(--cyan), var(--accent2), var(--rose));
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+  }
+  .hero-sub {
+    font-size: 1.1rem; color: var(--text2); max-width: 640px;
+    margin: 0 auto 2.5rem; line-height: 1.8;
+  }
+  .hero-stats {
+    display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap;
+  }
+  .stat-card {
+    background: var(--bg2); border: 1px solid var(--border2);
+    border-radius: 12px; padding: 1rem 1.4rem; min-width: 140px;
+    text-align: center;
+  }
+  .stat-card .num {
+    font-size: 1.6rem; font-weight: 800; font-family: 'JetBrains Mono', monospace;
+    color: var(--cyan);
+  }
+  .stat-card .label { font-size: 0.75rem; color: var(--text3); margin-top: 0.2rem; }
+
+  /* ── Cards / grids ── */
+  .grid-2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1rem; }
+  .grid-3 { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; }
+
+  .card {
+    background: var(--bg2); border: 1px solid var(--border2);
+    border-radius: 14px; padding: 1.4rem 1.5rem;
+    transition: border-color 0.2s, transform 0.2s;
+  }
+  .card:hover { border-color: rgba(99,102,241,0.4); transform: translateY(-2px); }
+  .card h3 {
+    font-size: 1rem; font-weight: 700; margin-bottom: 0.5rem;
+    display: flex; align-items: center; gap: 0.5rem;
+  }
+  .card p, .card li { font-size: 0.88rem; color: var(--text2); line-height: 1.7; }
+  .card ul { padding-left: 1.1rem; margin-top: 0.4rem; }
+  .card .dot {
+    width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
+  }
+
+  /* ── Layer diagram ── */
+  .layers {
+    display: flex; flex-direction: column; gap: 0.6rem; margin: 1.5rem 0;
+  }
+  .layer {
+    display: grid; grid-template-columns: 140px 1fr;
+    gap: 1rem; align-items: stretch;
+    background: var(--bg2); border: 1px solid var(--border2);
+    border-radius: 12px; overflow: hidden;
+  }
+  .layer-label {
+    display: flex; flex-direction: column; justify-content: center;
+    align-items: center; padding: 1rem 0.75rem;
+    font-weight: 700; font-size: 0.78rem; text-align: center;
+    letter-spacing: 0.03em; color: #fff;
+  }
+  .layer-body {
+    padding: 1rem 1.2rem; display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center;
+  }
+  .chip {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem; padding: 0.3rem 0.65rem;
+    border-radius: 6px; background: var(--bg3);
+    border: 1px solid var(--border2); color: var(--text);
+  }
+  .chip.hot { border-color: rgba(251,113,133,0.4); color: var(--rose); }
+  .chip.cold { border-color: rgba(56,189,248,0.4); color: var(--sky); }
+  .chip.meta { border-color: rgba(251,191,36,0.4); color: var(--amber); }
+  .chip.live { border-color: rgba(52,211,153,0.4); color: var(--green); }
+
+  /* ── Flow ── */
+  .flow {
+    display: flex; flex-wrap: wrap; align-items: center; justify-content: center;
+    gap: 0.5rem; margin: 1.5rem 0; padding: 1.5rem;
+    background: var(--bg2); border: 1px solid var(--border2); border-radius: 14px;
+  }
+  .flow-node {
+    background: var(--bg3); border: 1px solid var(--border);
+    border-radius: 10px; padding: 0.7rem 1rem; text-align: center;
+    min-width: 110px;
+  }
+  .flow-node .fn-title {
+    font-size: 0.78rem; font-weight: 700; margin-bottom: 0.15rem;
+  }
+  .flow-node .fn-sub {
+    font-size: 0.65rem; color: var(--text3); font-family: 'JetBrains Mono', monospace;
+  }
+  .flow-arrow {
+    color: var(--accent3); font-size: 1.2rem; font-weight: 700;
+  }
+
+  /* ── Tree viz ── */
+  .tree-viz {
+    background: var(--bg2); border: 1px solid var(--border2);
+    border-radius: 14px; padding: 1.5rem; font-family: 'JetBrains Mono', monospace;
+    font-size: 0.78rem; overflow-x: auto; line-height: 1.9;
+  }
+  .tree-viz .t-header { color: var(--amber); }
+  .tree-viz .t-msg { color: var(--sky); }
+  .tree-viz .t-asst { color: var(--green); }
+  .tree-viz .t-tool { color: var(--orange); }
+  .tree-viz .t-comp { color: var(--rose); }
+  .tree-viz .t-custom { color: var(--accent3); }
+  .tree-viz .t-branch { color: var(--text3); }
+  .tree-viz .t-active { background: rgba(34,211,238,0.12); border-radius: 4px; padding: 0 4px; }
+  .tree-viz .t-dim { color: var(--text3); opacity: 0.55; }
+
+  /* ── Table ── */
+  .data-table {
+    width: 100%; border-collapse: collapse; font-size: 0.85rem;
+    margin: 1rem 0 1.5rem;
+  }
+  .data-table th {
+    text-align: left; padding: 0.7rem 0.9rem;
+    background: var(--bg3); color: var(--text2); font-weight: 600;
+    border-bottom: 1px solid var(--border); font-size: 0.78rem;
+  }
+  .data-table td {
+    padding: 0.65rem 0.9rem; border-bottom: 1px solid var(--border2);
+    color: var(--text2); vertical-align: top;
+  }
+  .data-table tr:hover td { background: rgba(99,102,241,0.05); }
+  .data-table code {
+    font-family: 'JetBrains Mono', monospace; font-size: 0.78rem;
+    color: var(--cyan); background: rgba(34,211,238,0.08);
+    padding: 0.1rem 0.35rem; border-radius: 4px;
+  }
+
+  /* ── Callout ── */
+  .callout {
+    border-left: 3px solid var(--accent);
+    background: rgba(99,102,241,0.08);
+    border-radius: 0 10px 10px 0;
+    padding: 1rem 1.2rem; margin: 1.2rem 0;
+    font-size: 0.9rem; color: var(--text2);
+  }
+  .callout.warn { border-left-color: var(--amber); background: rgba(251,191,36,0.08); }
+  .callout.danger { border-left-color: var(--rose); background: rgba(251,113,133,0.08); }
+  .callout.ok { border-left-color: var(--green); background: rgba(52,211,153,0.08); }
+  .callout strong { color: var(--text); }
+
+  /* ── Code block ── */
+  pre.code {
+    background: #0d1220; border: 1px solid var(--border2);
+    border-radius: 10px; padding: 1rem 1.2rem;
+    overflow-x: auto; font-family: 'JetBrains Mono', monospace;
+    font-size: 0.75rem; line-height: 1.65; color: var(--text2);
+    margin: 1rem 0;
+  }
+  pre.code .k { color: var(--accent3); }
+  pre.code .s { color: var(--green); }
+  pre.code .c { color: var(--text3); }
+  pre.code .n { color: var(--amber); }
+
+  /* ── Timeline ── */
+  .timeline { position: relative; padding-left: 1.8rem; margin: 1.2rem 0; }
+  .timeline::before {
+    content: ''; position: absolute; left: 6px; top: 4px; bottom: 4px;
+    width: 2px; background: linear-gradient(to bottom, var(--cyan), var(--accent2), var(--rose));
+  }
+  .tl-item { position: relative; margin-bottom: 1.4rem; }
+  .tl-item::before {
+    content: ''; position: absolute; left: -1.55rem; top: 0.45rem;
+    width: 10px; height: 10px; border-radius: 50%;
+    background: var(--cyan); border: 2px solid var(--bg);
+    box-shadow: 0 0 0 2px var(--cyan);
+  }
+  .tl-item h4 { font-size: 0.95rem; font-weight: 700; margin-bottom: 0.3rem; }
+  .tl-item p { font-size: 0.85rem; color: var(--text2); }
+
+  /* ── Improvement cards ── */
+  .improve {
+    display: grid; grid-template-columns: auto 1fr; gap: 0.8rem 1rem;
+    align-items: start; padding: 1rem 0;
+    border-bottom: 1px solid var(--border2);
+  }
+  .improve:last-child { border-bottom: none; }
+  .prio {
+    font-family: 'JetBrains Mono', monospace; font-size: 0.68rem;
+    font-weight: 700; padding: 0.25rem 0.55rem; border-radius: 5px;
+    white-space: nowrap;
+  }
+  .prio.p0 { background: rgba(251,113,133,0.15); color: var(--rose); }
+  .prio.p1 { background: rgba(251,191,36,0.15); color: var(--amber); }
+  .prio.p2 { background: rgba(56,189,248,0.15); color: var(--sky); }
+  .prio.p3 { background: rgba(148,163,184,0.12); color: var(--text3); }
+
+  /* ── SVG diagrams ── */
+  .svg-wrap {
+    background: var(--bg2); border: 1px solid var(--border2);
+    border-radius: 14px; padding: 1.5rem; margin: 1.2rem 0;
+    overflow-x: auto;
+  }
+  .svg-wrap svg { display: block; margin: 0 auto; max-width: 100%; height: auto; }
+
+  /* ── Dual path ── */
+  .dual {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin: 1.2rem 0;
+  }
+  @media (max-width: 720px) {
+    .dual { grid-template-columns: 1fr; }
+    .layer { grid-template-columns: 1fr; }
+    .layer-label { padding: 0.6rem; flex-direction: row; gap: 0.5rem; }
+  }
+  .dual-col {
+    background: var(--bg2); border: 1px solid var(--border2);
+    border-radius: 14px; padding: 1.3rem;
+  }
+  .dual-col h3 {
+    font-size: 0.95rem; margin-bottom: 0.8rem;
+    display: flex; align-items: center; gap: 0.5rem;
+  }
+  .dual-col .badge {
+    font-size: 0.65rem; font-family: 'JetBrains Mono', monospace;
+    padding: 0.15rem 0.45rem; border-radius: 4px;
+  }
+  .badge.hot-b { background: rgba(251,113,133,0.15); color: var(--rose); }
+  .badge.cold-b { background: rgba(56,189,248,0.15); color: var(--sky); }
+
+  h2.sub { font-size: 1.25rem; font-weight: 700; margin: 2rem 0 0.8rem; }
+  h3.sub { font-size: 1.05rem; font-weight: 700; margin: 1.5rem 0 0.6rem; }
+
+  footer {
+    text-align: center; padding: 2.5rem 1rem 3rem;
+    color: var(--text3); font-size: 0.8rem; border-top: 1px solid var(--border2);
+  }
+  footer a { color: var(--accent3); text-decoration: none; }
+
+  .file-ref {
+    font-family: 'JetBrains Mono', monospace; font-size: 0.72rem;
+    color: var(--accent3); background: rgba(139,92,246,0.1);
+    padding: 0.1rem 0.4rem; border-radius: 4px;
+  }
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="logo">🧠 Memory Architecture</div>
+  <div class="links">
+    <a href="#hero">总览</a>
+    <a href="#layers">三层模型</a>
+    <a href="#jsonl">JSONL 格式</a>
+    <a href="#paths">读写路径</a>
+    <a href="#tree">树与分支</a>
+    <a href="#compact">压缩</a>
+    <a href="#runtime">运行时</a>
+    <a href="#client">客户端</a>
+    <a href="#map">符号地图</a>
+    <a href="#gaps">改进空间</a>
+    <a href="#ltm">长期记忆 LTM</a>
+  </div>
+</nav>
+
+<!-- ════════════ HERO ════════════ -->
+<section id="hero">
+  <div class="glow"></div>
+  <div class="section-inner">
+    <div class="hero-badge">CodeGraph 深度探索 · 2026-08-03</div>
+    <h1 class="hero-title">Pi Agent<br><span>记忆架构深度解析</span></h1>
+    <p class="hero-sub">
+      本文件基于 CodeGraph 对 <code>session-reader</code>、<code>rpc-manager</code>、
+      <code>types</code>、<code>agent-mode-persistence</code> 与客户端 hooks 的源码级分析，
+      刻画当前「会话即记忆」体系的完整数据流，为后续长期记忆改进提供基线。
+    </p>
+    <div class="hero-stats">
+      <div class="stat-card"><div class="num">3</div><div class="label">记忆层级</div></div>
+      <div class="stat-card"><div class="num">9</div><div class="label">Entry 类型</div></div>
+      <div class="stat-card"><div class="num">2</div><div class="label">分支机制</div></div>
+      <div class="stat-card"><div class="num">5</div><div class="label">globalThis 状态</div></div>
+      <div class="stat-card"><div class="num">0</div><div class="label">跨会话语义记忆</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- ════════════ LAYERS ════════════ -->
+<section id="layers">
+  <div class="section-inner">
+    <div class="section-tag">01 · Architecture</div>
+    <h2 class="section-title">三层记忆模型</h2>
+    <p class="section-desc">
+      当前系统没有独立的「Memory Service」。记忆 = 会话历史，以 append-only JSONL 为真理源，
+      进程内 AgentSession 为热缓存，浏览器 React state 为展示层。三者通过不同 API 路径同步。
+    </p>
+
+    <div class="layers">
+      <div class="layer">
+        <div class="layer-label" style="background:linear-gradient(160deg,#0e7490,#164e63)">
+          L3 展示层<br><span style="font-weight:400;font-size:0.65rem;opacity:0.85">Ephemeral UI</span>
+        </div>
+        <div class="layer-body">
+          <span class="chip live">messages[]</span>
+          <span class="chip live">entryIds[]</span>
+          <span class="chip live">streamingMessage</span>
+          <span class="chip live">activeLeafId</span>
+          <span class="chip live">tree</span>
+          <span class="chip">useAgentSession</span>
+          <span class="chip">agent-event-apply</span>
+        </div>
+      </div>
+      <div class="layer">
+        <div class="layer-label" style="background:linear-gradient(160deg,#6d28d9,#4c1d95)">
+          L2 运行时<br><span style="font-weight:400;font-size:0.65rem;opacity:0.85">Process Memory</span>
+        </div>
+        <div class="layer-body">
+          <span class="chip hot">__piSessions</span>
+          <span class="chip hot">AgentSessionWrapper</span>
+          <span class="chip hot">SessionManager (Pi)</span>
+          <span class="chip meta">__piSessionPathCache</span>
+          <span class="chip meta">__piStartLocks</span>
+          <span class="chip meta">__piWriteLocks</span>
+          <span class="chip">10min idle destroy</span>
+        </div>
+      </div>
+      <div class="layer">
+        <div class="layer-label" style="background:linear-gradient(160deg,#1e3a5f,#0f172a)">
+          L1 持久层<br><span style="font-weight:400;font-size:0.65rem;opacity:0.85">Disk Truth</span>
+        </div>
+        <div class="layer-body">
+          <span class="chip cold">~/.pi/agent/sessions/</span>
+          <span class="chip cold">&lt;encoded-cwd&gt;/</span>
+          <span class="chip cold">&lt;ts&gt;_&lt;uuid&gt;.jsonl</span>
+          <span class="chip cold">SessionHeader</span>
+          <span class="chip cold">SessionEntry tree</span>
+          <span class="chip">parentSession 链接</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="callout">
+      <strong>核心洞察：</strong>L1 是唯一权威源。L2 由 <code>startRpcSession</code> 从 JSONL hydrate；
+      L3 由只读 <code>/api/sessions/*</code> 或 SSE 事件增量构建。热路径写 L2→L1，冷路径只读 L1。
+    </div>
+
+    <div class="svg-wrap">
+      <svg viewBox="0 0 920 340" xmlns="http://www.w3.org/2000/svg" font-family="Inter,sans-serif">
+        <!-- Browser -->
+        <rect x="40" y="30" width="200" height="100" rx="12" fill="#1a2235" stroke="#38bdf8" stroke-width="1.5"/>
+        <text x="140" y="60" text-anchor="middle" fill="#38bdf8" font-size="12" font-weight="700">Browser UI</text>
+        <text x="140" y="82" text-anchor="middle" fill="#94a3b8" font-size="10">messages / entryIds</text>
+        <text x="140" y="100" text-anchor="middle" fill="#64748b" font-size="9">SSE · fetch context</text>
+
+        <!-- Next.js -->
+        <rect x="340" y="20" width="240" height="120" rx="12" fill="#1a2235" stroke="#8b5cf6" stroke-width="1.5"/>
+        <text x="460" y="48" text-anchor="middle" fill="#a78bfa" font-size="12" font-weight="700">Next.js Server</text>
+        <text x="460" y="70" text-anchor="middle" fill="#94a3b8" font-size="10">rpc-manager · session-reader</text>
+        <text x="460" y="90" text-anchor="middle" fill="#64748b" font-size="9">globalThis 注册表 / 路径缓存</text>
+        <text x="460" y="110" text-anchor="middle" fill="#64748b" font-size="9">AgentSessionWrapper</text>
+
+        <!-- Pi SDK -->
+        <rect x="680" y="30" width="200" height="100" rx="12" fill="#1a2235" stroke="#34d399" stroke-width="1.5"/>
+        <text x="780" y="60" text-anchor="middle" fill="#34d399" font-size="12" font-weight="700">Pi Coding Agent</text>
+        <text x="780" y="82" text-anchor="middle" fill="#94a3b8" font-size="10">SessionManager</text>
+        <text x="780" y="100" text-anchor="middle" fill="#64748b" font-size="9">createAgentSession</text>
+
+        <!-- Disk -->
+        <rect x="240" y="220" width="440" height="90" rx="12" fill="#111827" stroke="#fbbf24" stroke-width="1.5"/>
+        <text x="460" y="250" text-anchor="middle" fill="#fbbf24" font-size="12" font-weight="700">Disk · JSONL Sessions</text>
+        <text x="460" y="272" text-anchor="middle" fill="#94a3b8" font-size="10">~/.pi/agent/sessions/&lt;encoded-cwd&gt;/&lt;ts&gt;_&lt;uuid&gt;.jsonl</text>
+        <text x="460" y="292" text-anchor="middle" fill="#64748b" font-size="9">append-only · parentId tree · parentSession graph</text>
+
+        <!-- Arrows -->
+        <defs>
+          <marker id="arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+            <path d="M0,0 L6,3 L0,6" fill="none" stroke="#64748b" stroke-width="1.2"/>
+          </marker>
+        </defs>
+        <line x1="240" y1="80" x2="340" y2="80" stroke="#64748b" stroke-width="1.5" marker-end="url(#arr)"/>
+        <text x="290" y="70" text-anchor="middle" fill="#64748b" font-size="8">HTTP / SSE</text>
+        <line x1="580" y1="80" x2="680" y2="80" stroke="#64748b" stroke-width="1.5" marker-end="url(#arr)"/>
+        <text x="630" y="70" text-anchor="middle" fill="#64748b" font-size="8">in-process</text>
+        <line x1="460" y1="140" x2="460" y2="220" stroke="#fbbf24" stroke-width="1.5" marker-end="url(#arr)"/>
+        <text x="480" y="185" fill="#fbbf24" font-size="8">read / append</text>
+        <path d="M140 130 L140 265 Q140 280 160 280 L240 280" fill="none" stroke="#38bdf8" stroke-width="1.2" stroke-dasharray="4 3" marker-end="url(#arr)"/>
+        <text x="165" y="200" fill="#38bdf8" font-size="8">cold read</text>
+        <text x="165" y="212" fill="#38bdf8" font-size="8">(no session)</text>
+      </svg>
+    </div>
+  </div>
+</section>
+
+<!-- ════════════ JSONL ════════════ -->
+<section id="jsonl">
+  <div class="section-inner">
+    <div class="section-tag">02 · Schema</div>
+    <h2 class="section-title">JSONL 会话格式 = 记忆 schema</h2>
+    <p class="section-desc">
+      每个会话一个文件。第一行是 header，之后每一行是带 <code>parentId</code> 的树节点。
+      类型定义镜像自 Pi mono 的 session-manager，本地见 <span class="file-ref">lib/types.ts</span>。
+    </p>
+
+    <h3 class="sub">Header（第一行）</h3>
+    <pre class="code">{
+  <span class="k">"type"</span>: <span class="s">"session"</span>,
+  <span class="k">"version"</span>: <span class="n">3</span>,
+  <span class="k">"id"</span>: <span class="s">"&lt;uuid&gt;"</span>,
+  <span class="k">"timestamp"</span>: <span class="s">"..."</span>,
+  <span class="k">"cwd"</span>: <span class="s">"/path/to/project"</span>,
+  <span class="k">"parentSession"</span>: <span class="s">"/abs/path/parent.jsonl"</span>,  <span class="c">// optional — Fork 元数据</span>
+  <span class="k">"name"</span>: <span class="s">"optional display name"</span>
+}</pre>
+
+    <h3 class="sub">Entry 类型一览</h3>
+    <table class="data-table">
+      <thead>
+        <tr><th>type</th><th>作用</th><th>是否进入 LLM 上下文</th><th>备注</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>message</code></td>
+          <td>user / assistant / toolResult</td>
+          <td>是（沿 leaf 路径）</td>
+          <td>记忆主体</td>
+        </tr>
+        <tr>
+          <td><code>compaction</code></td>
+          <td>历史摘要节点</td>
+          <td>是（summary 替代前段）</td>
+          <td><code>firstKeptEntryId</code> 划界</td>
+        </tr>
+        <tr>
+          <td><code>model_change</code></td>
+          <td>切换模型</td>
+          <td>否（元数据）</td>
+          <td>影响后续请求</td>
+        </tr>
+        <tr>
+          <td><code>thinking_level_change</code></td>
+          <td>思考等级</td>
+          <td>否</td>
+          <td>持久化到路径状态</td>
+        </tr>
+        <tr>
+          <td><code>custom</code></td>
+          <td>扩展数据</td>
+          <td>否（默认）</td>
+          <td>Desktop 用 <code>desktop_agent_mode</code></td>
+        </tr>
+        <tr>
+          <td><code>custom_message</code></td>
+          <td>可显示自定义消息</td>
+          <td>视 display</td>
+          <td>UI 提示类</td>
+        </tr>
+        <tr>
+          <td><code>branch_summary</code></td>
+          <td>分支切换摘要</td>
+          <td>可能注入</td>
+          <td>Pi navigateTree 相关</td>
+        </tr>
+        <tr>
+          <td><code>label</code></td>
+          <td>节点标签</td>
+          <td>否</td>
+          <td>UI 标注</td>
+        </tr>
+        <tr>
+          <td><code>session_info</code></td>
+          <td>会话名称等</td>
+          <td>否</td>
+          <td>侧边栏展示</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="callout ok">
+      <strong>唯一的 Desktop 自定义记忆字段：</strong>
+      <code>customType: "desktop_agent_mode"</code> + <code>data: { mode: "plan"|"ask"|"full" }</code>。
+      切换模式时 <code>sessionManager.appendCustomEntry(...)</code> 追加；启动时
+      <code>findLastAgentMode(entries)</code> 自后向前扫描恢复。
+      见 <span class="file-ref">lib/agent-mode-persistence.ts</span>、
+      <span class="file-ref">lib/rpc-manager.ts</span>。
+    </div>
+  </div>
+</section>
+
+<!-- ════════════ PATHS ════════════ -->
+<section id="paths">
+  <div class="section-inner">
+    <div class="section-tag">03 · Data Paths</div>
+    <h2 class="section-title">双路径：热写 vs 冷读</h2>
+    <p class="section-desc">
+      架构刻意分离「运行 Agent」与「浏览历史」。冷读永不创建 AgentSession，避免资源浪费与副作用。
+    </p>
+
+    <div class="dual">
+      <div class="dual-col">
+        <h3><span class="badge hot-b">HOT</span> 写入 / 执行路径</h3>
+        <div class="timeline">
+          <div class="tl-item">
+            <h4>UI 发送</h4>
+            <p><code>handleSend</code> → 乐观追加 user 消息 → <code>POST /api/agent/[id]</code> 或 <code>/api/agent/new</code></p>
+          </div>
+          <div class="tl-item">
+            <h4>启动 / 复用 Session</h4>
+            <p><code>startRpcSession</code> 查 <code>__piSessions</code>；miss 则
+            <code>SessionManager.open|create</code> + <code>createAgentSession</code></p>
+          </div>
+          <div class="tl-item">
+            <h4>Pi 执行 + 落盘</h4>
+            <p><code>inner.prompt()</code> 驱动模型与工具；SessionManager 向 JSONL append message / toolResult</p>
+          </div>
+          <div class="tl-item">
+            <h4>SSE 推送</h4>
+            <p><code>GET /api/agent/[id]/events</code> → <code>applyAgentEvent</code> 更新 L3</p>
+          </div>
+          <div class="tl-item">
+            <h4>回合结束</h4>
+            <p><code>agent_end</code> 触发 <code>reloadSession</code>，从磁盘重同步 tree + messages</p>
+          </div>
+        </div>
+      </div>
+      <div class="dual-col">
+        <h3><span class="badge cold-b">COLD</span> 只读路径</h3>
+        <div class="timeline">
+          <div class="tl-item">
+            <h4>列表</h4>
+            <p><code>SessionManager.listAll()</code> → <code>listAllSessions</code> 填充路径缓存 + parent 映射</p>
+          </div>
+          <div class="tl-item">
+            <h4>解析路径</h4>
+            <p><code>resolveSessionPath(id)</code>：正缓存 hit / 负缓存 30s TTL / miss 则全量扫描</p>
+          </div>
+          <div class="tl-item">
+            <h4>加载会话</h4>
+            <p>读 JSONL → <code>buildTree</code> + <code>buildSessionContext(leafId)</code></p>
+          </div>
+          <div class="tl-item">
+            <h4>分支上下文</h4>
+            <p><code>GET .../context?leafId=</code> 仅重算 path→messages，不启动 Agent</p>
+          </div>
+          <div class="tl-item">
+            <h4>导出</h4>
+            <p><code>session-export</code> 流式/静态输出 HTML 或 Markdown</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <h3 class="sub">上下文重建算法（buildSessionContext）</h3>
+    <div class="flow">
+      <div class="flow-node">
+        <div class="fn-title">定位 leaf</div>
+        <div class="fn-sub">leafId | last entry</div>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-node">
+        <div class="fn-title">向上 walk</div>
+        <div class="fn-sub">parentId → root</div>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-node">
+        <div class="fn-title">找 compaction</div>
+        <div class="fn-sub">路径上最后一次</div>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-node">
+        <div class="fn-title">裁切 + 拼装</div>
+        <div class="fn-sub">summary + kept + after</div>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-node">
+        <div class="fn-title">归一化</div>
+        <div class="fn-sub">toolCall 字段</div>
+      </div>
+    </div>
+
+    <div class="callout">
+      <strong>entryIds[] 平行数组：</strong>与 <code>messages[]</code> 一一对应，把 UI 消息映射回 JSONL entry id，
+      是 Fork 按钮与 navigate_tree 的桥梁。Compaction 后第一条 message 的 entryId 指向 compaction 节点本身。
+    </div>
+  </div>
+</section>
+
+<!-- ════════════ TREE ════════════ -->
+<section id="tree">
+  <div class="section-inner">
+    <div class="section-tag">04 · Branching</div>
+    <h2 class="section-title">两种分支 = 两种记忆分裂策略</h2>
+    <p class="section-desc">
+      这是记忆系统最容易混淆的部分：同文件树分叉 vs 跨文件 Fork。侧边栏树用 <code>parentSession</code> 展示后者。
+    </p>
+
+    <div class="grid-2">
+      <div class="card">
+        <h3><span class="dot" style="background:var(--cyan)"></span>会话内分支（In-file）</h3>
+        <ul>
+          <li>同一 <code>.jsonl</code> 内通过 <code>parentId</code> 形成树</li>
+          <li>命令：<code>navigate_tree</code> → <code>inner.navigateTree(targetId)</code></li>
+          <li>UI：BranchNavigator；上下文：<code>?leafId=</code></li>
+          <li>记忆共享同一文件，仅「当前活跃路径」不同</li>
+          <li>切换后 <code>loadContext</code> 重绘 messages</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3><span class="dot" style="background:var(--rose)"></span>Fork / Branch（Cross-file）</h3>
+        <ul>
+          <li>新 JSONL；header 写 <code>parentSession</code></li>
+          <li>Agent 路径：<code>send({type:"fork", entryId})</code></li>
+          <li>API 路径：<code>POST .../branch</code>、<code>.../clone</code></li>
+          <li>Fork 点前历史拷贝；之后独立演化</li>
+          <li>顺序：建文件 → <code>startRpcSession</code> 预注册 → <code>destroy</code> 旧 wrapper</li>
+        </ul>
+      </div>
+    </div>
+
+    <h3 class="sub">同文件树示意（活跃路径高亮）</h3>
+    <div class="tree-viz">
+<span class="t-header">session header  id=S1  cwd=./proj</span>
+│
+├─ <span class="t-msg">[m1] message user: "修登录 bug"</span>
+│  └─ <span class="t-asst">[m2] message assistant + toolCall</span>
+│     └─ <span class="t-tool">[m3] toolResult</span>
+│        └─ <span class="t-asst">[m4] message assistant</span>
+│           ├─ <span class="t-msg t-active">[m5] message user: "换种方案"  ← leaf A</span>
+│           │  └─ <span class="t-asst t-active">[m6] assistant ...</span>
+│           └─ <span class="t-msg t-dim">[m7] message user: "继续原方案"  ← leaf B (inactive)</span>
+│              └─ <span class="t-asst t-dim">[m8] assistant ...</span>
+│
+└─ <span class="t-custom">[c1] custom desktop_agent_mode { mode: "ask" }</span>
+    </div>
+
+    <h3 class="sub">跨文件 Fork 后的会话图</h3>
+    <div class="tree-viz">
+<span class="t-header">S1.jsonl</span>  ──parentSession──▶  <span class="t-header">S2.jsonl</span>  (forked at m4)
+  full tree m1…m8                        copy of path → m4, then new growth
+                                           leaf starts after fork point
+
+<span class="t-branch">// 删除 S1 时 session-cascade 把 S2.parentSession 重写到 S1 的祖父（或移除）</span>
+    </div>
+
+    <div class="callout warn">
+      <strong>Fork 契约陷阱：</strong>必须先 <code>startRpcSession(newId)</code> 成功预注册，再 destroy 旧 wrapper。
+      若预注册失败：旧会话保持可用，删除孤儿 JSONL + invalidate 路径缓存。
+      详见 <span class="file-ref">lib/rpc-manager.ts</span> case <code>"fork"</code>。
+    </div>
+  </div>
+</section>
+
+<!-- ════════════ COMPACT ════════════ -->
+<section id="compact">
+  <div class="section-inner">
+    <div class="section-tag">05 · Compaction</div>
+    <h2 class="section-title">压缩：唯一的「遗忘」机制</h2>
+    <p class="section-desc">
+      没有外部向量库或事实抽取。当上下文逼近窗口时，Pi 用 LLM 把前段历史压成 summary entry，
+      这是系统目前<strong>唯一有损的记忆变换</strong>。
+    </p>
+
+    <div class="svg-wrap">
+      <svg viewBox="0 0 880 200" xmlns="http://www.w3.org/2000/svg" font-family="Inter,sans-serif">
+        <!-- Before -->
+        <text x="20" y="28" fill="#94a3b8" font-size="11" font-weight="600">压缩前（路径上的 entries）</text>
+        <rect x="20" y="45" width="70" height="36" rx="6" fill="#1a2235" stroke="#38bdf8"/>
+        <text x="55" y="67" text-anchor="middle" fill="#38bdf8" font-size="10">m1..mN</text>
+        <text x="100" y="67" fill="#64748b" font-size="16">→</text>
+        <rect x="120" y="45" width="90" height="36" rx="6" fill="#1a2235" stroke="#fb7185"/>
+        <text x="165" y="67" text-anchor="middle" fill="#fb7185" font-size="10">to summarize</text>
+        <text x="220" y="67" fill="#64748b" font-size="16">→</text>
+        <rect x="240" y="45" width="100" height="36" rx="6" fill="#1a2235" stroke="#34d399"/>
+        <text x="290" y="67" text-anchor="middle" fill="#34d399" font-size="10">keep recent</text>
+        <text x="350" y="67" fill="#64748b" font-size="16">→</text>
+        <rect x="370" y="45" width="50" height="36" rx="6" fill="#1a2235" stroke="#fbbf24"/>
+        <text x="395" y="67" text-anchor="middle" fill="#fbbf24" font-size="10">leaf</text>
+
+        <!-- After -->
+        <text x="20" y="120" fill="#94a3b8" font-size="11" font-weight="600">压缩后（上下文视图）</text>
+        <rect x="20" y="137" width="140" height="40" rx="6" fill="#2a1520" stroke="#fb7185" stroke-width="1.5"/>
+        <text x="90" y="155" text-anchor="middle" fill="#fb7185" font-size="10" font-weight="600">compaction</text>
+        <text x="90" y="168" text-anchor="middle" fill="#94a3b8" font-size="8">summary + firstKeptEntryId</text>
+        <text x="170" y="160" fill="#64748b" font-size="16">→</text>
+        <rect x="190" y="137" width="100" height="40" rx="6" fill="#1a2235" stroke="#34d399"/>
+        <text x="240" y="161" text-anchor="middle" fill="#34d399" font-size="10">kept messages</text>
+        <text x="300" y="160" fill="#64748b" font-size="16">→</text>
+        <rect x="320" y="137" width="80" height="40" rx="6" fill="#1a2235" stroke="#fbbf24"/>
+        <text x="360" y="161" text-anchor="middle" fill="#fbbf24" font-size="10">new turns</text>
+
+        <!-- note -->
+        <rect x="480" y="40" width="370" height="140" rx="10" fill="#111827" stroke="rgba(148,163,184,0.15)"/>
+        <text x="500" y="70" fill="#a78bfa" font-size="11" font-weight="700">Desktop 防护</text>
+        <text x="500" y="95" fill="#94a3b8" font-size="10">findCutPoint 预检：history 太短则</text>
+        <text x="500" y="112" fill="#94a3b8" font-size="10">抛 "Conversation too short to compact"</text>
+        <text x="500" y="138" fill="#94a3b8" font-size="10">UI：/compact 或 handleCompact</text>
+        <text x="500" y="155" fill="#94a3b8" font-size="10">事件：compaction_start/end（兼容 auto_*）</text>
+        <text x="500" y="172" fill="#64748b" font-size="9">成功后 reloadSession 从磁盘重载</text>
+      </svg>
+    </div>
+
+    <div class="callout danger">
+      <strong>改进记忆时必须注意：</strong>压缩是路径局部、有损的。原始 message 仍在 JSONL 文件中（append-only），
+      但 <code>buildSessionContext</code> 对 LLM/UI 可见的上下文会用 summary 替换前段。
+      任何「长期记忆抽取」若只看 context 视图会丢失细节——应读完整 entries 或在 compact 前抽取。
+    </div>
+  </div>
+</section>
+
+<!-- ════════════ RUNTIME ════════════ -->
+<section id="runtime">
+  <div class="section-inner">
+    <div class="section-tag">06 · Runtime State</div>
+    <h2 class="section-title">进程内记忆与并发控制</h2>
+    <p class="section-desc">
+      Next.js HMR 会丢掉模块级变量，因此会话相关状态必须挂在 <code>globalThis</code>。
+      这些不是「业务记忆」，而是记忆系统的运行时索引与锁。
+    </p>
+
+    <table class="data-table">
+      <thead>
+        <tr><th>globalThis 键</th><th>结构</th><th>用途</th><th>生命周期</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>__piSessions</code></td>
+          <td>Map&lt;id, Wrapper&gt;</td>
+          <td>活跃 Agent 热缓存</td>
+          <td>destroy / 空闲 10min / process exit</td>
+        </tr>
+        <tr>
+          <td><code>__piSessionPathCacheState</code></td>
+          <td>paths + misses</td>
+          <td>id → 文件路径；负缓存 30s</td>
+          <td>list 填充；DELETE/fork 失败 invalidate</td>
+        </tr>
+        <tr>
+          <td><code>__piStartLocks</code></td>
+          <td>Map&lt;id, Promise&gt;</td>
+          <td>并发 start 去重</td>
+          <td>start finally 删除</td>
+        </tr>
+        <tr>
+          <td><code>__piWriteLocks</code></td>
+          <td>Map&lt;path, Promise&gt;</td>
+          <td>per-file 写入串行化</td>
+          <td>withFileLock finally</td>
+        </tr>
+        <tr>
+          <td><code>__piAllowedRootsCache</code></td>
+          <td>{roots, expiresAt}</td>
+          <td>文件白名单（安全边界）</td>
+          <td>5s TTL</td>
+        </tr>
+        <tr>
+          <td><code>__piSessionOnlyTrust</code></td>
+          <td>Map&lt;id, bool&gt;</td>
+          <td>会话级信任标记</td>
+          <td>信任握手相关</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 class="sub">Session 生命周期（记忆热度）</h3>
+    <div class="flow">
+      <div class="flow-node">
+        <div class="fn-title">Cold</div>
+        <div class="fn-sub">仅磁盘 JSONL</div>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-node">
+        <div class="fn-title">Hydrate</div>
+        <div class="fn-sub">startRpcSession</div>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-node">
+        <div class="fn-title">Active</div>
+        <div class="fn-sub">prompt / events</div>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-node">
+        <div class="fn-title">Idle</div>
+        <div class="fn-sub">计时重置</div>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-node">
+        <div class="fn-title">Destroyed</div>
+        <div class="fn-sub">10min / fork</div>
+      </div>
+      <div class="flow-arrow">→</div>
+      <div class="flow-node">
+        <div class="fn-title">Cold</div>
+        <div class="fn-sub">磁盘仍在</div>
+      </div>
+    </div>
+
+    <div class="callout">
+      <strong>cascade 删除：</strong><span class="file-ref">lib/session-cascade.ts</span> 的
+      <code>rewriteChildHeader</code> 在删父会话时重写子会话 header 的 <code>parentSession</code>，
+      防止侧边栏出现悬挂父链接。这是会话图完整性的一部分。
+    </div>
+  </div>
+</section>
+
+<!-- ════════════ CLIENT ════════════ -->
+<section id="client">
+  <div class="section-inner">
+    <div class="section-tag">07 · Client Memory</div>
+    <h2 class="section-title">浏览器侧的瞬时记忆</h2>
+    <p class="section-desc">
+      L3 不持久化。切换 session 时用 <code>sessionScopedResetPatch()</code> 清空，防止串台。
+    </p>
+
+    <div class="grid-3">
+      <div class="card">
+        <h3><span class="dot" style="background:var(--sky)"></span>会话加载</h3>
+        <p><span class="file-ref">use-session-loader.ts</span></p>
+        <ul>
+          <li>data / tree / leafId</li>
+          <li>messages + entryIds</li>
+          <li>loadSession / loadContext</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3><span class="dot" style="background:var(--green)"></span>事件应用</h3>
+        <p><span class="file-ref">agent-event-apply.ts</span></p>
+        <ul>
+          <li>纯函数：event → patches</li>
+          <li>appendMessages / streamAction</li>
+          <li>reloadSession side effect</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3><span class="dot" style="background:var(--amber)"></span>流式状态</h3>
+        <p><span class="file-ref">stream-state.ts</span></p>
+        <ul>
+          <li>isStreaming</li>
+          <li>streamingMessage</li>
+          <li>start / update / end</li>
+        </ul>
+      </div>
+    </div>
+
+    <h3 class="sub">一轮对话中 L3 如何更新</h3>
+    <pre class="code"><span class="c">// 简化时序</span>
+handleSend:
+  setMessages(prev =&gt; [...prev, userMsg])     <span class="c">// 乐观更新</span>
+  dispatch({ type: <span class="s">"start"</span> })
+  sendAgentCommand(prompt)                     <span class="c">// 或 /api/agent/new</span>
+  connectEvents(sid)
+
+SSE message_update:
+  streamAction update → streamingMessage        <span class="c">// 打字机</span>
+
+SSE message_end:
+  appendMessages([completed])                   <span class="c">// 固化到 messages[]</span>
+  stream reset
+
+SSE agent_end:
+  reloadSession(sid)                            <span class="c">// 权威同步 tree/entryIds</span>
+  fetchAgentState</pre>
+  </div>
+</section>
+
+<!-- ════════════ MAP ════════════ -->
+<section id="map">
+  <div class="section-inner">
+    <div class="section-tag">08 · Symbol Map</div>
+    <h2 class="section-title">CodeGraph 符号与文件地图</h2>
+    <p class="section-desc">后续改记忆系统时，优先从这些入口切入。</p>
+
+    <table class="data-table">
+      <thead>
+        <tr><th>文件</th><th>关键符号</th><th>记忆职责</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><span class="file-ref">lib/types.ts</span></td>
+          <td>SessionHeader, SessionEntry*, SessionContext</td>
+          <td>记忆 schema 契约</td>
+        </tr>
+        <tr>
+          <td><span class="file-ref">lib/session-reader.ts</span></td>
+          <td>listAllSessions, buildTree, buildSessionContext, resolveSessionPath</td>
+          <td>冷读与上下文投影</td>
+        </tr>
+        <tr>
+          <td><span class="file-ref">lib/session-path-cache.ts</span></td>
+          <td>getCachedSessionPath, SESSION_MISS_TTL_MS</td>
+          <td>路径索引</td>
+        </tr>
+        <tr>
+          <td><span class="file-ref">lib/rpc-manager.ts</span></td>
+          <td>AgentSessionWrapper, startRpcSession, send(fork|compact|…)</td>
+          <td>热写、执行、Fork、压缩</td>
+        </tr>
+        <tr>
+          <td><span class="file-ref">lib/agent-mode-persistence.ts</span></td>
+          <td>findLastAgentMode, createAgentModeCustomEntry</td>
+          <td>自定义 entry 读写范例</td>
+        </tr>
+        <tr>
+          <td><span class="file-ref">lib/session-branch-clone.ts</span></td>
+          <td>extractAncestryPath, createBranchedHeader</td>
+          <td>跨文件分支/克隆纯函数</td>
+        </tr>
+        <tr>
+          <td><span class="file-ref">lib/session-cascade.ts</span></td>
+          <td>rewriteChildHeader</td>
+          <td>会话图维护</td>
+        </tr>
+        <tr>
+          <td><span class="file-ref">lib/session-lock.ts</span></td>
+          <td>withFileLock</td>
+          <td>并发写保护</td>
+        </tr>
+        <tr>
+          <td><span class="file-ref">lib/normalize.ts</span></td>
+          <td>normalizeToolCalls</td>
+          <td>SDK/UI 字段对齐</td>
+        </tr>
+        <tr>
+          <td><span class="file-ref">hooks/agent-session/*</span></td>
+          <td>useSessionLoader, applyAgentEvent, sessionScopedResetPatch</td>
+          <td>L3 状态机</td>
+        </tr>
+        <tr>
+          <td><span class="file-ref">@earendil-works/pi-coding-agent</span></td>
+          <td>SessionManager, createAgentSession, findCutPoint</td>
+          <td>真正的 append / compact / branch 实现</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="callout ok">
+      <strong>扩展记忆的推荐挂载点：</strong>
+      像 <code>desktop_agent_mode</code> 一样使用 <code>appendCustomEntry(customType, data)</code>
+      写入 JSONL，在 cold path 用 entry 扫描恢复——无需改 Pi 核心。
+      若要跨会话检索，需在 L1 之上新建索引层（见下一节）。
+    </div>
+  </div>
+</section>
+
+<!-- ════════════ GAPS ════════════ -->
+<section id="gaps">
+  <div class="section-inner">
+    <div class="section-tag">09 · Improvement Roadmap</div>
+    <h2 class="section-title">现状边界与改进铺垫</h2>
+    <p class="section-desc">
+      结论先行：今天的「记忆」= 单会话树状对话日志 + 可选有损压缩。
+      没有跨会话事实库、没有语义检索、没有用户偏好/项目知识的一等公民存储。
+    </p>
+
+    <h3 class="sub">已有能力（可复用）</h3>
+    <div class="grid-2">
+      <div class="card">
+        <h3>✅ 强项</h3>
+        <ul>
+          <li>Append-only 审计友好，易 fork/export</li>
+          <li>树 + compaction 兼顾探索与上下文预算</li>
+          <li>冷热分离，列表/历史零 Agent 开销</li>
+          <li>custom entry 扩展通道已验证</li>
+          <li>路径缓存 + 写锁 + 启动锁齐备</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>❌ 缺口</h3>
+        <ul>
+          <li>无跨会话 recall</li>
+          <li>无 embedding / hybrid search</li>
+          <li>compaction 细节不可自动「复活」到 prompt</li>
+          <li>无显式 fact / preference / decision 类型</li>
+          <li>无记忆治理（过期、删除审计、project scope）</li>
+          <li>无与 MCP 外部记忆服务的内置桥</li>
+        </ul>
+      </div>
+    </div>
+
+    <h3 class="sub">建议演进方向（按优先级）</h3>
+
+    <div class="improve">
+      <span class="prio p0">P0</span>
+      <div>
+        <strong>记忆类型分层设计文档</strong>
+        <p style="font-size:0.85rem;color:var(--text2);margin-top:0.3rem">
+          区分 Working（当前 context）、Episodic（会话 JSONL）、Semantic（可抽取事实）、
+          Procedural（skills/prefs）。先定义写入触发与读取注入点，再写代码。
+        </p>
+      </div>
+    </div>
+    <div class="improve">
+      <span class="prio p1">P1</span>
+      <div>
+        <strong>Custom Entry 扩展：显式记忆节点</strong>
+        <p style="font-size:0.85rem;color:var(--text2);margin-top:0.3rem">
+          仿 <code>desktop_agent_mode</code> 增加
+          <code>desktop_memory_note</code>（fact / preference / decision / architecture）。
+          写入：slash 命令或 agent 工具；读取：session 启动时注入 system 片段或独立 panel。
+          落点：<span class="file-ref">rpc-manager</span> append +
+          <span class="file-ref">session-reader</span> 扫描。
+        </p>
+      </div>
+    </div>
+    <div class="improve">
+      <span class="prio p1">P1</span>
+      <div>
+        <strong>Compact 前记忆抽取钩子</strong>
+        <p style="font-size:0.85rem;color:var(--text2);margin-top:0.3rem">
+          在 <code>case "compact"</code> 调 Pi compact 之前，对即将被摘要的路径跑抽取，
+          把结构化结果写入 custom entry 或外部 store，避免有损后不可恢复。
+        </p>
+      </div>
+    </div>
+    <div class="improve">
+      <span class="prio p2">P2</span>
+      <div>
+        <strong>项目级记忆索引（SQLite / JSONL sidecar）</strong>
+        <p style="font-size:0.85rem;color:var(--text2);margin-top:0.3rem">
+          按 cwd 聚合跨会话 notes，支持 keyword → 可选 embedding。
+          启动 session 时 <code>recall(cwd, query?)</code> 注入。
+          注意：不要污染 Pi 的 session JSONL 契约；用 sidecar 或 agentDir 下独立库。
+        </p>
+      </div>
+    </div>
+    <div class="improve">
+      <span class="prio p2">P2</span>
+      <div>
+        <strong>可选对接外部 Memory MCP</strong>
+        <p style="font-size:0.85rem;color:var(--text2);margin-top:0.3rem">
+          工具面：save / recall / smart_search。Desktop 提供开关与 project id 规范
+          （稳定 slug，禁止用易变路径）。与内置 sidecar 二选一或分层。
+        </p>
+      </div>
+    </div>
+    <div class="improve">
+      <span class="prio p3">P3</span>
+      <div>
+        <strong>记忆 UI：侧边栏 Memory 面板</strong>
+        <p style="font-size:0.85rem;color:var(--text2);margin-top:0.3rem">
+          浏览 / 编辑 / 删除笔记；展示来源 session 与 entry 链接；审计删除原因。
+        </p>
+      </div>
+    </div>
+
+    <h3 class="sub">改进时的硬约束（勿破坏）</h3>
+    <div class="grid-2">
+      <div class="card">
+        <h3>契约</h3>
+        <ul>
+          <li>JSONL 第一行必须是 session header</li>
+          <li>parentId 树不可出现环（branch 已有 visited 防护）</li>
+          <li>entryIds 与 messages 平行</li>
+          <li>Fork 预注册再 destroy</li>
+          <li>冷路径禁止创建 AgentSession</li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3>工程</h3>
+        <ul>
+          <li>globalThis 抗 HMR</li>
+          <li>写文件走 withFileLock</li>
+          <li>ToolCall 字段归一化两处（load + SSE）</li>
+          <li>compaction 事件新旧双名</li>
+          <li>测试优先覆盖纯函数（reader / cascade / branch）</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="callout ok">
+      <strong>设计已落地：</strong>跨会话长期记忆见下方
+      <a href="#ltm">§ LTM</a> 与
+      <a href="./superpowers/specs/2026-08-03-long-term-memory-design.md">2026-08-03-long-term-memory-design.md</a>。
+      本 HTML 仍是会话 JSONL 记忆基线；LTM 为旁路层，不改写 JSONL 契约。
+    </div>
+  </div>
+</section>
+
+<!-- ════════════ LTM ════════════ -->
+<section id="ltm">
+  <div class="section-inner">
+    <div class="section-tag">10 · Long-Term Memory</div>
+    <h2 class="section-title">长期记忆层（LTM）</h2>
+    <p class="section-desc">
+      在会话 JSONL（episodic）旁增加<strong>项目作用域</strong>的持久记忆层。
+      Phase 1 使用内置 SQLite；不修改 Pi 会话文件作为主存储。
+    </p>
+
+    <div class="grid-2">
+      <div class="card">
+        <h3><span class="dot" style="background:var(--green)"></span>代码与 API</h3>
+        <ul>
+          <li>实现：<span class="file-ref">lib/ltm/</span>（Service + MemoryBackend + SQLite）</li>
+          <li>HTTP：<code>/api/memory/*</code>（health / recall / remember / forget / stats）</li>
+          <li>Agent 工具：<code>memory_save</code> · <code>memory_recall</code> · <code>memory_forget</code></li>
+          <li>自动观察：<code>agent_end</code> + pre-compact（best-effort，不阻塞对话）</li>
+          <li>DB：<code>~/.pi/agent/memory/ltm.sqlite</code></li>
+        </ul>
+      </div>
+      <div class="card">
+        <h3><span class="dot" style="background:var(--accent2)"></span>设计与计划</h3>
+        <ul>
+          <li>
+            规格：
+            <a href="./superpowers/specs/2026-08-03-long-term-memory-design.md">
+              docs/superpowers/specs/2026-08-03-long-term-memory-design.md
+            </a>
+          </li>
+          <li>
+            实施计划：
+            <a href="./superpowers/plans/2026-08-03-long-term-memory.md">
+              docs/superpowers/plans/2026-08-03-long-term-memory.md
+            </a>
+          </li>
+          <li>v1：工具 + HTTP；无侧边栏 UI；不默认注入 system prompt</li>
+          <li>可插拔后端：SQLite（实现）/ agentmemory REST（stub）</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="callout">
+      <strong>与三层模型的关系：</strong>LTM 是 L1 旁的<strong>独立持久层</strong>（按 <code>projectId = hash(cwd)</code> 作用域），
+      不经 <code>SessionManager</code>。会话树、冷读、Fork/compact 契约保持不变；
+      模型仅通过 <code>memory_*</code> 工具显式读写。
+    </div>
+  </div>
+</section>
+
+<footer>
+  <p>Pi Agent Desktop · Memory Architecture</p>
+  <p style="margin-top:0.4rem">
+    基于 CodeGraph 源码分析 · 本地文件
+    <a href="./memory-architecture.html">docs/memory-architecture.html</a>
+    · 相关
+    <a href="./architecture.html">architecture.html</a>
+    ·
+    <a href="./ARCHITECTURE.md">ARCHITECTURE.md §8–9</a>
+    ·
+    <a href="./superpowers/specs/2026-08-03-long-term-memory-design.md">LTM 设计规格</a>
+  </p>
+  <p style="margin-top:0.6rem;opacity:0.6">生成日期 2026-08-03 · 不随代码自动更新，改记忆层后请人工校对</p>
+</footer>
+
+<script>
+  // Smooth active nav highlight
+  const links = document.querySelectorAll('nav .links a');
+  const sections = [...links].map(a => document.querySelector(a.getAttribute('href'))).filter(Boolean);
+  const io = new IntersectionObserver((entries) => {
+    entries.forEach(e => {
+      if (!e.isIntersecting) return;
+      links.forEach(l => l.style.color = '');
+      const id = '#' + e.target.id;
+      const active = document.querySelector(`nav .links a[href="${id}"]`);
+      if (active) active.style.color = 'var(--cyan)';
+    });
+  }, { rootMargin: '-30% 0px -55% 0px' });
+  sections.forEach(s => io.observe(s));
+</script>
+</body>
+</html>

--- a/docs/superpowers/plans/2026-08-03-long-term-memory.md
+++ b/docs/superpowers/plans/2026-08-03-long-term-memory.md
@@ -1,0 +1,583 @@
+# Long-Term Memory (LTM) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship project-scoped long-term memory (SQLite + FTS) with tools and API, automatic observe on agent_end and pre-compact, without changing session JSONL.
+
+**Architecture:** `MemoryService` facade over `MemoryBackend`; phase-1 `SqliteBackend` via Node built-in `node:sqlite` (`DatabaseSync` + FTS5); `AgentMemoryRestBackend` stub; hooks in rpc-manager / event path; tools via Pi inline extension.
+
+**Tech Stack:** TypeScript, Next.js App Router, `node:test` + `node:assert/strict`, `node:sqlite` (Node 24 / Electron host Node — no better-sqlite3), existing `desktop-settings` pattern.
+
+**Spec:** [docs/superpowers/specs/2026-08-03-long-term-memory-design.md](../specs/2026-08-03-long-term-memory-design.md)  
+**Branch:** `feature/long-term-memory`
+
+## Global Constraints
+
+- Do **not** change Pi JSONL schema or cold-read `session-reader` as LTM store.
+- LTM failures must be **best-effort** (never fail prompt/compact/UI).
+- Tools/API/hooks call **only** `MemoryService`, never SQL.
+- `projectId` = `proj_` + first 16 hex of sha256(normalized absolute cwd); Windows lowercase.
+- Observe kinds v1: `agent_end` | `pre_compact` only.
+- No system-prompt inject; no Memory UI panel.
+- Storage default: `{agentDir}/memory/ltm.sqlite` i.e. under `getAgentDir()`.
+- Tests: `node --test` with `*.test.ts`; no new npm deps if `node:sqlite` works (verified on Node 24).
+- Prefer small pure functions + temp DB files under `os.tmpdir()`.
+- Match existing code style: ESM `.ts` imports with `.ts` suffix where the repo already does.
+
+## File map
+
+| Path | Role |
+|------|------|
+| `lib/ltm/types.ts` | Domain types |
+| `lib/ltm/project-id.ts` | `projectIdFromCwd` |
+| `lib/ltm/jaccard.ts` | Token Jaccard for supersede |
+| `lib/ltm/backend.ts` | `MemoryBackend` interface |
+| `lib/ltm/sqlite-backend.ts` | SQLite + FTS5 |
+| `lib/ltm/agentmemory-backend.ts` | Stub |
+| `lib/ltm/config.ts` | Read LTM settings from desktop-settings / defaults |
+| `lib/ltm/service.ts` | Facade + `globalThis` singleton |
+| `lib/ltm/observe-payload.ts` | Build agent_end / pre_compact payloads |
+| `lib/ltm/index.ts` | Public exports |
+| `lib/ltm/*.test.ts` | Unit tests |
+| `lib/desktop-ltm-extension.ts` | Inline extension: memory_* tools |
+| `lib/desktop-settings.ts` | Extend settings with LTM fields |
+| `lib/rpc-manager.ts` | Wire extension, pre_compact, agent_end observe |
+| `app/api/memory/health/route.ts` | GET health |
+| `app/api/memory/recall/route.ts` | GET recall |
+| `app/api/memory/remember/route.ts` | POST remember |
+| `app/api/memory/forget/route.ts` | POST forget |
+| `app/api/memory/stats/route.ts` | GET stats |
+| `app/api/memory/routes.test.ts` | API tests (handler-level if possible) |
+
+---
+
+### Task 1: projectId + Jaccard pure helpers
+
+**Files:**
+- Create: `lib/ltm/project-id.ts`
+- Create: `lib/ltm/jaccard.ts`
+- Create: `lib/ltm/project-id.test.ts`
+- Create: `lib/ltm/jaccard.test.ts`
+
+**Interfaces:**
+- Produces: `projectIdFromCwd(cwd: string): string`
+- Produces: `jaccardSimilarity(a: string, b: string): number` (0..1)
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// lib/ltm/project-id.test.ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import { projectIdFromCwd } from "./project-id.ts";
+
+test("projectIdFromCwd is stable for same absolute path", () => {
+  const a = projectIdFromCwd(process.cwd());
+  const b = projectIdFromCwd(process.cwd());
+  assert.equal(a, b);
+  assert.match(a, /^proj_[0-9a-f]{16}$/);
+});
+
+test("projectIdFromCwd rejects empty cwd", () => {
+  assert.throws(() => projectIdFromCwd("   "), /cwd/i);
+});
+```
+
+```ts
+// lib/ltm/jaccard.test.ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import { jaccardSimilarity } from "./jaccard.ts";
+
+test("identical multi-word strings score 1", () => {
+  assert.equal(jaccardSimilarity("prefer dark mode theme", "prefer dark mode theme"), 1);
+});
+
+test("disjoint strings score 0", () => {
+  assert.equal(jaccardSimilarity("alpha beta gamma", "delta epsilon zeta"), 0);
+});
+
+test("high overlap exceeds 0.7", () => {
+  const s = jaccardSimilarity(
+    "use path resolve for session root directory layout",
+    "use path resolve for session root directory layout please"
+  );
+  assert.ok(s > 0.7);
+});
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+```bash
+node --test --test-force-exit lib/ltm/project-id.test.ts lib/ltm/jaccard.test.ts
+```
+
+- [ ] **Step 3: Implement**
+
+```ts
+// lib/ltm/project-id.ts
+import { createHash } from "node:crypto";
+import path from "node:path";
+
+export function projectIdFromCwd(cwd: string): string {
+  if (typeof cwd !== "string" || !cwd.trim()) {
+    throw new Error("cwd is required for projectId");
+  }
+  const resolved = path.resolve(cwd.trim());
+  const key = process.platform === "win32" ? resolved.toLowerCase() : resolved;
+  const hex = createHash("sha256").update(key, "utf8").digest("hex");
+  return `proj_${hex.slice(0, 16)}`;
+}
+```
+
+```ts
+// lib/ltm/jaccard.ts
+/** Whitespace tokens, drop length <= 2 (ASCII-oriented v1). */
+export function jaccardSimilarity(a: string, b: string): number {
+  const na = a.normalize("NFC").toLowerCase();
+  const nb = b.normalize("NFC").toLowerCase();
+  const setA = tokens(na);
+  const setB = tokens(nb);
+  if (setA.size === 0 || setB.size === 0) {
+    return na.trim().replace(/\s+/g, " ") === nb.trim().replace(/\s+/g, " ") ? 1 : 0;
+  }
+  let inter = 0;
+  for (const t of setA) if (setB.has(t)) inter++;
+  return inter / (setA.size + setB.size - inter);
+}
+
+function tokens(text: string): Set<string> {
+  return new Set(text.split(/\s+/).filter((t) => t.length > 2));
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+node --test --test-force-exit lib/ltm/project-id.test.ts lib/ltm/jaccard.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/ltm/project-id.ts lib/ltm/jaccard.ts lib/ltm/project-id.test.ts lib/ltm/jaccard.test.ts
+git commit -m "feat(ltm): add projectId and Jaccard helpers"
+```
+
+---
+
+### Task 2: Domain types + MemoryBackend interface
+
+**Files:**
+- Create: `lib/ltm/types.ts`
+- Create: `lib/ltm/backend.ts`
+
+**Interfaces:**
+- Produces: types and `MemoryBackend` as in spec §5–6 (copy signatures exactly from spec section 6).
+
+- [ ] **Step 1: Add `types.ts` and `backend.ts`** with exports matching the design doc §6 (`RememberInput`, `RecallInput`, `ObserveInput`, `ForgetInput`, `RecallHit`, `MemoryBackend`, `MemoryType`, `ObserveKind`).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add lib/ltm/types.ts lib/ltm/backend.ts
+git commit -m "feat(ltm): add domain types and MemoryBackend interface"
+```
+
+---
+
+### Task 3: SqliteBackend + FTS
+
+**Files:**
+- Create: `lib/ltm/sqlite-backend.ts`
+- Create: `lib/ltm/sqlite-backend.test.ts`
+
+**Interfaces:**
+- Consumes: `MemoryBackend`, `jaccardSimilarity`, types
+- Produces: `class SqliteBackend implements MemoryBackend` with constructor `(dbPath: string)`
+- Uses `node:sqlite` `DatabaseSync`
+- Schema: tables `observations`, `memories`; FTS5 `observations_fts`, `memories_fts` with external content or simple content tables (prefer **content=** sync triggers or dual-write insert into FTS on write — pick dual-write insert/delete for simplicity)
+
+**Requirements:**
+- `remember`: supersede if latest same project Jaccard > 0.7
+- `recall`: FTS MATCH on memories and observations; merge by score; respect `kinds` and `limit`
+- `observe`: insert row + FTS
+- `forget`: delete by ids scoped to `projectId`
+- `health`: `{ ok: true, backend: "sqlite" }`
+- Create parent dir of `dbPath` if missing
+- Escape FTS query: strip characters that break MATCH (e.g. keep alphanumerics and spaces; quote tokens) — implement `sanitizeFtsQuery(q: string): string` in same file or `fts-query.ts`
+
+- [ ] **Step 1: Write failing integration tests** using a temp file:
+
+```ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { SqliteBackend } from "./sqlite-backend.ts";
+
+test("remember and recall within project", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "ltm-"));
+  const backend = new SqliteBackend(join(dir, "t.sqlite"));
+  try {
+    await backend.remember({
+      projectId: "proj_aaa",
+      content: "Prefer using path resolve for session roots",
+      type: "preference",
+    });
+    const hits = await backend.recall({
+      projectId: "proj_aaa",
+      query: "session roots",
+      limit: 5,
+    });
+    assert.ok(hits.some((h) => h.kind === "memory"));
+  } finally {
+    await backend.close?.();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("recall does not leak across projects", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "ltm-"));
+  const backend = new SqliteBackend(join(dir, "t.sqlite"));
+  try {
+    await backend.remember({ projectId: "proj_a", content: "unique zebra widget convention" });
+    const hits = await backend.recall({ projectId: "proj_b", query: "zebra widget", limit: 5 });
+    assert.equal(hits.length, 0);
+  } finally {
+    await backend.close?.();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("observe agent_end is recallable", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "ltm-"));
+  const backend = new SqliteBackend(join(dir, "t.sqlite"));
+  try {
+    await backend.observe({
+      projectId: "proj_a",
+      sessionId: "sess1",
+      kind: "agent_end",
+      title: "fix login",
+      narrative: "User: fix login\nAssistant: patched auth middleware",
+    });
+    const hits = await backend.recall({
+      projectId: "proj_a",
+      query: "auth middleware",
+      kinds: ["observation"],
+    });
+    assert.ok(hits.length >= 1);
+  } finally {
+    await backend.close?.();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+node --test --test-force-exit lib/ltm/sqlite-backend.test.ts
+```
+
+- [ ] **Step 3: Implement `SqliteBackend`** with schema init on construct, all interface methods.
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+node --test --test-force-exit lib/ltm/sqlite-backend.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/ltm/sqlite-backend.ts lib/ltm/sqlite-backend.test.ts
+git commit -m "feat(ltm): SQLite backend with FTS recall"
+```
+
+---
+
+### Task 4: Config + Service singleton + stub backend
+
+**Files:**
+- Create: `lib/ltm/config.ts`
+- Create: `lib/ltm/agentmemory-backend.ts`
+- Create: `lib/ltm/service.ts`
+- Create: `lib/ltm/service.test.ts`
+- Create: `lib/ltm/index.ts`
+- Modify: `lib/desktop-settings.ts` (+ tests in `lib/desktop-settings.test.ts` if present, else extend)
+
+**Interfaces:**
+- Produces:
+  - `getLtmConfig(agentDir: string): LtmConfig`
+  - `getMemoryService(agentDir?: string): MemoryService`
+  - `MemoryService` methods: `rememberFromCwd`, `recallFromCwd`, `observeFromCwd`, `forgetFromCwd`, `health`, `isEnabled`
+- `LtmConfig`: `{ enabled, backend: "sqlite"|"agentmemory", dbPath, observeAgentEnd, observePreCompact, agentmemoryUrl }`
+- Defaults per spec §11; `dbPath` default `join(agentDir, "memory", "ltm.sqlite")`
+- Extend `DesktopSettings` with optional nested `ltm?: Partial<LtmConfig fields without dbPath computed>` OR flat keys — **prefer nested `ltm` object** merged in `mergeDesktopSettings`
+- `AgentMemoryRestBackend`: every method throws `Error("agentmemory backend not implemented in v1")` except `health` → `{ ok: false, backend: "agentmemory", detail: "not_implemented" }`
+- Service: if `!enabled`, methods throw or return structured; for observe hooks use `safeObserve` that no-ops when disabled
+- Store service on `globalThis.__piLtmService` keyed by dbPath or single instance
+
+- [ ] **Step 1: Tests for config defaults + service remember/recall via temp agentDir**
+
+```ts
+// service.test.ts outline
+test("getMemoryService remember/recall with temp agentDir", async () => {
+  // set agentDir via constructor injection: prefer MemoryService.create(config) for testability
+});
+```
+
+**Design note for implementer:** expose `MemoryService.create(config: LtmConfig)` for tests and `getMemoryService()` for production that reads settings + `getAgentDir()` from pi-coding-agent.
+
+- [ ] **Step 2: Implement config, stub, service, index exports**
+
+- [ ] **Step 3: Run tests**
+
+```bash
+node --test --test-force-exit lib/ltm/service.test.ts lib/desktop-settings.test.ts
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/ltm/config.ts lib/ltm/agentmemory-backend.ts lib/ltm/service.ts lib/ltm/service.test.ts lib/ltm/index.ts lib/desktop-settings.ts lib/desktop-settings.test.ts
+git commit -m "feat(ltm): MemoryService facade, config, agentmemory stub"
+```
+
+---
+
+### Task 5: Observe payload builders
+
+**Files:**
+- Create: `lib/ltm/observe-payload.ts`
+- Create: `lib/ltm/observe-payload.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `buildAgentEndObservation(input: { userText: string; assistantText: string }): { title: string; narrative: string }`
+  - `buildPreCompactObservation(input: { messagesText: string }): { title: string; narrative: string }`
+- Truncation: title 80 chars; user 500; assistant 4000; pre_compact body 6000
+- Empty strings → still valid short placeholders (`"(empty)"`)
+
+- [ ] **Step 1: Write tests for truncation and title extraction**
+
+- [ ] **Step 2: Implement**
+
+- [ ] **Step 3: Pass tests + commit**
+
+```bash
+git add lib/ltm/observe-payload.ts lib/ltm/observe-payload.test.ts
+git commit -m "feat(ltm): observe payload builders"
+```
+
+---
+
+### Task 6: HTTP API routes
+
+**Files:**
+- Create: `app/api/memory/health/route.ts`
+- Create: `app/api/memory/recall/route.ts`
+- Create: `app/api/memory/remember/route.ts`
+- Create: `app/api/memory/forget/route.ts`
+- Create: `app/api/memory/stats/route.ts`
+- Create: `app/api/memory/routes.test.ts` — test pure request parsers / or import handlers if exportable
+
+**Pattern:** Follow existing API routes (`getRequestId`, `logApiError`, JSON responses). Use `getMemoryService()` server-side.
+
+| Route | Behavior |
+|-------|----------|
+| GET health | service.health(); if disabled include enabled:false |
+| GET recall | require `cwd` + `q` query params |
+| POST remember | JSON `{ cwd, content, type?, concepts?, files? }` |
+| POST forget | JSON `{ cwd, memoryIds?, observationIds? }` |
+| GET stats | count for project (implement `stats(projectId)` on service/sqlite if missing — add method) |
+
+If LTM disabled: **503** `{ error: "ltm_disabled" }`.
+
+- [ ] **Step 1: Add `stats` to backend/service if not present** (small method: `SELECT COUNT(*)` for memories/observations by project).
+
+- [ ] **Step 2: Implement routes**
+
+- [ ] **Step 3: Unit-test validation helpers** (extract `parseRecallQuery(url)` to `lib/ltm/http.ts` if cleaner for testing without Next request machinery)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/api/memory lib/ltm/http.ts lib/ltm/http.test.ts
+git commit -m "feat(ltm): HTTP API for recall/remember/forget/health/stats"
+```
+
+---
+
+### Task 7: Wire pre_compact observe in rpc-manager
+
+**Files:**
+- Modify: `lib/rpc-manager.ts` (`case "compact"`)
+- Create: `lib/ltm/compact-observe.test.ts` — unit test a extracted function rather than full wrapper if needed
+
+**Logic:**
+
+```ts
+// Before await this.inner.compact(...)
+// After the "too short" throw check
+void safeLtmPreCompactObserve({
+  sessionId: this.sessionId,
+  cwd: this.inner.sessionManager.getHeader()?.cwd ?? process.cwd(),
+  // branch text: join recent message contents from getBranch() message entries
+});
+```
+
+Implement `safeLtmPreCompactObserve` in `lib/ltm/observe-hooks.ts`:
+- try/catch all
+- if !config.observePreCompact or !enabled return
+- build text from provided string
+- call service.observeFromCwd
+
+- [ ] **Step 1: Extract branch messages → string helper + test**
+
+- [ ] **Step 2: Call from compact case**
+
+- [ ] **Step 3: Manual sanity: unit test helper; optional mock service
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/rpc-manager.ts lib/ltm/observe-hooks.ts lib/ltm/observe-hooks.test.ts
+git commit -m "feat(ltm): pre-compact observation hook"
+```
+
+---
+
+### Task 8: Wire agent_end observe
+
+**Files:**
+- Modify: `lib/rpc-manager.ts` `start()` subscribe handler
+- Modify: `lib/ltm/observe-hooks.ts`
+
+**Logic:** On inner event where `event.type === "agent_end"` (or settled equivalent used by pi — verify against `AgentSessionEvent` types in pi package):
+
+```ts
+void safeLtmAgentEndObserve({
+  sessionId: this.sessionId,
+  cwd: header.cwd,
+  userText: lastUserFromBranch(...),
+  assistantText: lastAssistantFromBranch(...),
+});
+```
+
+If event payload already includes messages, prefer that; else read `sessionManager.getBranch()` message entries.
+
+- [ ] **Step 1: Confirm event type name** from `@earendil-works/pi-coding-agent` / existing SSE mapping in `agent-events-manager.ts` (`agent_end`).
+
+- [ ] **Step 2: Implement safe hook + wire in subscribe**
+
+- [ ] **Step 3: Test payload path with pure helpers (already in observe-payload); hook wrapper try/catch unit test
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/rpc-manager.ts lib/ltm/observe-hooks.ts lib/ltm/observe-hooks.test.ts
+git commit -m "feat(ltm): agent_end observation hook"
+```
+
+---
+
+### Task 9: memory_* tools via inline extension
+
+**Files:**
+- Create: `lib/desktop-ltm-extension.ts`
+- Create: `lib/desktop-ltm-extension.test.ts` (factory registers tool names — shallow test)
+- Modify: `lib/rpc-manager.ts` `startRpcSession` `extensionFactories: [desktopApprovalInlineExtension(modeRef), desktopLtmInlineExtension({ getCwd: () => cwd })]`
+
+**Tools (TypeBox or project’s existing schema style — match pi ToolDefinition):**
+
+| name | parameters | behavior |
+|------|------------|----------|
+| `memory_save` | content (required), type optional | service.rememberFromCwd(cwd, …) |
+| `memory_recall` | query, limit? | service.recallFromCwd |
+| `memory_forget` | memoryIds?: string[] | service.forgetFromCwd |
+
+When LTM disabled, tools can still register but execute returns text error "Long-term memory is disabled".
+
+**Important:** Tools must not require ask-mode confirm (they are not bash/write/edit).
+
+- [ ] **Step 1: Implement extension factory**
+
+- [ ] **Step 2: Register in startRpcSession**
+
+- [ ] **Step 3: Surface test that source includes `desktopLtmInlineExtension` (pattern like `rpc-manager.test.ts` source scans) OR unit-test factory with mock ExtensionAPI
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/desktop-ltm-extension.ts lib/desktop-ltm-extension.test.ts lib/rpc-manager.ts lib/rpc-manager.test.ts
+git commit -m "feat(ltm): register memory_save/recall/forget tools"
+```
+
+---
+
+### Task 10: Docs + smoke checklist
+
+**Files:**
+- Modify: `docs/memory-architecture.html` — add short section linking to LTM spec and noting LTM layer
+- Optional one-line in `AGENTS.md` under architecture: LTM at `lib/ltm`, API `/api/memory/*`
+
+- [ ] **Step 1: Link docs**
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+npm run test
+npx tsc --noEmit
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/memory-architecture.html docs/superpowers/specs/2026-08-03-long-term-memory-design.md docs/superpowers/plans/2026-08-03-long-term-memory.md AGENTS.md
+git commit -m "docs(ltm): link long-term memory architecture and plan"
+```
+
+---
+
+## Spec coverage checklist
+
+| Spec item | Task |
+|-----------|------|
+| MemoryBackend + SQLite FTS | 2, 3 |
+| projectId cwd hash | 1 |
+| remember + supersede | 3, 4 |
+| recall tools only | 9 |
+| observe agent_end | 8 |
+| observe pre_compact | 7 |
+| API routes | 6 |
+| agentmemory stub | 4 |
+| config flags | 4 |
+| no JSONL change | (global) |
+| globalThis service | 4 |
+| tests | 1–9 |
+| node:sqlite driver | 3 (verified) |
+
+## Self-review notes
+
+- No TBD placeholders in tasks.  
+- SQLite driver fixed to `node:sqlite` (no new dependency).  
+- Tool registration uses proven `extensionFactories` pattern.  
+- Stats method added in Task 6 if not in Task 3 — implementers should add `stats` on backend in Task 3 or 6 consistently (`stats(projectId): Promise<{ memoryCount: number; observationCount: number }>`).
+
+**Recommended:** implement `stats` on `MemoryBackend` in **Task 3** so Task 6 only wires HTTP.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-08-03-long-term-memory.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, review between tasks  
+2. **Inline Execution** — this session, executing-plans with checkpoints  
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-08-03-long-term-memory-design.md
+++ b/docs/superpowers/specs/2026-08-03-long-term-memory-design.md
@@ -1,0 +1,388 @@
+# Long-Term Memory (LTM) Design
+
+**Date:** 2026-08-03  
+**Branch:** `feature/long-term-memory`  
+**Status:** Approved for implementation planning  
+**Related:** [docs/memory-architecture.html](../../memory-architecture.html) (session memory baseline)
+
+## 1. Summary
+
+Add a **project-scoped long-term memory layer** beside the existing Pi session JSONL (episodic log). Architecture is **pluggable backends** behind a single service interface. Phase 1 implements **built-in SQLite** only; an **agentmemory REST** adapter is stubbed for later.
+
+Session files, cold-read paths, and Pi `SessionManager` contracts are **not** modified as the primary store.
+
+## 2. Decisions (locked)
+
+| Topic | Choice |
+|-------|--------|
+| Architecture | **C**: `MemoryBackend` interface + swappable adapters |
+| Phase-1 backend | **SQLite** (built-in) |
+| agentmemory REST | Interface + stub only; selecting it returns a clear "not implemented" error |
+| `projectId` | Hash of normalized absolute `cwd` (Windows: resolve + lowercase) |
+| Auto observe | **Turn boundary only**: `agent_end` + **pre-compact** |
+| Into the model | **Tools only**: `memory_recall` / `memory_save` (optional `memory_forget`) |
+| Auto inject system prompt | **No** in v1 |
+| User-facing surface | Agent tools + `/api/memory/*`; **no** Memory sidebar UI |
+| DB path | `~/.pi/agent/memory/ltm.sqlite` (override via settings) |
+
+### Non-goals (v1)
+
+- Vector / hybrid graph search, crystallize chains, full tool-trajectory logging  
+- Default context injection on every prompt  
+- Memory management UI  
+- Depending on a running agentmemory / iii process  
+- Changing `.jsonl` schema as the LTM source of truth  
+- Multi-root project registry (cwd move = new `projectId` is accepted in v1)
+
+## 3. Goals
+
+1. Cross-session recall of durable facts and compact-safe observations for a project.  
+2. Explicit save path aligned with agentmemory memory types.  
+3. Automatic, zero-LLM capture at low-noise hooks (`agent_end`, pre-compact).  
+4. Clean seam so a future agentmemory REST backend does not rewrite tools/API/hooks.  
+5. Best-effort capture: LTM failures never block chat, compact, or tool UX.
+
+## 4. Architecture
+
+```
+┌─────────────────────────────────────────────┐
+│  Agent tools / HTTP /api/memory/*           │
+└─────────────────────┬───────────────────────┘
+                      ▼
+┌─────────────────────────────────────────────┐
+│  MemoryService (lib/ltm/service.ts)         │
+│  - resolve projectId from cwd               │
+│  - validate inputs                          │
+│  - optional supersede / orchestration       │
+└─────────────────────┬───────────────────────┘
+                      │ MemoryBackend
+          ┌───────────┴───────────┐
+          ▼                       ▼
+┌──────────────────┐    ┌──────────────────────────┐
+│ SqliteBackend    │    │ AgentMemoryRestBackend   │
+│ (phase 1)        │    │ (stub phase 1)           │
+└────────┬─────────┘    └──────────────────────────┘
+         ▼
+ ~/.pi/agent/memory/ltm.sqlite
+```
+
+### Module layout
+
+| Path | Responsibility |
+|------|----------------|
+| `lib/ltm/types.ts` | Domain types |
+| `lib/ltm/project-id.ts` | Pure `projectIdFromCwd(cwd)` |
+| `lib/ltm/backend.ts` | `MemoryBackend` interface |
+| `lib/ltm/sqlite-backend.ts` | SQLite + FTS5 |
+| `lib/ltm/agentmemory-backend.ts` | Stub |
+| `lib/ltm/service.ts` | Facade; singleton on `globalThis` for HMR |
+| `lib/ltm/observe-hooks.ts` | Build observe payloads from agent/compact context |
+| `lib/ltm/index.ts` | Public exports |
+| `app/api/memory/**` | HTTP routes |
+| Tool registration | Via existing Pi tool / desktop extension mechanism |
+
+**Rule:** hooks, routes, and tools call **only** `MemoryService`, never SQL or a concrete backend.
+
+### Layer relationship to session memory
+
+| Layer | Role after LTM |
+|-------|----------------|
+| L1 JSONL | Episodic session truth (unchanged) |
+| L2 AgentSession | Hot execution; fire observe hooks best-effort |
+| L3 UI | Unchanged for v1 (no memory panel) |
+| **LTM store** | Project-scoped semantic/episodic index |
+
+See baseline analysis: `docs/memory-architecture.html`.
+
+## 5. Data model (SQLite)
+
+### 5.1 `observations`
+
+| Column | Type | Notes |
+|--------|------|--------|
+| `id` | TEXT PK | e.g. `obs_<ts>_<rand>` |
+| `project_id` | TEXT NOT NULL | indexed |
+| `session_id` | TEXT NOT NULL | Pi session id |
+| `kind` | TEXT NOT NULL | `agent_end` \| `pre_compact` |
+| `title` | TEXT NOT NULL | short |
+| `narrative` | TEXT NOT NULL | searchable body (truncated, e.g. 4k chars) |
+| `source_json` | TEXT | optional raw snippet JSON |
+| `created_at` | TEXT NOT NULL | ISO-8601 |
+
+### 5.2 `memories`
+
+| Column | Type | Notes |
+|--------|------|--------|
+| `id` | TEXT PK | e.g. `mem_...` |
+| `project_id` | TEXT NOT NULL | indexed |
+| `type` | TEXT NOT NULL | `pattern` \| `preference` \| `architecture` \| `bug` \| `workflow` \| `fact` |
+| `title` | TEXT NOT NULL | first ~80 chars of content |
+| `content` | TEXT NOT NULL | |
+| `concepts_json` | TEXT | optional JSON string array |
+| `files_json` | TEXT | optional JSON string array |
+| `source_observation_ids_json` | TEXT | optional |
+| `is_latest` | INTEGER NOT NULL | 1/0 for supersede |
+| `parent_id` | TEXT | previous version id |
+| `created_at` / `updated_at` | TEXT | ISO-8601 |
+
+Default `type` when omitted: `fact`.
+
+### 5.3 FTS
+
+- `memories_fts` over `title`, `content`  
+- `observations_fts` over `title`, `narrative`  
+- Phase 1 retrieval is **keyword/FTS only** (no embeddings).
+
+### 5.4 `projectId`
+
+```ts
+function projectIdFromCwd(cwd: string): string {
+  const resolved = path.resolve(cwd);
+  const key = process.platform === "win32" ? resolved.toLowerCase() : resolved;
+  // sha256 hex, first 16 chars
+  return `proj_${sha256(key).slice(0, 16)}`;
+}
+```
+
+- Empty / invalid cwd → reject at service/API boundary (400).  
+- Same directory after rename/move/drive letter change may yield a **new** project in v1 (accepted).
+
+## 6. `MemoryBackend` interface
+
+```ts
+export type MemoryType =
+  | "pattern"
+  | "preference"
+  | "architecture"
+  | "bug"
+  | "workflow"
+  | "fact";
+
+export type ObserveKind = "agent_end" | "pre_compact";
+
+export interface RememberInput {
+  projectId: string;
+  content: string;
+  type?: MemoryType;
+  concepts?: string[];
+  files?: string[];
+  sourceObservationIds?: string[];
+  sessionId?: string;
+}
+
+export interface RecallInput {
+  projectId: string;
+  query: string;
+  limit?: number; // default 10, max 50
+  kinds?: Array<"memory" | "observation">; // default both
+}
+
+export interface ObserveInput {
+  projectId: string;
+  sessionId: string;
+  kind: ObserveKind;
+  title: string;
+  narrative: string;
+  source?: unknown;
+}
+
+export interface ForgetInput {
+  projectId: string;
+  memoryIds?: string[];
+  observationIds?: string[];
+}
+
+export interface RecallHit {
+  kind: "memory" | "observation";
+  id: string;
+  title: string;
+  snippet: string;
+  score?: number;
+  type?: MemoryType | ObserveKind;
+  createdAt: string;
+}
+
+export interface MemoryBackend {
+  remember(input: RememberInput): Promise<{ id: string; type: MemoryType }>;
+  recall(input: RecallInput): Promise<RecallHit[]>;
+  observe(
+    input: ObserveInput
+  ): Promise<{ observationId: string } | { deduplicated: true }>;
+  forget(input: ForgetInput): Promise<{ deleted: number }>;
+  health(): Promise<{ ok: boolean; backend: string; detail?: string }>;
+  close?(): Promise<void>;
+}
+```
+
+### Supersede
+
+When saving a memory, if another **latest** memory in the **same `projectId`** has Jaccard token similarity **> 0.7** on content, mark the old one `is_latest = 0` and set `parent_id` on the new row (agentmemory-inspired). Prefer a pure helper for unit tests (CJK-aware optional later; v1 may use simple whitespace tokens with a documented limitation).
+
+### Dedup (observe)
+
+Optional short-window dedup for identical `sessionId + kind + title` hash; return `{ deduplicated: true }`. Not required for correctness.
+
+## 7. Write paths
+
+### 7.1 Explicit `memory_save`
+
+1. Tool or `POST /api/memory/remember` with `cwd` + `content` (+ optional type/concepts/files).  
+2. `MemoryService` → `projectIdFromCwd` → `backend.remember`.  
+3. Update FTS.
+
+### 7.2 Auto `agent_end` (zero-LLM)
+
+**Hook site:** after a successful agent turn end is known server-side (prefer the same place that already drives session consistency — e.g. path that handles agent completion before/with reload). Implementation plan will pick the single most reliable event in `rpc-manager` / session event bridge.
+
+**Payload (synthetic):**
+
+- `kind: "agent_end"`  
+- `title`: first line / 80 chars of last user prompt  
+- `narrative`: `User: <truncated>\nAssistant: <truncated>` (e.g. user 500 / assistant 4000 chars)  
+- `sessionId`, `projectId` from session cwd  
+
+**Failure:** log and swallow; never fail the agent turn.
+
+### 7.3 Auto `pre_compact` (zero-LLM)
+
+**Hook site:** `AgentSessionWrapper.send` `case "compact"` — **before** `inner.compact(...)` (after the existing "too short" guard is fine so we do not observe empty compacts).
+
+**Payload:**
+
+- `kind: "pre_compact"`  
+- `narrative`: text built from current branch path / recent messages about to be summarized (truncate)  
+- purpose: preserve signal that compaction would otherwise hide from **context views** (raw JSONL may still retain history)
+
+**Failure:** best-effort; compact still proceeds.
+
+### 7.4 Not captured in v1
+
+- Per-tool `write` / `edit` / `bash` observations  
+- Prompt-submit every keystroke  
+- Image / vision  
+
+## 8. Read path
+
+1. Tool `memory_recall({ query, limit? })` resolves cwd from the active agent session.  
+2. FTS over memories (primary) and observations (secondary); merge/rank by FTS score.  
+3. Return compact hits; model decides how to use them.  
+4. **No** automatic system-prompt injection.
+
+## 9. HTTP API
+
+Base: local desktop trust model (same as other `/api/*`).
+
+| Method | Path | Body / query | Response |
+|--------|------|--------------|----------|
+| GET | `/api/memory/health` | — | `{ ok, backend, ... }` |
+| GET | `/api/memory/recall` | `cwd`, `q`, `limit?` | `{ hits: RecallHit[] }` |
+| POST | `/api/memory/remember` | `{ cwd, content, type?, concepts?, files? }` | `{ id, type }` |
+| POST | `/api/memory/forget` | `{ cwd, memoryIds?, observationIds? }` | `{ deleted }` |
+| GET | `/api/memory/stats` | `cwd` | `{ memoryCount, observationCount }` (debug) |
+
+- Missing `cwd` or empty `q`/`content` where required → 400 with stable error shape (`lib/api-error` patterns).  
+- If `ltm.enabled === false` → 503 or 404 with clear message (pick one in implementation; prefer **503** + `{ error: "ltm_disabled" }`).
+
+## 10. Agent tools
+
+| Tool name | Maps to | Notes |
+|-----------|---------|--------|
+| `memory_save` | `remember` | Types as above |
+| `memory_recall` | `recall` | |
+| `memory_forget` | `forget` | Optional but recommended in v1 for governance |
+
+Registration mechanism: follow existing desktop extension / Pi `registerTool` patterns used for other desktop tools so tools appear in the active tool list when LTM is enabled. Exact file placement left to implementation plan (prefer not to bloat `rpc-manager.ts` — thin glue only).
+
+## 11. Configuration
+
+Extend desktop settings (or env overrides) with:
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `ltm.enabled` | `true` | Master switch |
+| `ltm.backend` | `"sqlite"` | `"sqlite"` \| `"agentmemory"` |
+| `ltm.dbPath` | `~/.pi/agent/memory/ltm.sqlite` | SQLite path |
+| `ltm.observeAgentEnd` | `true` | |
+| `ltm.observePreCompact` | `true` | |
+| `ltm.agentmemoryUrl` | `http://127.0.0.1:3111` | For future REST adapter |
+
+When `backend === "agentmemory"` in v1: `health` reports not implemented; mutating/recall methods throw/return structured error **not** silent empty success.
+
+## 12. Concurrency & process lifecycle
+
+- Open DB with a single service instance per process; store on `globalThis` (HMR-safe, same rationale as `__piSessions`).  
+- Serialize writes per process with a simple mutex/queue if better-sqlite3 / async driver needs it.  
+- `close` on process exit optional; OS will release file handles.  
+- Electron + Next child process: LTM lives in the **Node server process** that runs API routes (same as sessions), not in the BrowserWindow renderer.
+
+## 13. Integration seams (do not break)
+
+| Existing behavior | Constraint |
+|-------------------|------------|
+| JSONL schema / `session-reader` cold path | Unchanged |
+| Fork pre-register then destroy | Unchanged; LTM is project-scoped not session-graph-scoped |
+| Compact too-short guard | Still throw; observe only when compact will run |
+| ToolCall normalize | Unrelated |
+| `withFileLock` | Not required for SQLite if single connection + write queue; do not invent dual locking schemes |
+
+## 14. Testing
+
+| Area | Tests |
+|------|--------|
+| `projectIdFromCwd` | Windows-style case, relative→absolute, stability |
+| Supersede helper | Above/below 0.7 threshold |
+| Observe payload builders | Truncation, empty assistant |
+| SqliteBackend | temp DB: remember, recall FTS, forget, supersede, observe |
+| compact hook | mock service: observe called before compact when enabled |
+| API routes | validation 400, happy path, disabled 503 |
+| agentmemory stub | clear error |
+
+Prefer pure functions + temp directories; no live network.
+
+## 15. Implementation phases (this branch)
+
+1. **Core:** types, project-id, backend interface, sqlite, service, globalThis  
+2. **API:** `/api/memory/*` + tests  
+3. **Hooks:** pre-compact + agent_end observe  
+4. **Tools:** `memory_save` / `memory_recall` / `memory_forget`  
+5. **Stub:** agentmemory backend + config switch  
+6. **Docs:** link from `memory-architecture.html` / AGENTS notes if needed  
+
+Do not start phase 2 until phase 1 unit tests pass, etc. Detailed task breakdown belongs in a **writing-plans** document after this spec is accepted.
+
+## 16. Future (out of scope for v1 code)
+
+- Real `AgentMemoryRestBackend` (hybrid search, viewer)  
+- Opt-in inject (`ltm.injectContext`)  
+- Project registry (stable id across cwd moves)  
+- Embeddings / FTS + vector  
+- Memory UI panel  
+- Observe write/edit tools  
+- Compact-triggered LLM extract into `memories` (not only observations)
+
+## 17. Risks & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| DB growth | Truncation on observe; later retention job |
+| Noisy agent_end | Truncation + kind filter in recall; settings to disable observe |
+| Wrong project after path change | Documented v1 limitation; registry later |
+| Hook misses agent_end | Integration test; prefer one server-side source of truth |
+| better-sqlite3 native module in Electron | Prefer `node:sqlite` (Node 22+) if available in runtime, or pure `sql.js` / carefully validated native dep — **implementation plan must verify** Electron/Node version and choose one driver before coding |
+
+## 18. Success criteria (v1 done)
+
+1. Save a memory in session A; new session B same cwd can `memory_recall` it.  
+2. Compact triggers a `pre_compact` observation retrievable by keyword.  
+3. Agent end creates an `agent_end` observation without failing the turn.  
+4. Disabling `ltm.enabled` stops tools/API from writing.  
+5. Session JSONL still works offline if DB deleted (graceful degrade).  
+6. Unit tests green for project id, sqlite backend, and API validation.
+
+## 19. Approval
+
+- Architecture brainstorm: 2026-08-03  
+- User choices: C → backend 1 → projectId 1 → observe 1 → inject 1 → surface 1  
+- Design draft approved (user confirmed) prior to this file  
+
+**Next step:** user reviews this file; on OK, invoke **writing-plans** for an implementation plan on `feature/long-term-memory` (no feature code until plan exists and is accepted if required by workflow).

--- a/lib/desktop-ltm-extension.test.ts
+++ b/lib/desktop-ltm-extension.test.ts
@@ -36,6 +36,7 @@ test("withMemoryTools appends memory tools when non-empty", () => {
 test("desktopLtmInlineExtension factory registers three tool names", () => {
   const registered: string[] = [];
   const ext = desktopLtmInlineExtension({ getCwd: () => "/tmp/proj" });
+  assert.ok(typeof ext === "object" && ext !== null && "name" in ext);
   assert.equal(ext.name, "desktop-ltm");
   assert.equal(typeof ext.factory, "function");
 

--- a/lib/desktop-ltm-extension.test.ts
+++ b/lib/desktop-ltm-extension.test.ts
@@ -1,0 +1,97 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  createDesktopLtmFactory,
+  desktopLtmInlineExtension,
+  MEMORY_TOOL_NAMES,
+  withMemoryTools,
+} from "./desktop-ltm-extension.ts";
+import { resetMemoryServiceForTests } from "./ltm/service.ts";
+
+test("MEMORY_TOOL_NAMES lists save/recall/forget", () => {
+  assert.deepEqual([...MEMORY_TOOL_NAMES].sort(), [
+    "memory_forget",
+    "memory_recall",
+    "memory_save",
+  ]);
+});
+
+test("withMemoryTools appends memory tools when non-empty", () => {
+  assert.deepEqual(withMemoryTools([]), []);
+  assert.deepEqual(
+    withMemoryTools(["read", "bash"]).sort(),
+    ["bash", "memory_forget", "memory_recall", "memory_save", "read"]
+  );
+  // no duplicates
+  assert.equal(
+    withMemoryTools(["read", "memory_save"]).filter((n) => n === "memory_save")
+      .length,
+    1
+  );
+});
+
+test("desktopLtmInlineExtension factory registers three tool names", () => {
+  const registered: string[] = [];
+  const ext = desktopLtmInlineExtension({ getCwd: () => "/tmp/proj" });
+  assert.equal(ext.name, "desktop-ltm");
+  assert.equal(typeof ext.factory, "function");
+
+  const factory = createDesktopLtmFactory({ getCwd: () => "/tmp/proj" });
+  factory({
+    registerTool: (tool: { name: string }) => {
+      registered.push(tool.name);
+    },
+  } as never);
+
+  assert.deepEqual(registered.sort(), [...MEMORY_TOOL_NAMES].sort());
+});
+
+test("memory tools return disabled text when LTM is off", async () => {
+  const agentDir = mkdtempSync(join(tmpdir(), "ltm-ext-"));
+  try {
+    writeFileSync(
+      join(agentDir, "desktop-settings.json"),
+      JSON.stringify({ ltm: { enabled: false } }),
+      "utf-8"
+    );
+    resetMemoryServiceForTests();
+
+    type ExecTool = {
+      name: string;
+      execute: (
+        id: string,
+        params: Record<string, unknown>
+      ) => Promise<{ content: Array<{ type: string; text: string }> }>;
+    };
+    const tools = new Map<string, ExecTool>();
+    createDesktopLtmFactory({
+      getCwd: () => join(agentDir, "proj"),
+      agentDir,
+    })({
+      registerTool: (tool: ExecTool) => {
+        tools.set(tool.name, tool);
+      },
+    } as never);
+
+    const save = await tools.get("memory_save")!.execute("t1", {
+      content: "x",
+    });
+    assert.equal(save.content[0]?.text, "Long-term memory is disabled");
+
+    const recall = await tools.get("memory_recall")!.execute("t2", {
+      query: "x",
+    });
+    assert.equal(recall.content[0]?.text, "Long-term memory is disabled");
+
+    const forget = await tools.get("memory_forget")!.execute("t3", {
+      memoryIds: ["m1"],
+    });
+    assert.equal(forget.content[0]?.text, "Long-term memory is disabled");
+  } finally {
+    resetMemoryServiceForTests();
+    rmSync(agentDir, { recursive: true, force: true });
+  }
+});

--- a/lib/desktop-ltm-extension.ts
+++ b/lib/desktop-ltm-extension.ts
@@ -1,0 +1,201 @@
+/**
+ * Inline pi extension: long-term memory tools (memory_save / recall / forget).
+ * Not gated by Ask-mode confirm (not bash/write/edit).
+ */
+import { Type } from "typebox";
+import type {
+  ExtensionAPI,
+  ExtensionFactory,
+  InlineExtension,
+} from "@earendil-works/pi-coding-agent";
+import { isLtmDisabledError, isMemoryType, LTM_DISABLED } from "./ltm/http.ts";
+import { getMemoryService } from "./ltm/service.ts";
+
+export const MEMORY_TOOL_NAMES = [
+  "memory_save",
+  "memory_recall",
+  "memory_forget",
+] as const;
+
+export type MemoryToolName = (typeof MEMORY_TOOL_NAMES)[number];
+
+const LTM_DISABLED_TEXT = "Long-term memory is disabled";
+
+export type DesktopLtmExtensionOptions = {
+  /** Session project cwd; resolved at execute time. */
+  getCwd: () => string;
+  /** Optional agentDir override for getMemoryService (tests). */
+  agentDir?: string;
+};
+
+/** Append memory_* tools when any coding tools are active; empty stay empty (noTools: all). */
+export function withMemoryTools(tools: string[]): string[] {
+  if (tools.length === 0) return tools;
+  const next = [...tools];
+  for (const name of MEMORY_TOOL_NAMES) {
+    if (!next.includes(name)) next.push(name);
+  }
+  return next;
+}
+
+function textResult(text: string, details: unknown = {}) {
+  return {
+    content: [{ type: "text" as const, text }],
+    details,
+  };
+}
+
+function disabledResult() {
+  return textResult(LTM_DISABLED_TEXT, { error: LTM_DISABLED });
+}
+
+function mapError(err: unknown) {
+  if (isLtmDisabledError(err)) return disabledResult();
+  const message = err instanceof Error ? err.message : String(err);
+  if (message === LTM_DISABLED) return disabledResult();
+  return textResult(`Memory error: ${message}`, { error: message });
+}
+
+const SaveParams = Type.Object({
+  content: Type.String({ description: "Memory content to store" }),
+  type: Type.Optional(
+    Type.String({
+      description:
+        "Memory type: pattern | preference | architecture | bug | workflow | fact",
+    })
+  ),
+});
+
+const RecallParams = Type.Object({
+  query: Type.String({ description: "Search query for project memory" }),
+  limit: Type.Optional(
+    Type.Number({ description: "Max hits (1–50, default 10)" })
+  ),
+});
+
+const ForgetParams = Type.Object({
+  memoryIds: Type.Optional(
+    Type.Array(Type.String(), { description: "Memory ids to delete" })
+  ),
+});
+
+export function createDesktopLtmFactory(
+  options: DesktopLtmExtensionOptions
+): ExtensionFactory {
+  const { getCwd, agentDir } = options;
+
+  return (pi: ExtensionAPI) => {
+    pi.registerTool({
+      name: "memory_save",
+      label: "Memory Save",
+      description:
+        "Save a durable project memory (preference, architecture note, bug, fact, etc.).",
+      promptSnippet: "Save long-term project memory",
+      parameters: SaveParams,
+      async execute(_toolCallId, params) {
+        try {
+          const service = getMemoryService(agentDir);
+          if (!service.isEnabled()) return disabledResult();
+
+          const type =
+            params.type !== undefined && isMemoryType(params.type)
+              ? params.type
+              : undefined;
+          if (params.type !== undefined && type === undefined) {
+            return textResult(
+              `Invalid memory type: ${String(params.type)}. Use pattern|preference|architecture|bug|workflow|fact.`,
+              { error: "invalid_type" }
+            );
+          }
+
+          const result = await service.rememberFromCwd(getCwd(), {
+            content: params.content,
+            ...(type !== undefined ? { type } : {}),
+          });
+          return textResult(
+            `Saved memory ${result.id} (type: ${result.type})`,
+            result
+          );
+        } catch (err) {
+          return mapError(err);
+        }
+      },
+    });
+
+    pi.registerTool({
+      name: "memory_recall",
+      label: "Memory Recall",
+      description:
+        "Search project long-term memory and observations by query.",
+      promptSnippet: "Recall project long-term memory",
+      parameters: RecallParams,
+      async execute(_toolCallId, params) {
+        try {
+          const service = getMemoryService(agentDir);
+          if (!service.isEnabled()) return disabledResult();
+
+          const limit =
+            typeof params.limit === "number" && Number.isFinite(params.limit)
+              ? Math.min(50, Math.max(1, Math.floor(params.limit)))
+              : undefined;
+
+          const hits = await service.recallFromCwd(getCwd(), {
+            query: params.query,
+            ...(limit !== undefined ? { limit } : {}),
+          });
+
+          if (hits.length === 0) {
+            return textResult("No matching memories.", { hits: [] });
+          }
+
+          const lines = hits.map((h, i) => {
+            const score =
+              h.score !== undefined ? ` score=${h.score.toFixed(3)}` : "";
+            const kind = h.kind;
+            const type = h.type ? ` (${h.type})` : "";
+            return `${i + 1}. [${kind}${type}] ${h.id}${score}\n   ${h.title}\n   ${h.snippet}`;
+          });
+
+          return textResult(lines.join("\n\n"), { hits });
+        } catch (err) {
+          return mapError(err);
+        }
+      },
+    });
+
+    pi.registerTool({
+      name: "memory_forget",
+      label: "Memory Forget",
+      description: "Delete project memories by id.",
+      promptSnippet: "Forget (delete) project memories by id",
+      parameters: ForgetParams,
+      async execute(_toolCallId, params) {
+        try {
+          const service = getMemoryService(agentDir);
+          if (!service.isEnabled()) return disabledResult();
+
+          const memoryIds = params.memoryIds;
+          if (!memoryIds || memoryIds.length === 0) {
+            return textResult("No memoryIds provided; nothing deleted.", {
+              deleted: 0,
+            });
+          }
+
+          const result = await service.forgetFromCwd(getCwd(), { memoryIds });
+          return textResult(`Deleted ${result.deleted} memor(ies).`, result);
+        } catch (err) {
+          return mapError(err);
+        }
+      },
+    });
+  };
+}
+
+export function desktopLtmInlineExtension(
+  options: DesktopLtmExtensionOptions
+): InlineExtension {
+  return {
+    name: "desktop-ltm",
+    factory: createDesktopLtmFactory(options),
+  };
+}

--- a/lib/desktop-settings.test.ts
+++ b/lib/desktop-settings.test.ts
@@ -55,3 +55,46 @@ test("validateDesktopSettingsBody", () => {
   assert.match(validateDesktopSettingsBody(null)!, /object/);
   assert.match(validateDesktopSettingsBody({ defaultAgentMode: "x" })!, /defaultAgentMode/);
 });
+
+test("mergeDesktopSettings merges nested ltm and ignores invalid backend", () => {
+  const m = mergeDesktopSettings({
+    defaultAgentMode: "full",
+    ltm: {
+      enabled: false,
+      backend: "nope",
+      observeAgentEnd: false,
+      agentmemoryUrl: "http://localhost:9999",
+    },
+  });
+  assert.equal(m.defaultAgentMode, "full");
+  assert.deepEqual(m.ltm, {
+    enabled: false,
+    observeAgentEnd: false,
+    agentmemoryUrl: "http://localhost:9999",
+  });
+});
+
+test("read/write round-trip preserves nested ltm", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-desktop-settings-ltm-"));
+  try {
+    const written = writeDesktopSettings(dir, {
+      defaultAgentMode: "ask",
+      defaultToolPreset: "default",
+      ltm: { enabled: false, backend: "sqlite", dbPath: "C:/tmp/ltm.sqlite" },
+    });
+    assert.equal(written.ltm?.enabled, false);
+    assert.equal(written.ltm?.backend, "sqlite");
+    const read = readDesktopSettings(dir);
+    assert.deepEqual(read.ltm, written.ltm);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("validateDesktopSettingsBody rejects invalid ltm.backend", () => {
+  assert.match(
+    validateDesktopSettingsBody({ ltm: { backend: "redis" } })!,
+    /ltm\.backend/
+  );
+  assert.equal(validateDesktopSettingsBody({ ltm: { enabled: true } }), null);
+});

--- a/lib/desktop-settings.ts
+++ b/lib/desktop-settings.ts
@@ -13,9 +13,21 @@ import {
   type ToolPreset,
 } from "./approval-policy.ts";
 
+/** Optional nested LTM overrides in desktop-settings.json (`ltm`). */
+export interface DesktopLtmSettings {
+  enabled?: boolean;
+  backend?: "sqlite" | "agentmemory";
+  dbPath?: string;
+  observeAgentEnd?: boolean;
+  observePreCompact?: boolean;
+  agentmemoryUrl?: string;
+}
+
 export interface DesktopSettings {
   defaultAgentMode: AgentMode;
   defaultToolPreset: ToolPreset;
+  /** Optional LTM config; omitted when unset. Merged by getLtmConfig. */
+  ltm?: DesktopLtmSettings;
 }
 
 export const DESKTOP_SETTINGS_FILENAME = "desktop-settings.json";
@@ -31,16 +43,32 @@ export function desktopSettingsPath(agentDir: string): string {
   return join(agentDir, DESKTOP_SETTINGS_FILENAME);
 }
 
+function mergeDesktopLtmSettings(raw: unknown): DesktopLtmSettings | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const o = raw as Record<string, unknown>;
+  const out: DesktopLtmSettings = {};
+  if (typeof o.enabled === "boolean") out.enabled = o.enabled;
+  if (o.backend === "sqlite" || o.backend === "agentmemory") out.backend = o.backend;
+  if (typeof o.dbPath === "string") out.dbPath = o.dbPath;
+  if (typeof o.observeAgentEnd === "boolean") out.observeAgentEnd = o.observeAgentEnd;
+  if (typeof o.observePreCompact === "boolean") out.observePreCompact = o.observePreCompact;
+  if (typeof o.agentmemoryUrl === "string") out.agentmemoryUrl = o.agentmemoryUrl;
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
 export function mergeDesktopSettings(raw: unknown): DesktopSettings {
   const base = defaultDesktopSettings();
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return base;
   const obj = raw as Record<string, unknown>;
-  return {
+  const ltm = mergeDesktopLtmSettings(obj.ltm);
+  const result: DesktopSettings = {
     defaultAgentMode: isAgentMode(obj.defaultAgentMode) ? obj.defaultAgentMode : base.defaultAgentMode,
     defaultToolPreset: isToolPreset(obj.defaultToolPreset)
       ? obj.defaultToolPreset
       : base.defaultToolPreset,
   };
+  if (ltm) result.ltm = ltm;
+  return result;
 }
 
 export function readDesktopSettings(agentDir: string): DesktopSettings {
@@ -73,6 +101,37 @@ export function validateDesktopSettingsBody(body: unknown): string | null {
   }
   if (obj.defaultToolPreset !== undefined && !isToolPreset(obj.defaultToolPreset)) {
     return "defaultToolPreset must be none | default | full";
+  }
+  if (obj.ltm !== undefined) {
+    if (!obj.ltm || typeof obj.ltm !== "object" || Array.isArray(obj.ltm)) {
+      return "ltm must be an object";
+    }
+    const ltm = obj.ltm as Record<string, unknown>;
+    if (ltm.enabled !== undefined && typeof ltm.enabled !== "boolean") {
+      return "ltm.enabled must be a boolean";
+    }
+    if (
+      ltm.backend !== undefined &&
+      ltm.backend !== "sqlite" &&
+      ltm.backend !== "agentmemory"
+    ) {
+      return "ltm.backend must be sqlite | agentmemory";
+    }
+    if (ltm.dbPath !== undefined && typeof ltm.dbPath !== "string") {
+      return "ltm.dbPath must be a string";
+    }
+    if (ltm.observeAgentEnd !== undefined && typeof ltm.observeAgentEnd !== "boolean") {
+      return "ltm.observeAgentEnd must be a boolean";
+    }
+    if (
+      ltm.observePreCompact !== undefined &&
+      typeof ltm.observePreCompact !== "boolean"
+    ) {
+      return "ltm.observePreCompact must be a boolean";
+    }
+    if (ltm.agentmemoryUrl !== undefined && typeof ltm.agentmemoryUrl !== "string") {
+      return "ltm.agentmemoryUrl must be a string";
+    }
   }
   return null;
 }

--- a/lib/ltm/agentmemory-backend.ts
+++ b/lib/ltm/agentmemory-backend.ts
@@ -1,0 +1,55 @@
+import type { MemoryBackend } from "./backend.ts";
+import type {
+  ForgetInput,
+  MemoryType,
+  ObserveInput,
+  RecallHit,
+  RecallInput,
+  RememberInput,
+} from "./types.ts";
+
+const NOT_IMPLEMENTED = "agentmemory backend not implemented in v1";
+
+/**
+ * Phase-1 stub for a future agentmemory REST adapter.
+ * health reports not_implemented; all other methods throw.
+ */
+export class AgentMemoryRestBackend implements MemoryBackend {
+  private readonly _url: string;
+
+  constructor(url: string = "http://127.0.0.1:3111") {
+    this._url = url;
+  }
+
+  get url(): string {
+    return this._url;
+  }
+
+  async remember(
+    _input: RememberInput
+  ): Promise<{ id: string; type: MemoryType }> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async recall(_input: RecallInput): Promise<RecallHit[]> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async observe(
+    _input: ObserveInput
+  ): Promise<{ observationId: string } | { deduplicated: true }> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async forget(_input: ForgetInput): Promise<{ deleted: number }> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+
+  async health(): Promise<{ ok: boolean; backend: string; detail?: string }> {
+    return {
+      ok: false,
+      backend: "agentmemory",
+      detail: "not_implemented",
+    };
+  }
+}

--- a/lib/ltm/agentmemory-backend.ts
+++ b/lib/ltm/agentmemory-backend.ts
@@ -26,22 +26,26 @@ export class AgentMemoryRestBackend implements MemoryBackend {
   }
 
   async remember(
-    _input: RememberInput
+    input: RememberInput
   ): Promise<{ id: string; type: MemoryType }> {
+    void input;
     throw new Error(NOT_IMPLEMENTED);
   }
 
-  async recall(_input: RecallInput): Promise<RecallHit[]> {
+  async recall(input: RecallInput): Promise<RecallHit[]> {
+    void input;
     throw new Error(NOT_IMPLEMENTED);
   }
 
   async observe(
-    _input: ObserveInput
+    input: ObserveInput
   ): Promise<{ observationId: string } | { deduplicated: true }> {
+    void input;
     throw new Error(NOT_IMPLEMENTED);
   }
 
-  async forget(_input: ForgetInput): Promise<{ deleted: number }> {
+  async forget(input: ForgetInput): Promise<{ deleted: number }> {
+    void input;
     throw new Error(NOT_IMPLEMENTED);
   }
 

--- a/lib/ltm/backend.ts
+++ b/lib/ltm/backend.ts
@@ -1,0 +1,19 @@
+import type {
+  ForgetInput,
+  MemoryType,
+  ObserveInput,
+  RecallHit,
+  RecallInput,
+  RememberInput,
+} from "./types";
+
+export interface MemoryBackend {
+  remember(input: RememberInput): Promise<{ id: string; type: MemoryType }>;
+  recall(input: RecallInput): Promise<RecallHit[]>;
+  observe(
+    input: ObserveInput
+  ): Promise<{ observationId: string } | { deduplicated: true }>;
+  forget(input: ForgetInput): Promise<{ deleted: number }>;
+  health(): Promise<{ ok: boolean; backend: string; detail?: string }>;
+  close?(): Promise<void>;
+}

--- a/lib/ltm/config.ts
+++ b/lib/ltm/config.ts
@@ -1,0 +1,79 @@
+import { join } from "node:path";
+import { readDesktopSettings } from "../desktop-settings.ts";
+
+export type LtmBackendKind = "sqlite" | "agentmemory";
+
+export interface LtmConfig {
+  enabled: boolean;
+  backend: LtmBackendKind;
+  dbPath: string;
+  observeAgentEnd: boolean;
+  observePreCompact: boolean;
+  agentmemoryUrl: string;
+}
+
+/** Partial LTM overrides stored under desktop-settings.json `ltm`. */
+export type LtmConfigPartial = {
+  enabled?: boolean;
+  backend?: LtmBackendKind;
+  dbPath?: string;
+  observeAgentEnd?: boolean;
+  observePreCompact?: boolean;
+  agentmemoryUrl?: string;
+};
+
+export function isLtmBackendKind(value: unknown): value is LtmBackendKind {
+  return value === "sqlite" || value === "agentmemory";
+}
+
+export function defaultLtmConfig(agentDir: string): LtmConfig {
+  return {
+    enabled: true,
+    backend: "sqlite",
+    dbPath: join(agentDir, "memory", "ltm.sqlite"),
+    observeAgentEnd: true,
+    observePreCompact: true,
+    agentmemoryUrl: "http://127.0.0.1:3111",
+  };
+}
+
+/** Merge a partial (e.g. from desktop-settings) onto defaults for agentDir. */
+export function mergeLtmConfig(
+  agentDir: string,
+  partial: LtmConfigPartial | undefined
+): LtmConfig {
+  const base = defaultLtmConfig(agentDir);
+  if (!partial) return base;
+
+  const dbPath =
+    typeof partial.dbPath === "string" && partial.dbPath.trim().length > 0
+      ? partial.dbPath.trim()
+      : base.dbPath;
+  const agentmemoryUrl =
+    typeof partial.agentmemoryUrl === "string" &&
+    partial.agentmemoryUrl.trim().length > 0
+      ? partial.agentmemoryUrl.trim()
+      : base.agentmemoryUrl;
+
+  return {
+    enabled:
+      typeof partial.enabled === "boolean" ? partial.enabled : base.enabled,
+    backend: isLtmBackendKind(partial.backend) ? partial.backend : base.backend,
+    dbPath,
+    observeAgentEnd:
+      typeof partial.observeAgentEnd === "boolean"
+        ? partial.observeAgentEnd
+        : base.observeAgentEnd,
+    observePreCompact:
+      typeof partial.observePreCompact === "boolean"
+        ? partial.observePreCompact
+        : base.observePreCompact,
+    agentmemoryUrl,
+  };
+}
+
+/** Read desktop-settings.json `ltm` and merge with defaults for agentDir. */
+export function getLtmConfig(agentDir: string): LtmConfig {
+  const settings = readDesktopSettings(agentDir);
+  return mergeLtmConfig(agentDir, settings.ltm);
+}

--- a/lib/ltm/http.test.ts
+++ b/lib/ltm/http.test.ts
@@ -1,0 +1,129 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  isLtmDisabledError,
+  isMemoryType,
+  parseForgetBody,
+  parseLimit,
+  parseRecallQuery,
+  parseRememberBody,
+  parseStatsQuery,
+  LTM_DISABLED,
+} from "./http.ts";
+
+test("parseRecallQuery requires cwd and q", () => {
+  const missing = parseRecallQuery("http://x/api/memory/recall");
+  assert.equal(missing.ok, false);
+  if (!missing.ok) assert.match(missing.error, /cwd/);
+
+  const noQ = parseRecallQuery("http://x/api/memory/recall?cwd=/proj");
+  assert.equal(noQ.ok, false);
+  if (!noQ.ok) assert.match(noQ.error, /q/);
+
+  const ok = parseRecallQuery(
+    "http://x/api/memory/recall?cwd=%2Fproj&q=session+roots&limit=5"
+  );
+  assert.equal(ok.ok, true);
+  if (ok.ok) {
+    assert.equal(ok.value.cwd, "/proj");
+    assert.equal(ok.value.query, "session roots");
+    assert.equal(ok.value.limit, 5);
+  }
+});
+
+test("parseRecallQuery accepts URLSearchParams", () => {
+  const params = new URLSearchParams({ cwd: "D:\\work", q: "prefer path" });
+  const ok = parseRecallQuery(params);
+  assert.equal(ok.ok, true);
+  if (ok.ok) {
+    assert.equal(ok.value.cwd, "D:\\work");
+    assert.equal(ok.value.query, "prefer path");
+    assert.equal(ok.value.limit, undefined);
+  }
+});
+
+test("parseRecallQuery rejects blank cwd/q", () => {
+  const blank = parseRecallQuery("http://x/?cwd=%20&q=hi");
+  assert.equal(blank.ok, false);
+});
+
+test("parseLimit clamps to 1..50", () => {
+  assert.equal(parseLimit(undefined), 10);
+  assert.equal(parseLimit("3"), 3);
+  assert.equal(parseLimit(0), 1);
+  assert.equal(parseLimit(100), 50);
+  assert.equal(parseLimit("nope"), 10);
+});
+
+test("parseStatsQuery requires cwd", () => {
+  assert.equal(parseStatsQuery("http://x/stats").ok, false);
+  const ok = parseStatsQuery(new URL("http://x/stats?cwd=/a"));
+  assert.equal(ok.ok, true);
+  if (ok.ok) assert.equal(ok.value.cwd, "/a");
+});
+
+test("parseRememberBody validates fields", () => {
+  assert.equal(parseRememberBody(null).ok, false);
+  assert.equal(parseRememberBody({}).ok, false);
+  assert.equal(parseRememberBody({ cwd: "/p" }).ok, false);
+
+  const badType = parseRememberBody({
+    cwd: "/p",
+    content: "note",
+    type: "unknown",
+  });
+  assert.equal(badType.ok, false);
+
+  const badConcepts = parseRememberBody({
+    cwd: "/p",
+    content: "note",
+    concepts: [1],
+  });
+  assert.equal(badConcepts.ok, false);
+
+  const ok = parseRememberBody({
+    cwd: "/p",
+    content: "Prefer path resolve",
+    type: "preference",
+    concepts: ["path"],
+    files: ["lib/a.ts"],
+  });
+  assert.equal(ok.ok, true);
+  if (ok.ok) {
+    assert.equal(ok.value.cwd, "/p");
+    assert.equal(ok.value.type, "preference");
+    assert.deepEqual(ok.value.concepts, ["path"]);
+    assert.deepEqual(ok.value.files, ["lib/a.ts"]);
+  }
+});
+
+test("parseForgetBody requires cwd and at least one id list", () => {
+  assert.equal(parseForgetBody({ cwd: "/p" }).ok, false);
+  assert.equal(
+    parseForgetBody({ cwd: "/p", memoryIds: [], observationIds: [] }).ok,
+    false
+  );
+
+  const ok = parseForgetBody({
+    cwd: "/p",
+    memoryIds: ["mem_1"],
+  });
+  assert.equal(ok.ok, true);
+  if (ok.ok) {
+    assert.deepEqual(ok.value.memoryIds, ["mem_1"]);
+  }
+
+  const both = parseForgetBody({
+    cwd: "/p",
+    observationIds: ["obs_1"],
+  });
+  assert.equal(both.ok, true);
+});
+
+test("isMemoryType and isLtmDisabledError", () => {
+  assert.equal(isMemoryType("fact"), true);
+  assert.equal(isMemoryType("nope"), false);
+  assert.equal(isLtmDisabledError(new Error(LTM_DISABLED)), true);
+  assert.equal(isLtmDisabledError(new Error("other")), false);
+  assert.equal(isLtmDisabledError("ltm_disabled"), false);
+});

--- a/lib/ltm/http.ts
+++ b/lib/ltm/http.ts
@@ -1,0 +1,201 @@
+import type { MemoryType } from "./types.ts";
+
+export const LTM_DISABLED = "ltm_disabled";
+
+const MEMORY_TYPES = new Set<MemoryType>([
+  "pattern",
+  "preference",
+  "architecture",
+  "bug",
+  "workflow",
+  "fact",
+]);
+
+const DEFAULT_LIMIT = 10;
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 50;
+
+export type ParseOk<T> = { ok: true; value: T };
+export type ParseErr = { ok: false; error: string };
+export type ParseResult<T> = ParseOk<T> | ParseErr;
+
+export interface RecallQuery {
+  cwd: string;
+  query: string;
+  limit?: number;
+}
+
+export interface StatsQuery {
+  cwd: string;
+}
+
+export interface RememberBody {
+  cwd: string;
+  content: string;
+  type?: MemoryType;
+  concepts?: string[];
+  files?: string[];
+}
+
+export interface ForgetBody {
+  cwd: string;
+  memoryIds?: string[];
+  observationIds?: string[];
+}
+
+export function isLtmDisabledError(err: unknown): boolean {
+  return err instanceof Error && err.message === LTM_DISABLED;
+}
+
+export function isMemoryType(value: unknown): value is MemoryType {
+  return typeof value === "string" && MEMORY_TYPES.has(value as MemoryType);
+}
+
+/** Clamp limit to [1, 50]; invalid → default 10. */
+export function parseLimit(value: unknown): number {
+  if (value === null || value === undefined || value === "") return DEFAULT_LIMIT;
+  const num = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(num)) return DEFAULT_LIMIT;
+  return Math.min(MAX_LIMIT, Math.max(MIN_LIMIT, Math.floor(num)));
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function stringArray(value: unknown, field: string): ParseResult<string[] | undefined> {
+  if (value === undefined || value === null) return { ok: true, value: undefined };
+  if (!Array.isArray(value)) {
+    return { ok: false, error: `${field} must be an array of strings` };
+  }
+  for (const item of value) {
+    if (typeof item !== "string") {
+      return { ok: false, error: `${field} must be an array of strings` };
+    }
+  }
+  return { ok: true, value: value as string[] };
+}
+
+/**
+ * GET /api/memory/recall — require `cwd` + `q`; optional `limit`.
+ * Accepts URL, URLSearchParams, or a full request URL string.
+ */
+export function parseRecallQuery(
+  input: URL | URLSearchParams | string
+): ParseResult<RecallQuery> {
+  const params =
+    input instanceof URLSearchParams
+      ? input
+      : input instanceof URL
+        ? input.searchParams
+        : new URL(input, "http://localhost").searchParams;
+
+  const cwd = nonEmptyString(params.get("cwd"));
+  if (!cwd) return { ok: false, error: "cwd is required" };
+
+  const q = nonEmptyString(params.get("q"));
+  if (!q) return { ok: false, error: "q is required" };
+
+  const limitRaw = params.get("limit");
+  const limit =
+    limitRaw === null || limitRaw === ""
+      ? undefined
+      : parseLimit(limitRaw);
+
+  return {
+    ok: true,
+    value: limit === undefined ? { cwd, query: q } : { cwd, query: q, limit },
+  };
+}
+
+/** GET /api/memory/stats — require `cwd`. */
+export function parseStatsQuery(
+  input: URL | URLSearchParams | string
+): ParseResult<StatsQuery> {
+  const params =
+    input instanceof URLSearchParams
+      ? input
+      : input instanceof URL
+        ? input.searchParams
+        : new URL(input, "http://localhost").searchParams;
+
+  const cwd = nonEmptyString(params.get("cwd"));
+  if (!cwd) return { ok: false, error: "cwd is required" };
+  return { ok: true, value: { cwd } };
+}
+
+/** POST /api/memory/remember — JSON body. */
+export function parseRememberBody(body: unknown): ParseResult<RememberBody> {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, error: "JSON body is required" };
+  }
+  const o = body as Record<string, unknown>;
+
+  const cwd = nonEmptyString(o.cwd);
+  if (!cwd) return { ok: false, error: "cwd is required" };
+
+  if (typeof o.content !== "string" || o.content.trim().length === 0) {
+    return { ok: false, error: "content is required" };
+  }
+
+  let type: MemoryType | undefined;
+  if (o.type !== undefined && o.type !== null) {
+    if (!isMemoryType(o.type)) {
+      return {
+        ok: false,
+        error:
+          "type must be one of: pattern, preference, architecture, bug, workflow, fact",
+      };
+    }
+    type = o.type;
+  }
+
+  const concepts = stringArray(o.concepts, "concepts");
+  if (!concepts.ok) return concepts;
+
+  const files = stringArray(o.files, "files");
+  if (!files.ok) return files;
+
+  const result: RememberBody = { cwd, content: o.content };
+  if (type !== undefined) result.type = type;
+  if (concepts.value !== undefined) result.concepts = concepts.value;
+  if (files.value !== undefined) result.files = files.value;
+  return { ok: true, value: result };
+}
+
+/** POST /api/memory/forget — JSON body. */
+export function parseForgetBody(body: unknown): ParseResult<ForgetBody> {
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, error: "JSON body is required" };
+  }
+  const o = body as Record<string, unknown>;
+
+  const cwd = nonEmptyString(o.cwd);
+  if (!cwd) return { ok: false, error: "cwd is required" };
+
+  const memoryIds = stringArray(o.memoryIds, "memoryIds");
+  if (!memoryIds.ok) return memoryIds;
+
+  const observationIds = stringArray(o.observationIds, "observationIds");
+  if (!observationIds.ok) return observationIds;
+
+  const hasMem =
+    memoryIds.value !== undefined && memoryIds.value.length > 0;
+  const hasObs =
+    observationIds.value !== undefined && observationIds.value.length > 0;
+  if (!hasMem && !hasObs) {
+    return {
+      ok: false,
+      error: "memoryIds or observationIds is required",
+    };
+  }
+
+  const result: ForgetBody = { cwd };
+  if (memoryIds.value !== undefined) result.memoryIds = memoryIds.value;
+  if (observationIds.value !== undefined) {
+    result.observationIds = observationIds.value;
+  }
+  return { ok: true, value: result };
+}

--- a/lib/ltm/index.ts
+++ b/lib/ltm/index.ts
@@ -1,0 +1,32 @@
+export type { MemoryBackend } from "./backend.ts";
+export { AgentMemoryRestBackend } from "./agentmemory-backend.ts";
+export {
+  defaultLtmConfig,
+  getLtmConfig,
+  isLtmBackendKind,
+  mergeLtmConfig,
+  type LtmBackendKind,
+  type LtmConfig,
+  type LtmConfigPartial,
+} from "./config.ts";
+export { jaccardSimilarity } from "./jaccard.ts";
+export { projectIdFromCwd } from "./project-id.ts";
+export {
+  getMemoryService,
+  MemoryService,
+  resetMemoryServiceForTests,
+  type ForgetFromCwdInput,
+  type ObserveFromCwdInput,
+  type RecallFromCwdInput,
+  type RememberFromCwdInput,
+} from "./service.ts";
+export { sanitizeFtsQuery, SqliteBackend } from "./sqlite-backend.ts";
+export type {
+  ForgetInput,
+  MemoryType,
+  ObserveInput,
+  ObserveKind,
+  RecallHit,
+  RecallInput,
+  RememberInput,
+} from "./types.ts";

--- a/lib/ltm/index.ts
+++ b/lib/ltm/index.ts
@@ -9,6 +9,21 @@ export {
   type LtmConfig,
   type LtmConfigPartial,
 } from "./config.ts";
+export {
+  isLtmDisabledError,
+  isMemoryType,
+  LTM_DISABLED,
+  parseForgetBody,
+  parseLimit,
+  parseRecallQuery,
+  parseRememberBody,
+  parseStatsQuery,
+  type ForgetBody,
+  type ParseResult,
+  type RecallQuery,
+  type RememberBody,
+  type StatsQuery,
+} from "./http.ts";
 export { jaccardSimilarity } from "./jaccard.ts";
 export { projectIdFromCwd } from "./project-id.ts";
 export {

--- a/lib/ltm/jaccard.test.ts
+++ b/lib/ltm/jaccard.test.ts
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { jaccardSimilarity } from "./jaccard.ts";
+
+test("identical multi-word strings score 1", () => {
+  assert.equal(jaccardSimilarity("prefer dark mode theme", "prefer dark mode theme"), 1);
+});
+
+test("disjoint strings score 0", () => {
+  assert.equal(jaccardSimilarity("alpha beta gamma", "delta epsilon zeta"), 0);
+});
+
+test("high overlap exceeds 0.7", () => {
+  const s = jaccardSimilarity(
+    "use path resolve for session root directory layout",
+    "use path resolve for session root directory layout please"
+  );
+  assert.ok(s > 0.7);
+});

--- a/lib/ltm/jaccard.ts
+++ b/lib/ltm/jaccard.ts
@@ -1,0 +1,17 @@
+/** Whitespace tokens, drop length <= 2 (ASCII-oriented v1). */
+export function jaccardSimilarity(a: string, b: string): number {
+  const na = a.normalize("NFC").toLowerCase();
+  const nb = b.normalize("NFC").toLowerCase();
+  const setA = tokens(na);
+  const setB = tokens(nb);
+  if (setA.size === 0 || setB.size === 0) {
+    return na.trim().replace(/\s+/g, " ") === nb.trim().replace(/\s+/g, " ") ? 1 : 0;
+  }
+  let inter = 0;
+  for (const t of setA) if (setB.has(t)) inter++;
+  return inter / (setA.size + setB.size - inter);
+}
+
+function tokens(text: string): Set<string> {
+  return new Set(text.split(/\s+/).filter((t) => t.length > 2));
+}

--- a/lib/ltm/observe-hooks.test.ts
+++ b/lib/ltm/observe-hooks.test.ts
@@ -1,0 +1,166 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  branchEntriesToMessagesText,
+  contentToText,
+  safeLtmPreCompactObserve,
+} from "./observe-hooks.ts";
+import {
+  getMemoryService,
+  resetMemoryServiceForTests,
+} from "./service.ts";
+
+test("contentToText handles string content", () => {
+  assert.equal(contentToText("hello"), "hello");
+});
+
+test("contentToText joins text and thinking blocks", () => {
+  const text = contentToText([
+    { type: "text", text: "line1" },
+    { type: "thinking", thinking: "think" },
+    { type: "toolCall", toolName: "bash", input: {} },
+    { type: "image", source: { type: "url", url: "x" } },
+  ]);
+  assert.equal(text, "line1\nthink");
+});
+
+test("contentToText returns empty for unknown shapes", () => {
+  assert.equal(contentToText(null), "");
+  assert.equal(contentToText(42), "");
+  assert.equal(contentToText([{ type: "image" }]), "");
+});
+
+test("branchEntriesToMessagesText extracts user/assistant/toolResult only", () => {
+  const entries = [
+    { type: "session", id: "s" },
+    {
+      type: "message",
+      message: { role: "user", content: "Fix the bug" },
+    },
+    {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Looking into it" }],
+      },
+    },
+    {
+      type: "message",
+      message: {
+        role: "toolResult",
+        toolCallId: "t1",
+        content: [{ type: "text", text: "file contents" }],
+      },
+    },
+    {
+      type: "message",
+      message: { role: "custom", content: "skip me", display: true },
+    },
+    { type: "compaction", summary: "old summary" },
+    {
+      type: "message",
+      message: { role: "user", content: "  " },
+    },
+  ];
+
+  const text = branchEntriesToMessagesText(entries);
+  assert.equal(
+    text,
+    "user: Fix the bug\n\nassistant: Looking into it\n\ntoolResult: file contents"
+  );
+});
+
+test("branchEntriesToMessagesText empty branch is empty string", () => {
+  assert.equal(branchEntriesToMessagesText([]), "");
+  assert.equal(branchEntriesToMessagesText([{ type: "compaction" }]), "");
+});
+
+test("safeLtmPreCompactObserve no-ops when observePreCompact false", async () => {
+  const agentDir = mkdtempSync(join(tmpdir(), "ltm-hooks-"));
+  try {
+    writeFileSync(
+      join(agentDir, "desktop-settings.json"),
+      JSON.stringify({
+        ltm: {
+          enabled: true,
+          observePreCompact: false,
+          dbPath: join(agentDir, "memory", "ltm.sqlite"),
+        },
+      })
+    );
+    resetMemoryServiceForTests();
+
+    await safeLtmPreCompactObserve({
+      sessionId: "sess-1",
+      cwd: agentDir,
+      messagesText: "should not persist",
+      agentDir,
+    });
+
+    const service = getMemoryService(agentDir);
+    assert.equal(service.getConfig().observePreCompact, false);
+    const hits = await service.recallFromCwd(agentDir, {
+      query: "should not persist",
+      limit: 5,
+      kinds: ["observation"],
+    });
+    assert.equal(hits.length, 0);
+  } finally {
+    resetMemoryServiceForTests();
+    rmSync(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("safeLtmPreCompactObserve persists when enabled", async () => {
+  const agentDir = mkdtempSync(join(tmpdir(), "ltm-hooks-on-"));
+  try {
+    writeFileSync(
+      join(agentDir, "desktop-settings.json"),
+      JSON.stringify({
+        ltm: {
+          enabled: true,
+          observePreCompact: true,
+          dbPath: join(agentDir, "memory", "ltm.sqlite"),
+        },
+      })
+    );
+    resetMemoryServiceForTests();
+
+    await safeLtmPreCompactObserve({
+      sessionId: "sess-compact-1",
+      cwd: agentDir,
+      messagesText: "user: remember this before compact\n\nassistant: ok",
+      agentDir,
+    });
+
+    const service = getMemoryService(agentDir);
+    const hits = await service.recallFromCwd(agentDir, {
+      query: "remember this before compact",
+      limit: 5,
+      kinds: ["observation"],
+    });
+    assert.ok(hits.length >= 1, "expected at least one observation hit");
+    assert.ok(
+      hits.some(
+        (h) =>
+          h.kind === "observation" &&
+          (h.snippet.includes("remember this") ||
+            h.title.includes("remember this"))
+      )
+    );
+  } finally {
+    resetMemoryServiceForTests();
+    rmSync(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("safeLtmPreCompactObserve swallows errors", async () => {
+  await safeLtmPreCompactObserve({
+    sessionId: "x",
+    cwd: "\0invalid",
+    messagesText: "anything",
+  });
+});

--- a/lib/ltm/observe-hooks.test.ts
+++ b/lib/ltm/observe-hooks.test.ts
@@ -6,6 +6,9 @@ import { tmpdir } from "node:os";
 import {
   branchEntriesToMessagesText,
   contentToText,
+  lastAssistantFromBranch,
+  lastUserFromBranch,
+  safeLtmAgentEndObserve,
   safeLtmPreCompactObserve,
 } from "./observe-hooks.ts";
 import {
@@ -162,5 +165,158 @@ test("safeLtmPreCompactObserve swallows errors", async () => {
     sessionId: "x",
     cwd: "\0invalid",
     messagesText: "anything",
+  });
+});
+
+test("lastUserFromBranch / lastAssistantFromBranch from branch entries", () => {
+  const entries = [
+    {
+      type: "message",
+      message: { role: "user", content: "first question" },
+    },
+    {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "first answer" }],
+      },
+    },
+    {
+      type: "message",
+      message: { role: "user", content: "second question" },
+    },
+    {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "second answer" }],
+      },
+    },
+    { type: "compaction", summary: "skip" },
+  ];
+  assert.equal(lastUserFromBranch(entries), "second question");
+  assert.equal(lastAssistantFromBranch(entries), "second answer");
+});
+
+test("lastUserFromBranch / lastAssistantFromBranch from raw messages", () => {
+  const messages = [
+    { role: "user", content: "prompt me" },
+    { role: "toolResult", content: [{ type: "text", text: "tool out" }] },
+    { role: "assistant", content: [{ type: "text", text: "done" }] },
+  ];
+  assert.equal(lastUserFromBranch(messages), "prompt me");
+  assert.equal(lastAssistantFromBranch(messages), "done");
+});
+
+test("lastUserFromBranch skips empty role text", () => {
+  const entries = [
+    {
+      type: "message",
+      message: { role: "user", content: "real user" },
+    },
+    {
+      type: "message",
+      message: { role: "user", content: "   " },
+    },
+    {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "  " }],
+      },
+    },
+  ];
+  assert.equal(lastUserFromBranch(entries), "real user");
+  assert.equal(lastAssistantFromBranch(entries), "");
+});
+
+test("safeLtmAgentEndObserve no-ops when observeAgentEnd false", async () => {
+  const agentDir = mkdtempSync(join(tmpdir(), "ltm-agent-end-off-"));
+  try {
+    writeFileSync(
+      join(agentDir, "desktop-settings.json"),
+      JSON.stringify({
+        ltm: {
+          enabled: true,
+          observeAgentEnd: false,
+          dbPath: join(agentDir, "memory", "ltm.sqlite"),
+        },
+      })
+    );
+    resetMemoryServiceForTests();
+
+    await safeLtmAgentEndObserve({
+      sessionId: "sess-end-1",
+      cwd: agentDir,
+      userText: "should not persist agent end",
+      assistantText: "nope",
+      agentDir,
+    });
+
+    const service = getMemoryService(agentDir);
+    assert.equal(service.getConfig().observeAgentEnd, false);
+    const hits = await service.recallFromCwd(agentDir, {
+      query: "should not persist agent end",
+      limit: 5,
+      kinds: ["observation"],
+    });
+    assert.equal(hits.length, 0);
+  } finally {
+    resetMemoryServiceForTests();
+    rmSync(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("safeLtmAgentEndObserve persists when enabled", async () => {
+  const agentDir = mkdtempSync(join(tmpdir(), "ltm-agent-end-on-"));
+  try {
+    writeFileSync(
+      join(agentDir, "desktop-settings.json"),
+      JSON.stringify({
+        ltm: {
+          enabled: true,
+          observeAgentEnd: true,
+          dbPath: join(agentDir, "memory", "ltm.sqlite"),
+        },
+      })
+    );
+    resetMemoryServiceForTests();
+
+    await safeLtmAgentEndObserve({
+      sessionId: "sess-end-2",
+      cwd: agentDir,
+      userText: "remember this agent end turn",
+      assistantText: "stored for later recall",
+      agentDir,
+    });
+
+    const service = getMemoryService(agentDir);
+    const hits = await service.recallFromCwd(agentDir, {
+      query: "remember this agent end turn",
+      limit: 5,
+      kinds: ["observation"],
+    });
+    assert.ok(hits.length >= 1, "expected at least one observation hit");
+    assert.ok(
+      hits.some(
+        (h) =>
+          h.kind === "observation" &&
+          (h.snippet.includes("remember this") ||
+            h.title.includes("remember this") ||
+            h.snippet.includes("stored for later"))
+      )
+    );
+  } finally {
+    resetMemoryServiceForTests();
+    rmSync(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("safeLtmAgentEndObserve swallows errors", async () => {
+  await safeLtmAgentEndObserve({
+    sessionId: "x",
+    cwd: "\0invalid",
+    userText: "u",
+    assistantText: "a",
   });
 });

--- a/lib/ltm/observe-hooks.ts
+++ b/lib/ltm/observe-hooks.ts
@@ -1,4 +1,7 @@
-import { buildPreCompactObservation } from "./observe-payload.ts";
+import {
+  buildAgentEndObservation,
+  buildPreCompactObservation,
+} from "./observe-payload.ts";
 import { getMemoryService } from "./service.ts";
 
 /** Pull plain text from user/assistant/toolResult content shapes. */
@@ -17,6 +20,45 @@ export function contentToText(content: unknown): string {
     }
   }
   return parts.join("\n");
+}
+
+/**
+ * Resolve a message-like object from either:
+ * - agent_end event.messages items: `{ role, content }`
+ * - session branch entries: `{ type: "message", message: { role, content } }`
+ */
+function coerceMessage(item: unknown): Record<string, unknown> | null {
+  if (!item || typeof item !== "object") return null;
+  const o = item as Record<string, unknown>;
+  if (o.type === "message" && o.message && typeof o.message === "object") {
+    return o.message as Record<string, unknown>;
+  }
+  if (typeof o.role === "string") return o;
+  return null;
+}
+
+/**
+ * Last non-empty text for `role` walking source from the end.
+ * Accepts branch entries or raw message arrays.
+ */
+function lastRoleText(source: unknown[], role: "user" | "assistant"): string {
+  for (let i = source.length - 1; i >= 0; i--) {
+    const message = coerceMessage(source[i]);
+    if (!message || message.role !== role) continue;
+    const text = contentToText(message.content).trim();
+    if (text) return text;
+  }
+  return "";
+}
+
+/** Last user message text from branch entries or message list. */
+export function lastUserFromBranch(source: unknown[]): string {
+  return lastRoleText(source, "user");
+}
+
+/** Last assistant message text from branch entries or message list. */
+export function lastAssistantFromBranch(source: unknown[]): string {
+  return lastRoleText(source, "assistant");
 }
 
 /**
@@ -79,5 +121,42 @@ export async function safeLtmPreCompactObserve(
     });
   } catch (err) {
     console.error("ltm pre_compact observe failed:", err);
+  }
+}
+
+export interface AgentEndObserveInput {
+  sessionId: string;
+  cwd: string;
+  userText: string;
+  assistantText: string;
+  /** Optional: force agentDir for getMemoryService (tests). */
+  agentDir?: string;
+}
+
+/**
+ * Best-effort agent_end LTM observe. Never throws — event path must proceed.
+ * Skips when LTM disabled or observeAgentEnd is false.
+ */
+export async function safeLtmAgentEndObserve(
+  input: AgentEndObserveInput
+): Promise<void> {
+  try {
+    const service = getMemoryService(input.agentDir);
+    const config = service.getConfig();
+    if (!config.enabled || !config.observeAgentEnd) return;
+
+    const { title, narrative } = buildAgentEndObservation({
+      userText: input.userText,
+      assistantText: input.assistantText,
+    });
+
+    await service.observeFromCwd(input.cwd, {
+      sessionId: input.sessionId,
+      kind: "agent_end",
+      title,
+      narrative,
+    });
+  } catch (err) {
+    console.error("ltm agent_end observe failed:", err);
   }
 }

--- a/lib/ltm/observe-hooks.ts
+++ b/lib/ltm/observe-hooks.ts
@@ -1,0 +1,83 @@
+import { buildPreCompactObservation } from "./observe-payload.ts";
+import { getMemoryService } from "./service.ts";
+
+/** Pull plain text from user/assistant/toolResult content shapes. */
+export function contentToText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const b = block as Record<string, unknown>;
+    if (b.type === "text" && typeof b.text === "string") {
+      parts.push(b.text);
+    } else if (b.type === "thinking" && typeof b.thinking === "string") {
+      parts.push(b.thinking);
+    }
+  }
+  return parts.join("\n");
+}
+
+/**
+ * Join message text from session branch entries (getBranch()).
+ * Only message entries with user / assistant / toolResult roles contribute.
+ */
+export function branchEntriesToMessagesText(entries: unknown[]): string {
+  const chunks: string[] = [];
+
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    if (e.type !== "message") continue;
+
+    const message = e.message;
+    if (!message || typeof message !== "object") continue;
+    const m = message as Record<string, unknown>;
+    const role = m.role;
+    if (role !== "user" && role !== "assistant" && role !== "toolResult") {
+      continue;
+    }
+
+    const text = contentToText(m.content).trim();
+    if (!text) continue;
+    chunks.push(`${role}: ${text}`);
+  }
+
+  return chunks.join("\n\n");
+}
+
+export interface PreCompactObserveInput {
+  sessionId: string;
+  cwd: string;
+  messagesText: string;
+  /** Optional: force agentDir for getMemoryService (tests). */
+  agentDir?: string;
+}
+
+/**
+ * Best-effort pre_compact LTM observe. Never throws — compact path must proceed.
+ * Skips when LTM disabled or observePreCompact is false.
+ */
+export async function safeLtmPreCompactObserve(
+  input: PreCompactObserveInput
+): Promise<void> {
+  try {
+    const service = getMemoryService(input.agentDir);
+    const config = service.getConfig();
+    if (!config.enabled || !config.observePreCompact) return;
+
+    const { title, narrative } = buildPreCompactObservation({
+      messagesText: input.messagesText,
+    });
+
+    await service.observeFromCwd(input.cwd, {
+      sessionId: input.sessionId,
+      kind: "pre_compact",
+      title,
+      narrative,
+    });
+  } catch (err) {
+    console.error("ltm pre_compact observe failed:", err);
+  }
+}

--- a/lib/ltm/observe-payload.test.ts
+++ b/lib/ltm/observe-payload.test.ts
@@ -33,8 +33,8 @@ test("buildAgentEndObservation truncates user 500 and assistant 4000", () => {
   const userText = "u".repeat(600);
   const assistantText = "a".repeat(5000);
   const { narrative } = buildAgentEndObservation({ userText, assistantText });
-  const userPart = narrative.match(/^User: (.*)\nAssistant: /s)?.[1] ?? "";
-  const asstPart = narrative.match(/\nAssistant: (.*)$/s)?.[1] ?? "";
+  const userPart = narrative.match(/^User: ([\s\S]*)\nAssistant: /)?.[1] ?? "";
+  const asstPart = narrative.match(/\nAssistant: ([\s\S]*)$/)?.[1] ?? "";
   assert.equal(userPart.length, 500);
   assert.equal(asstPart.length, 4000);
   assert.equal(userPart, "u".repeat(500));

--- a/lib/ltm/observe-payload.test.ts
+++ b/lib/ltm/observe-payload.test.ts
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildAgentEndObservation,
+  buildPreCompactObservation,
+} from "./observe-payload.ts";
+
+test("buildAgentEndObservation uses first line of user as title (≤80)", () => {
+  const user = "fix login bug\nmore detail here";
+  const { title, narrative } = buildAgentEndObservation({
+    userText: user,
+    assistantText: "patched auth",
+  });
+  assert.equal(title, "fix login bug");
+  // Narrative keeps full (truncated) user text, not only the first line.
+  assert.equal(
+    narrative,
+    "User: fix login bug\nmore detail here\nAssistant: patched auth"
+  );
+});
+
+test("buildAgentEndObservation truncates title to 80 chars", () => {
+  const user = "x".repeat(100);
+  const { title } = buildAgentEndObservation({
+    userText: user,
+    assistantText: "ok",
+  });
+  assert.equal(title.length, 80);
+  assert.equal(title, "x".repeat(80));
+});
+
+test("buildAgentEndObservation truncates user 500 and assistant 4000", () => {
+  const userText = "u".repeat(600);
+  const assistantText = "a".repeat(5000);
+  const { narrative } = buildAgentEndObservation({ userText, assistantText });
+  const userPart = narrative.match(/^User: (.*)\nAssistant: /s)?.[1] ?? "";
+  const asstPart = narrative.match(/\nAssistant: (.*)$/s)?.[1] ?? "";
+  assert.equal(userPart.length, 500);
+  assert.equal(asstPart.length, 4000);
+  assert.equal(userPart, "u".repeat(500));
+  assert.equal(asstPart, "a".repeat(4000));
+});
+
+test("buildAgentEndObservation empty strings become (empty)", () => {
+  const { title, narrative } = buildAgentEndObservation({
+    userText: "",
+    assistantText: "",
+  });
+  assert.equal(title, "(empty)");
+  assert.equal(narrative, "User: (empty)\nAssistant: (empty)");
+});
+
+test("buildPreCompactObservation title from first line ≤80", () => {
+  const messagesText = "session summary line\nrest of messages";
+  const { title, narrative } = buildPreCompactObservation({ messagesText });
+  assert.equal(title, "session summary line");
+  assert.equal(narrative, messagesText);
+});
+
+test("buildPreCompactObservation truncates body to 6000", () => {
+  const messagesText = "m".repeat(7000);
+  const { title, narrative } = buildPreCompactObservation({ messagesText });
+  assert.equal(narrative.length, 6000);
+  assert.equal(narrative, "m".repeat(6000));
+  assert.equal(title.length, 80);
+});
+
+test("buildPreCompactObservation empty becomes (empty)", () => {
+  const { title, narrative } = buildPreCompactObservation({ messagesText: "" });
+  assert.equal(title, "(empty)");
+  assert.equal(narrative, "(empty)");
+});

--- a/lib/ltm/observe-payload.ts
+++ b/lib/ltm/observe-payload.ts
@@ -1,0 +1,52 @@
+const TITLE_MAX = 80;
+const USER_MAX = 500;
+const ASSISTANT_MAX = 4000;
+const PRE_COMPACT_MAX = 6000;
+const EMPTY = "(empty)";
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : text.slice(0, max);
+}
+
+/** First line, truncated to TITLE_MAX; empty → "(empty)". */
+function titleFromText(text: string): string {
+  const line = text.split(/\r?\n/, 1)[0] ?? text;
+  const clipped = truncate(line, TITLE_MAX);
+  return clipped.length === 0 ? EMPTY : clipped;
+}
+
+function orEmpty(text: string): string {
+  return text.length === 0 ? EMPTY : text;
+}
+
+/**
+ * Zero-LLM payload for agent_end observe:
+ * - title: first line / 80 chars of last user prompt
+ * - narrative: User: (≤500) + Assistant: (≤4000)
+ */
+export function buildAgentEndObservation(input: {
+  userText: string;
+  assistantText: string;
+}): { title: string; narrative: string } {
+  const user = truncate(input.userText, USER_MAX);
+  const assistant = truncate(input.assistantText, ASSISTANT_MAX);
+  return {
+    title: titleFromText(input.userText),
+    narrative: `User: ${orEmpty(user)}\nAssistant: ${orEmpty(assistant)}`,
+  };
+}
+
+/**
+ * Zero-LLM payload for pre_compact observe:
+ * - title: first line / 80 chars of messages text
+ * - narrative: messages body truncated to 6000
+ */
+export function buildPreCompactObservation(input: {
+  messagesText: string;
+}): { title: string; narrative: string } {
+  const body = truncate(input.messagesText, PRE_COMPACT_MAX);
+  return {
+    title: titleFromText(input.messagesText),
+    narrative: orEmpty(body),
+  };
+}

--- a/lib/ltm/project-id.test.ts
+++ b/lib/ltm/project-id.test.ts
@@ -1,0 +1,14 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { projectIdFromCwd } from "./project-id.ts";
+
+test("projectIdFromCwd is stable for same absolute path", () => {
+  const a = projectIdFromCwd(process.cwd());
+  const b = projectIdFromCwd(process.cwd());
+  assert.equal(a, b);
+  assert.match(a, /^proj_[0-9a-f]{16}$/);
+});
+
+test("projectIdFromCwd rejects empty cwd", () => {
+  assert.throws(() => projectIdFromCwd("   "), /cwd/i);
+});

--- a/lib/ltm/project-id.ts
+++ b/lib/ltm/project-id.ts
@@ -1,0 +1,12 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+
+export function projectIdFromCwd(cwd: string): string {
+  if (typeof cwd !== "string" || !cwd.trim()) {
+    throw new Error("cwd is required for projectId");
+  }
+  const resolved = path.resolve(cwd.trim());
+  const key = process.platform === "win32" ? resolved.toLowerCase() : resolved;
+  const hex = createHash("sha256").update(key, "utf8").digest("hex");
+  return `proj_${hex.slice(0, 16)}`;
+}

--- a/lib/ltm/service.test.ts
+++ b/lib/ltm/service.test.ts
@@ -1,0 +1,257 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { AgentMemoryRestBackend } from "./agentmemory-backend.ts";
+import {
+  defaultLtmConfig,
+  getLtmConfig,
+  mergeLtmConfig,
+} from "./config.ts";
+import {
+  getMemoryService,
+  MemoryService,
+  resetMemoryServiceForTests,
+} from "./service.ts";
+import { projectIdFromCwd } from "./project-id.ts";
+
+function withTempAgentDir(
+  fn: (agentDir: string) => Promise<void> | void
+): Promise<void> {
+  const agentDir = mkdtempSync(join(tmpdir(), "ltm-svc-"));
+  return Promise.resolve(fn(agentDir)).finally(() => {
+    resetMemoryServiceForTests();
+    rmSync(agentDir, { recursive: true, force: true });
+  });
+}
+
+test("defaultLtmConfig uses agentDir/memory/ltm.sqlite", () => {
+  const cfg = defaultLtmConfig("/tmp/agent");
+  assert.equal(cfg.enabled, true);
+  assert.equal(cfg.backend, "sqlite");
+  assert.equal(cfg.dbPath, join("/tmp/agent", "memory", "ltm.sqlite"));
+  assert.equal(cfg.observeAgentEnd, true);
+  assert.equal(cfg.observePreCompact, true);
+  assert.equal(cfg.agentmemoryUrl, "http://127.0.0.1:3111");
+});
+
+test("getLtmConfig merges desktop-settings nested ltm", async () => {
+  await withTempAgentDir((agentDir) => {
+    writeFileSync(
+      join(agentDir, "desktop-settings.json"),
+      JSON.stringify({
+        defaultAgentMode: "ask",
+        defaultToolPreset: "default",
+        ltm: {
+          enabled: false,
+          backend: "sqlite",
+          observePreCompact: false,
+          agentmemoryUrl: "http://127.0.0.1:4000",
+        },
+      }),
+      "utf-8"
+    );
+    const cfg = getLtmConfig(agentDir);
+    assert.equal(cfg.enabled, false);
+    assert.equal(cfg.backend, "sqlite");
+    assert.equal(cfg.observePreCompact, false);
+    assert.equal(cfg.observeAgentEnd, true);
+    assert.equal(cfg.agentmemoryUrl, "http://127.0.0.1:4000");
+    assert.equal(cfg.dbPath, join(agentDir, "memory", "ltm.sqlite"));
+  });
+});
+
+test("mergeLtmConfig honors custom dbPath", () => {
+  const cfg = mergeLtmConfig("/agent", { dbPath: "D:/data/custom.sqlite" });
+  assert.equal(cfg.dbPath, "D:/data/custom.sqlite");
+});
+
+test("MemoryService.create remember/recall with temp agentDir", async () => {
+  await withTempAgentDir(async (agentDir) => {
+    const cfg = defaultLtmConfig(agentDir);
+    const svc = MemoryService.create(cfg);
+    try {
+      const cwd = join(agentDir, "proj");
+      mkdirSync(cwd, { recursive: true });
+
+      const saved = await svc.rememberFromCwd(cwd, {
+        content: "Prefer path resolve for session roots in LTM tests",
+        type: "preference",
+      });
+      assert.match(saved.id, /^mem_/);
+      assert.equal(saved.type, "preference");
+
+      const hits = await svc.recallFromCwd(cwd, {
+        query: "session roots",
+        limit: 5,
+      });
+      assert.ok(hits.some((h) => h.kind === "memory"));
+
+      const stats = await svc.statsFromCwd(cwd);
+      assert.equal(stats.memoryCount, 1);
+      assert.equal(stats.observationCount, 0);
+
+      assert.equal(svc.isEnabled(), true);
+      const health = await svc.health();
+      assert.equal(health.ok, true);
+      assert.equal(health.backend, "sqlite");
+    } finally {
+      await svc.close();
+    }
+  });
+});
+
+test("observeFromCwd no-ops when disabled; remember throws ltm_disabled", async () => {
+  await withTempAgentDir(async (agentDir) => {
+    const cfg = mergeLtmConfig(agentDir, { enabled: false });
+    const svc = MemoryService.create(cfg);
+    try {
+      const cwd = join(agentDir, "proj");
+      mkdirSync(cwd, { recursive: true });
+
+      const obs = await svc.observeFromCwd(cwd, {
+        sessionId: "s1",
+        kind: "agent_end",
+        title: "t",
+        narrative: "should not persist",
+      });
+      assert.deepEqual(obs, { deduplicated: true });
+
+      await assert.rejects(
+        () =>
+          svc.rememberFromCwd(cwd, {
+            content: "x",
+          }),
+        (err: unknown) => {
+          assert.ok(err instanceof Error);
+          assert.equal(err.message, "ltm_disabled");
+          return true;
+        }
+      );
+
+      await assert.rejects(
+        () => svc.recallFromCwd(cwd, { query: "x" }),
+        /ltm_disabled/
+      );
+
+      await assert.rejects(
+        () => svc.forgetFromCwd(cwd, { memoryIds: ["mem_1"] }),
+        /ltm_disabled/
+      );
+
+      const health = await svc.health();
+      assert.equal(health.ok, false);
+      assert.equal(health.detail, "ltm_disabled");
+    } finally {
+      await svc.close();
+    }
+  });
+});
+
+test("observeFromCwd persists when enabled", async () => {
+  await withTempAgentDir(async (agentDir) => {
+    const svc = MemoryService.create(defaultLtmConfig(agentDir));
+    try {
+      const cwd = join(agentDir, "proj");
+      mkdirSync(cwd, { recursive: true });
+      const result = await svc.observeFromCwd(cwd, {
+        sessionId: "sess-1",
+        kind: "pre_compact",
+        title: "compact snapshot",
+        narrative: "User asked about auth middleware patch",
+      });
+      assert.ok("observationId" in result);
+      const hits = await svc.recallFromCwd(cwd, {
+        query: "auth middleware",
+        kinds: ["observation"],
+      });
+      assert.ok(hits.length >= 1);
+      const stats = await svc.statsFromCwd(cwd);
+      assert.equal(stats.observationCount, 1);
+    } finally {
+      await svc.close();
+    }
+  });
+});
+
+test("AgentMemoryRestBackend health is not_implemented; methods throw", async () => {
+  const backend = new AgentMemoryRestBackend("http://127.0.0.1:3111");
+  const health = await backend.health();
+  assert.equal(health.ok, false);
+  assert.equal(health.backend, "agentmemory");
+  assert.equal(health.detail, "not_implemented");
+
+  await assert.rejects(
+    () =>
+      backend.remember({
+        projectId: "proj_x",
+        content: "hi",
+      }),
+    /not implemented in v1/
+  );
+  await assert.rejects(
+    () => backend.recall({ projectId: "proj_x", query: "hi" }),
+    /not implemented/
+  );
+});
+
+test("MemoryService with agentmemory backend health + throw", async () => {
+  await withTempAgentDir(async (agentDir) => {
+    const cfg = mergeLtmConfig(agentDir, { backend: "agentmemory" });
+    const svc = MemoryService.create(cfg);
+    try {
+      const health = await svc.health();
+      assert.equal(health.ok, false);
+      assert.equal(health.detail, "not_implemented");
+      await assert.rejects(
+        () =>
+          svc.rememberFromCwd(agentDir, {
+            content: "x",
+          }),
+        /not implemented/
+      );
+    } finally {
+      await svc.close();
+    }
+  });
+});
+
+test("getMemoryService singleton reuses same instance for same agentDir", async () => {
+  await withTempAgentDir(async (agentDir) => {
+    resetMemoryServiceForTests();
+    const a = getMemoryService(agentDir);
+    const b = getMemoryService(agentDir);
+    assert.equal(a, b);
+    assert.equal(a.isEnabled(), true);
+    await a.close();
+    resetMemoryServiceForTests();
+  });
+});
+
+test("rememberFromCwd scopes by projectId from cwd", async () => {
+  await withTempAgentDir(async (agentDir) => {
+    const svc = MemoryService.create(defaultLtmConfig(agentDir));
+    try {
+      const cwdA = join(agentDir, "a");
+      const cwdB = join(agentDir, "b");
+      mkdirSync(cwdA, { recursive: true });
+      mkdirSync(cwdB, { recursive: true });
+      assert.notEqual(projectIdFromCwd(cwdA), projectIdFromCwd(cwdB));
+
+      await svc.rememberFromCwd(cwdA, {
+        content: "unique flamingo widget convention",
+      });
+      const hitsB = await svc.recallFromCwd(cwdB, {
+        query: "flamingo widget",
+      });
+      assert.equal(hitsB.length, 0);
+      const hitsA = await svc.recallFromCwd(cwdA, {
+        query: "flamingo widget",
+      });
+      assert.ok(hitsA.length >= 1);
+    } finally {
+      await svc.close();
+    }
+  });
+});

--- a/lib/ltm/service.ts
+++ b/lib/ltm/service.ts
@@ -1,0 +1,188 @@
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import type { MemoryBackend } from "./backend.ts";
+import { AgentMemoryRestBackend } from "./agentmemory-backend.ts";
+import { getLtmConfig, type LtmConfig } from "./config.ts";
+import { projectIdFromCwd } from "./project-id.ts";
+import { SqliteBackend } from "./sqlite-backend.ts";
+import type {
+  ForgetInput,
+  MemoryType,
+  ObserveInput,
+  RecallHit,
+  RecallInput,
+  RememberInput,
+} from "./types.ts";
+
+const DISABLED_ERROR = "ltm_disabled";
+
+export type RememberFromCwdInput = Omit<RememberInput, "projectId">;
+export type RecallFromCwdInput = Omit<RecallInput, "projectId">;
+export type ObserveFromCwdInput = Omit<ObserveInput, "projectId">;
+export type ForgetFromCwdInput = Omit<ForgetInput, "projectId">;
+
+type LtmServiceGlobal = {
+  __piLtmService?: MemoryService;
+  __piLtmServiceKey?: string;
+};
+
+function ltmGlobal(): LtmServiceGlobal {
+  return globalThis as typeof globalThis & LtmServiceGlobal;
+}
+
+function createBackend(config: LtmConfig): MemoryBackend {
+  if (config.backend === "agentmemory") {
+    return new AgentMemoryRestBackend(config.agentmemoryUrl);
+  }
+  return new SqliteBackend(config.dbPath);
+}
+
+function serviceKey(config: LtmConfig): string {
+  return `${config.backend}|${config.dbPath}|${config.enabled}`;
+}
+
+export class MemoryService {
+  private readonly config: LtmConfig;
+  private readonly backend: MemoryBackend;
+
+  private constructor(config: LtmConfig, backend: MemoryBackend) {
+    this.config = config;
+    this.backend = backend;
+  }
+
+  /** Testable factory: builds a service from an explicit config (no globalThis). */
+  static create(config: LtmConfig): MemoryService {
+    return new MemoryService(config, createBackend(config));
+  }
+
+  isEnabled(): boolean {
+    return this.config.enabled;
+  }
+
+  getConfig(): Readonly<LtmConfig> {
+    return this.config;
+  }
+
+  async health(): Promise<{ ok: boolean; backend: string; detail?: string }> {
+    if (!this.config.enabled) {
+      return { ok: false, backend: this.config.backend, detail: DISABLED_ERROR };
+    }
+    return this.backend.health();
+  }
+
+  async rememberFromCwd(
+    cwd: string,
+    input: RememberFromCwdInput
+  ): Promise<{ id: string; type: MemoryType }> {
+    this.assertEnabled();
+    return this.backend.remember({
+      ...input,
+      projectId: projectIdFromCwd(cwd),
+    });
+  }
+
+  async recallFromCwd(
+    cwd: string,
+    input: RecallFromCwdInput
+  ): Promise<RecallHit[]> {
+    this.assertEnabled();
+    return this.backend.recall({
+      ...input,
+      projectId: projectIdFromCwd(cwd),
+    });
+  }
+
+  /**
+   * Observe path for hooks: silent no-op when LTM is disabled.
+   * Returns `{ deduplicated: true }` when skipped (disabled).
+   */
+  async observeFromCwd(
+    cwd: string,
+    input: ObserveFromCwdInput
+  ): Promise<{ observationId: string } | { deduplicated: true }> {
+    if (!this.config.enabled) {
+      return { deduplicated: true };
+    }
+    return this.backend.observe({
+      ...input,
+      projectId: projectIdFromCwd(cwd),
+    });
+  }
+
+  /** Alias for hooks: same as observeFromCwd (no-ops when disabled). */
+  async safeObserve(
+    cwd: string,
+    input: ObserveFromCwdInput
+  ): Promise<{ observationId: string } | { deduplicated: true }> {
+    return this.observeFromCwd(cwd, input);
+  }
+
+  async forgetFromCwd(
+    cwd: string,
+    input: ForgetFromCwdInput
+  ): Promise<{ deleted: number }> {
+    this.assertEnabled();
+    return this.backend.forget({
+      ...input,
+      projectId: projectIdFromCwd(cwd),
+    });
+  }
+
+  async statsFromCwd(
+    cwd: string
+  ): Promise<{ memoryCount: number; observationCount: number }> {
+    this.assertEnabled();
+    const projectId = projectIdFromCwd(cwd);
+    if (this.backend instanceof SqliteBackend) {
+      return this.backend.stats(projectId);
+    }
+    throw new Error("stats not supported for this backend");
+  }
+
+  async close(): Promise<void> {
+    await this.backend.close?.();
+  }
+
+  private assertEnabled(): void {
+    if (!this.config.enabled) {
+      throw new Error(DISABLED_ERROR);
+    }
+  }
+}
+
+/**
+ * Process-wide singleton (HMR-safe via globalThis).
+ * Keyed by backend|dbPath|enabled so config changes get a fresh instance.
+ */
+export function getMemoryService(agentDir?: string): MemoryService {
+  const dir = agentDir ?? getAgentDir();
+  const config = getLtmConfig(dir);
+  const key = serviceKey(config);
+  const g = ltmGlobal();
+
+  if (g.__piLtmService && g.__piLtmServiceKey === key) {
+    return g.__piLtmService;
+  }
+
+  const previous = g.__piLtmService;
+  const next = MemoryService.create(config);
+  g.__piLtmService = next;
+  g.__piLtmServiceKey = key;
+
+  // Best-effort close of previous instance (different dbPath / config).
+  if (previous) {
+    void previous.close().catch(() => {});
+  }
+
+  return next;
+}
+
+/** Test helper: clear the process singleton. */
+export function resetMemoryServiceForTests(): void {
+  const g = ltmGlobal();
+  const prev = g.__piLtmService;
+  g.__piLtmService = undefined;
+  g.__piLtmServiceKey = undefined;
+  if (prev) {
+    void prev.close().catch(() => {});
+  }
+}

--- a/lib/ltm/sqlite-backend.test.ts
+++ b/lib/ltm/sqlite-backend.test.ts
@@ -1,0 +1,240 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { SqliteBackend, sanitizeFtsQuery } from "./sqlite-backend.ts";
+
+function withTempBackend(
+  fn: (backend: SqliteBackend, dir: string) => Promise<void>
+): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), "ltm-"));
+  const backend = new SqliteBackend(join(dir, "t.sqlite"));
+  return fn(backend, dir).finally(async () => {
+    await backend.close?.();
+    rmSync(dir, { recursive: true, force: true });
+  });
+}
+
+test("remember and recall within project", async () => {
+  await withTempBackend(async (backend) => {
+    await backend.remember({
+      projectId: "proj_aaa",
+      content: "Prefer using path resolve for session roots",
+      type: "preference",
+    });
+    const hits = await backend.recall({
+      projectId: "proj_aaa",
+      query: "session roots",
+      limit: 5,
+    });
+    assert.ok(hits.some((h) => h.kind === "memory"));
+  });
+});
+
+test("recall does not leak across projects", async () => {
+  await withTempBackend(async (backend) => {
+    await backend.remember({
+      projectId: "proj_a",
+      content: "unique zebra widget convention",
+    });
+    const hits = await backend.recall({
+      projectId: "proj_b",
+      query: "zebra widget",
+      limit: 5,
+    });
+    assert.equal(hits.length, 0);
+  });
+});
+
+test("observe agent_end is recallable", async () => {
+  await withTempBackend(async (backend) => {
+    await backend.observe({
+      projectId: "proj_a",
+      sessionId: "sess1",
+      kind: "agent_end",
+      title: "fix login",
+      narrative: "User: fix login\nAssistant: patched auth middleware",
+    });
+    const hits = await backend.recall({
+      projectId: "proj_a",
+      query: "auth middleware",
+      kinds: ["observation"],
+    });
+    assert.ok(hits.length >= 1);
+    assert.equal(hits[0]!.kind, "observation");
+  });
+});
+
+test("remember supersedes high-jaccard latest memory", async () => {
+  await withTempBackend(async (backend) => {
+    const first = await backend.remember({
+      projectId: "proj_s",
+      content: "use path resolve for session root directory layout",
+      type: "preference",
+    });
+    const second = await backend.remember({
+      projectId: "proj_s",
+      content: "use path resolve for session root directory layout please",
+      type: "preference",
+    });
+    assert.notEqual(first.id, second.id);
+
+    const hits = await backend.recall({
+      projectId: "proj_s",
+      query: "path resolve session",
+      kinds: ["memory"],
+      limit: 10,
+    });
+    // Only latest version should appear
+    assert.ok(hits.every((h) => h.id === second.id));
+    assert.ok(hits.some((h) => h.id === second.id));
+
+    const stats = await backend.stats("proj_s");
+    assert.equal(stats.memoryCount, 1);
+  });
+});
+
+test("forget deletes by id within project", async () => {
+  await withTempBackend(async (backend) => {
+    const mem = await backend.remember({
+      projectId: "proj_f",
+      content: "forgettable alpha bravo convention",
+    });
+    const obs = await backend.observe({
+      projectId: "proj_f",
+      sessionId: "s1",
+      kind: "agent_end",
+      title: "t",
+      narrative: "forgettable charlie delta narrative text",
+    });
+    assert.ok("observationId" in obs);
+
+    const deleted = await backend.forget({
+      projectId: "proj_f",
+      memoryIds: [mem.id],
+      observationIds: [obs.observationId],
+    });
+    assert.equal(deleted.deleted, 2);
+
+    const hits = await backend.recall({
+      projectId: "proj_f",
+      query: "forgettable",
+      limit: 10,
+    });
+    assert.equal(hits.length, 0);
+  });
+});
+
+test("forget does not delete other project rows", async () => {
+  await withTempBackend(async (backend) => {
+    const mem = await backend.remember({
+      projectId: "proj_x",
+      content: "shared keyword pineapple",
+    });
+    await backend.remember({
+      projectId: "proj_y",
+      content: "shared keyword pineapple other",
+    });
+    const r = await backend.forget({
+      projectId: "proj_y",
+      memoryIds: [mem.id],
+    });
+    assert.equal(r.deleted, 0);
+    const hits = await backend.recall({
+      projectId: "proj_x",
+      query: "pineapple",
+      kinds: ["memory"],
+    });
+    assert.equal(hits.length, 1);
+  });
+});
+
+test("health reports sqlite backend", async () => {
+  await withTempBackend(async (backend) => {
+    const h = await backend.health();
+    assert.equal(h.ok, true);
+    assert.equal(h.backend, "sqlite");
+  });
+});
+
+test("creates parent directory for dbPath", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "ltm-"));
+  const nested = join(dir, "a", "b", "c.sqlite");
+  try {
+    const backend = new SqliteBackend(nested);
+    assert.ok(existsSync(nested) || existsSync(join(dir, "a", "b")));
+    await backend.remember({ projectId: "p", content: "nested db path works fine" });
+    await backend.close?.();
+    assert.ok(existsSync(nested));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("sanitizeFtsQuery strips special chars and quotes tokens", () => {
+  assert.equal(sanitizeFtsQuery('session roots'), '"session" "roots"');
+  assert.equal(sanitizeFtsQuery('foo AND bar'), '"foo" "and" "bar"');
+  assert.equal(sanitizeFtsQuery('a*b(c)'), '"a" "b" "c"');
+  assert.equal(sanitizeFtsQuery("   "), "");
+  assert.equal(sanitizeFtsQuery(""), "");
+});
+
+test("empty or garbage query returns no hits", async () => {
+  await withTempBackend(async (backend) => {
+    await backend.remember({ projectId: "p", content: "something stored" });
+    const hits = await backend.recall({ projectId: "p", query: "***" });
+    assert.equal(hits.length, 0);
+  });
+});
+
+test("kinds filter memories only", async () => {
+  await withTempBackend(async (backend) => {
+    await backend.remember({
+      projectId: "proj_k",
+      content: "shared keyword orange muffin",
+    });
+    await backend.observe({
+      projectId: "proj_k",
+      sessionId: "s",
+      kind: "pre_compact",
+      title: "c",
+      narrative: "shared keyword orange muffin observed",
+    });
+    const memOnly = await backend.recall({
+      projectId: "proj_k",
+      query: "orange muffin",
+      kinds: ["memory"],
+    });
+    assert.ok(memOnly.every((h) => h.kind === "memory"));
+    assert.ok(memOnly.length >= 1);
+
+    const obsOnly = await backend.recall({
+      projectId: "proj_k",
+      query: "orange muffin",
+      kinds: ["observation"],
+    });
+    assert.ok(obsOnly.every((h) => h.kind === "observation"));
+    assert.ok(obsOnly.length >= 1);
+  });
+});
+
+test("stats counts memories and observations", async () => {
+  await withTempBackend(async (backend) => {
+    await backend.remember({ projectId: "proj_st", content: "one memory about widgets" });
+    await backend.observe({
+      projectId: "proj_st",
+      sessionId: "s",
+      kind: "agent_end",
+      title: "t",
+      narrative: "one observation about widgets",
+    });
+    const s = await backend.stats("proj_st");
+    assert.equal(s.memoryCount, 1);
+    assert.equal(s.observationCount, 1);
+    assert.deepEqual(await backend.stats("proj_other"), {
+      memoryCount: 0,
+      observationCount: 0,
+    });
+  });
+});

--- a/lib/ltm/sqlite-backend.ts
+++ b/lib/ltm/sqlite-backend.ts
@@ -1,0 +1,373 @@
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import type { MemoryBackend } from "./backend";
+import { jaccardSimilarity } from "./jaccard.ts";
+import type {
+  ForgetInput,
+  MemoryType,
+  ObserveInput,
+  RecallHit,
+  RecallInput,
+  RememberInput,
+} from "./types";
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
+const SUPERSEDE_THRESHOLD = 0.7;
+const SNIPPET_MAX = 240;
+const TITLE_MAX = 80;
+const NARRATIVE_MAX = 4000;
+
+/** Strip FTS5 operators; return space-joined quoted tokens for safe MATCH. */
+export function sanitizeFtsQuery(q: string): string {
+  if (!q || !q.trim()) return "";
+  const cleaned = q
+    .normalize("NFC")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]+/gu, " ");
+  const tokens = cleaned.split(/\s+/).filter((t) => t.length > 0);
+  if (tokens.length === 0) return "";
+  return tokens.map((t) => `"${t.replace(/"/g, "")}"`).join(" ");
+}
+
+function newId(prefix: "mem" | "obs"): string {
+  const ts = Date.now().toString(36);
+  const rand = Math.random().toString(36).slice(2, 10);
+  return `${prefix}_${ts}_${rand}`;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function titleFromContent(content: string): string {
+  const line = content.split(/\r?\n/, 1)[0] ?? content;
+  return line.length <= TITLE_MAX ? line : line.slice(0, TITLE_MAX);
+}
+
+function snippetOf(text: string): string {
+  const t = text.replace(/\s+/g, " ").trim();
+  return t.length <= SNIPPET_MAX ? t : `${t.slice(0, SNIPPET_MAX)}…`;
+}
+
+function clampLimit(limit: number | undefined): number {
+  if (limit == null || !Number.isFinite(limit)) return DEFAULT_LIMIT;
+  return Math.min(MAX_LIMIT, Math.max(1, Math.floor(limit)));
+}
+
+export class SqliteBackend implements MemoryBackend {
+  private readonly db: DatabaseSync;
+
+  constructor(dbPath: string) {
+    mkdirSync(dirname(dbPath), { recursive: true });
+    this.db = new DatabaseSync(dbPath);
+    this.db.exec("PRAGMA journal_mode = WAL;");
+    this.db.exec("PRAGMA foreign_keys = ON;");
+    this.initSchema();
+  }
+
+  private initSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS observations (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        title TEXT NOT NULL,
+        narrative TEXT NOT NULL,
+        source_json TEXT,
+        created_at TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_obs_project ON observations(project_id);
+
+      CREATE TABLE IF NOT EXISTS memories (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL,
+        type TEXT NOT NULL,
+        title TEXT NOT NULL,
+        content TEXT NOT NULL,
+        concepts_json TEXT,
+        files_json TEXT,
+        source_observation_ids_json TEXT,
+        is_latest INTEGER NOT NULL,
+        parent_id TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_mem_project_latest
+        ON memories(project_id, is_latest);
+
+      CREATE VIRTUAL TABLE IF NOT EXISTS observations_fts USING fts5(
+        id UNINDEXED,
+        project_id UNINDEXED,
+        title,
+        narrative
+      );
+
+      CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+        id UNINDEXED,
+        project_id UNINDEXED,
+        title,
+        content
+      );
+    `);
+  }
+
+  async remember(
+    input: RememberInput
+  ): Promise<{ id: string; type: MemoryType }> {
+    const type: MemoryType = input.type ?? "fact";
+    const content = input.content;
+    const title = titleFromContent(content);
+    const now = nowIso();
+    const id = newId("mem");
+
+    let parentId: string | null = null;
+    const latest = this.db
+      .prepare(
+        `SELECT id, content FROM memories
+         WHERE project_id = ? AND is_latest = 1`
+      )
+      .all(input.projectId) as Array<{ id: string; content: string }>;
+
+    for (const row of latest) {
+      if (jaccardSimilarity(content, row.content) > SUPERSEDE_THRESHOLD) {
+        parentId = row.id;
+        this.db
+          .prepare(
+            `UPDATE memories SET is_latest = 0, updated_at = ? WHERE id = ?`
+          )
+          .run(now, row.id);
+        // One supersede parent is enough; first high match wins.
+        break;
+      }
+    }
+
+    this.db
+      .prepare(
+        `INSERT INTO memories (
+          id, project_id, type, title, content,
+          concepts_json, files_json, source_observation_ids_json,
+          is_latest, parent_id, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)`
+      )
+      .run(
+        id,
+        input.projectId,
+        type,
+        title,
+        content,
+        input.concepts ? JSON.stringify(input.concepts) : null,
+        input.files ? JSON.stringify(input.files) : null,
+        input.sourceObservationIds
+          ? JSON.stringify(input.sourceObservationIds)
+          : null,
+        parentId,
+        now,
+        now
+      );
+
+    this.db
+      .prepare(
+        `INSERT INTO memories_fts(id, project_id, title, content)
+         VALUES (?, ?, ?, ?)`
+      )
+      .run(id, input.projectId, title, content);
+
+    return { id, type };
+  }
+
+  async recall(input: RecallInput): Promise<RecallHit[]> {
+    const match = sanitizeFtsQuery(input.query);
+    if (!match) return [];
+
+    const limit = clampLimit(input.limit);
+    const kinds = input.kinds ?? ["memory", "observation"];
+    const wantMemory = kinds.includes("memory");
+    const wantObs = kinds.includes("observation");
+    const hits: RecallHit[] = [];
+
+    if (wantMemory) {
+      const rows = this.db
+        .prepare(
+          `SELECT m.id, m.title, m.content, m.type, m.created_at,
+                  bm25(memories_fts) AS rank
+           FROM memories_fts
+           JOIN memories m ON m.id = memories_fts.id
+           WHERE memories_fts MATCH ?
+             AND m.project_id = ?
+             AND m.is_latest = 1
+           ORDER BY rank
+           LIMIT ?`
+        )
+        .all(match, input.projectId, limit) as Array<{
+        id: string;
+        title: string;
+        content: string;
+        type: MemoryType;
+        created_at: string;
+        rank: number;
+      }>;
+
+      for (const r of rows) {
+        hits.push({
+          kind: "memory",
+          id: r.id,
+          title: r.title,
+          snippet: snippetOf(r.content),
+          score: -r.rank,
+          type: r.type,
+          createdAt: r.created_at,
+        });
+      }
+    }
+
+    if (wantObs) {
+      const rows = this.db
+        .prepare(
+          `SELECT o.id, o.title, o.narrative, o.kind, o.created_at,
+                  bm25(observations_fts) AS rank
+           FROM observations_fts
+           JOIN observations o ON o.id = observations_fts.id
+           WHERE observations_fts MATCH ?
+             AND o.project_id = ?
+           ORDER BY rank
+           LIMIT ?`
+        )
+        .all(match, input.projectId, limit) as Array<{
+        id: string;
+        title: string;
+        narrative: string;
+        kind: string;
+        created_at: string;
+        rank: number;
+      }>;
+
+      for (const r of rows) {
+        hits.push({
+          kind: "observation",
+          id: r.id,
+          title: r.title,
+          snippet: snippetOf(r.narrative),
+          score: -r.rank,
+          type: r.kind as RecallHit["type"],
+          createdAt: r.created_at,
+        });
+      }
+    }
+
+    hits.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+    return hits.slice(0, limit);
+  }
+
+  async observe(
+    input: ObserveInput
+  ): Promise<{ observationId: string } | { deduplicated: true }> {
+    const id = newId("obs");
+    const narrative =
+      input.narrative.length > NARRATIVE_MAX
+        ? input.narrative.slice(0, NARRATIVE_MAX)
+        : input.narrative;
+    const createdAt = nowIso();
+    const sourceJson =
+      input.source === undefined ? null : JSON.stringify(input.source);
+
+    this.db
+      .prepare(
+        `INSERT INTO observations (
+          id, project_id, session_id, kind, title, narrative, source_json, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        id,
+        input.projectId,
+        input.sessionId,
+        input.kind,
+        input.title,
+        narrative,
+        sourceJson,
+        createdAt
+      );
+
+    this.db
+      .prepare(
+        `INSERT INTO observations_fts(id, project_id, title, narrative)
+         VALUES (?, ?, ?, ?)`
+      )
+      .run(id, input.projectId, input.title, narrative);
+
+    return { observationId: id };
+  }
+
+  async forget(input: ForgetInput): Promise<{ deleted: number }> {
+    let deleted = 0;
+
+    if (input.memoryIds?.length) {
+      const delMem = this.db.prepare(
+        `DELETE FROM memories WHERE id = ? AND project_id = ?`
+      );
+      const delMemFts = this.db.prepare(`DELETE FROM memories_fts WHERE id = ?`);
+      for (const id of input.memoryIds) {
+        const result = delMem.run(id, input.projectId) as { changes: number };
+        if (result.changes > 0) {
+          delMemFts.run(id);
+          deleted += result.changes;
+        }
+      }
+    }
+
+    if (input.observationIds?.length) {
+      const delObs = this.db.prepare(
+        `DELETE FROM observations WHERE id = ? AND project_id = ?`
+      );
+      const delObsFts = this.db.prepare(
+        `DELETE FROM observations_fts WHERE id = ?`
+      );
+      for (const id of input.observationIds) {
+        const result = delObs.run(id, input.projectId) as { changes: number };
+        if (result.changes > 0) {
+          delObsFts.run(id);
+          deleted += result.changes;
+        }
+      }
+    }
+
+    return { deleted };
+  }
+
+  async health(): Promise<{ ok: boolean; backend: string; detail?: string }> {
+    try {
+      this.db.prepare("SELECT 1").get();
+      return { ok: true, backend: "sqlite" };
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      return { ok: false, backend: "sqlite", detail };
+    }
+  }
+
+  /** Debug / API stats: latest memories + all observations for a project. */
+  async stats(
+    projectId: string
+  ): Promise<{ memoryCount: number; observationCount: number }> {
+    const mem = this.db
+      .prepare(
+        `SELECT COUNT(*) AS c FROM memories
+         WHERE project_id = ? AND is_latest = 1`
+      )
+      .get(projectId) as { c: number };
+    const obs = this.db
+      .prepare(
+        `SELECT COUNT(*) AS c FROM observations WHERE project_id = ?`
+      )
+      .get(projectId) as { c: number };
+    return {
+      memoryCount: Number(mem.c),
+      observationCount: Number(obs.c),
+    };
+  }
+
+  async close(): Promise<void> {
+    this.db.close();
+  }
+}

--- a/lib/ltm/types.ts
+++ b/lib/ltm/types.ts
@@ -1,0 +1,51 @@
+export type MemoryType =
+  | "pattern"
+  | "preference"
+  | "architecture"
+  | "bug"
+  | "workflow"
+  | "fact";
+
+export type ObserveKind = "agent_end" | "pre_compact";
+
+export interface RememberInput {
+  projectId: string;
+  content: string;
+  type?: MemoryType;
+  concepts?: string[];
+  files?: string[];
+  sourceObservationIds?: string[];
+  sessionId?: string;
+}
+
+export interface RecallInput {
+  projectId: string;
+  query: string;
+  limit?: number; // default 10, max 50
+  kinds?: Array<"memory" | "observation">; // default both
+}
+
+export interface ObserveInput {
+  projectId: string;
+  sessionId: string;
+  kind: ObserveKind;
+  title: string;
+  narrative: string;
+  source?: unknown;
+}
+
+export interface ForgetInput {
+  projectId: string;
+  memoryIds?: string[];
+  observationIds?: string[];
+}
+
+export interface RecallHit {
+  kind: "memory" | "observation";
+  id: string;
+  title: string;
+  snippet: string;
+  score?: number;
+  type?: MemoryType | ObserveKind;
+  createdAt: string;
+}

--- a/lib/rpc-manager.test.ts
+++ b/lib/rpc-manager.test.ts
@@ -20,6 +20,11 @@ test("startRpcSession does not pass a hardcoded default tool allowlist", () => {
   assert.match(source, /setActiveToolsByName\(effectiveTools\)/);
 });
 
+test("startRpcSession registers desktopLtmInlineExtension", () => {
+  assert.match(source, /desktopLtmInlineExtension\(\{\s*getCwd:\s*\(\)\s*=>\s*cwd\s*\}\)/);
+  assert.match(source, /withMemoryTools/);
+});
+
 function makeStubInner(overrides: {
   subscribe?: SubscribeFn;
   sessionManager?: unknown;
@@ -566,7 +571,10 @@ test("set_agent_mode plan forces read tools", async () => {
   w.initPolicy("ask", "default");
   const result = await w.send({ type: "set_agent_mode", mode: "plan" }) as { agentMode: string };
   assert.equal(result.agentMode, "plan");
-  assert.deepEqual(applied.at(-1)?.slice().sort(), ["find", "grep", "ls", "read"]);
+  assert.deepEqual(
+    applied.at(-1)?.slice().sort(),
+    ["find", "grep", "ls", "memory_forget", "memory_recall", "memory_save", "read"]
+  );
 });
 
 test("get_state includes agentMode", async () => {

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -15,6 +15,10 @@ import {
 } from "./approval-policy.ts";
 import { ExtensionUiBridge } from "./extension-ui-bridge.ts";
 import { desktopApprovalInlineExtension, type AgentModeRef } from "./desktop-approval-extension.ts";
+import {
+  desktopLtmInlineExtension,
+  withMemoryTools,
+} from "./desktop-ltm-extension.ts";
 import { readDesktopSettings } from "./desktop-settings.ts";
 import { findLastAgentMode } from "./agent-mode-persistence.ts";
 import {
@@ -119,7 +123,7 @@ export class AgentSessionWrapper {
     }
     this._agentMode = mode;
     this._modeRef.current = mode;
-    const tools = effectiveToolsForMode(mode, this._toolPreset);
+    const tools = withMemoryTools(effectiveToolsForMode(mode, this._toolPreset));
     this.inner.setActiveToolsByName(tools);
     if (tools.length === 0) {
       const state = this.inner.agent?.state as { systemPrompt?: string } | undefined;
@@ -453,9 +457,11 @@ export class AgentSessionWrapper {
         this._toolPreset = this.inferPresetFromTools(toolNames);
         if (this._agentMode === "plan") {
           this._toolPresetBeforePlan = this._toolPreset;
-          this.inner.setActiveToolsByName([...effectiveToolsForMode("plan", this._toolPreset)]);
+          this.inner.setActiveToolsByName(
+            withMemoryTools([...effectiveToolsForMode("plan", this._toolPreset)])
+          );
         } else {
-          this.inner.setActiveToolsByName(toolNames);
+          this.inner.setActiveToolsByName(withMemoryTools(toolNames));
         }
         return null;
       }
@@ -652,13 +658,18 @@ export async function startRpcSession(
       else if (key === [...toolNamesForPreset("full")].sort().join(",")) toolPreset = "full";
     }
 
-    const effectiveTools = effectiveToolsForMode(agentMode, toolPreset);
+    const effectiveTools = withMemoryTools(
+      effectiveToolsForMode(agentMode, toolPreset)
+    );
 
     const modeRef: AgentModeRef = { current: agentMode };
     const resourceLoader = new DefaultResourceLoader({
       cwd,
       agentDir,
-      extensionFactories: [desktopApprovalInlineExtension(modeRef)],
+      extensionFactories: [
+        desktopApprovalInlineExtension(modeRef),
+        desktopLtmInlineExtension({ getCwd: () => cwd }),
+      ],
     });
     await resourceLoader.reload();
 

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -643,7 +643,7 @@ export async function startRpcSession(
       : SessionManager.create(cwd, undefined);
 
     const storedMode = findLastAgentMode(sessionManager.getEntries() as never);
-    let agentMode: AgentMode = isAgentMode(opts.agentMode)
+    const agentMode: AgentMode = isAgentMode(opts.agentMode)
       ? opts.agentMode
       : (storedMode ?? desktop.defaultAgentMode);
     let toolPreset: ToolPreset = isToolPreset(opts.toolPreset)

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -19,6 +19,9 @@ import { readDesktopSettings } from "./desktop-settings.ts";
 import { findLastAgentMode } from "./agent-mode-persistence.ts";
 import {
   branchEntriesToMessagesText,
+  lastAssistantFromBranch,
+  lastUserFromBranch,
+  safeLtmAgentEndObserve,
   safeLtmPreCompactObserve,
 } from "./ltm/observe-hooks.ts";
 
@@ -155,6 +158,22 @@ export class AgentSessionWrapper {
   start(): void {
     this.unsubscribe = this.inner.subscribe((event: AgentEvent) => {
       this.resetIdleTimer();
+      // Best-effort LTM observe when an agent loop settles.
+      if (event.type === "agent_end") {
+        try {
+          const source = Array.isArray(event.messages)
+            ? (event.messages as unknown[])
+            : (this.inner.sessionManager.getBranch() as unknown[]);
+          void safeLtmAgentEndObserve({
+            sessionId: this.sessionId,
+            cwd: this.inner.sessionManager.getHeader()?.cwd ?? process.cwd(),
+            userText: lastUserFromBranch(source),
+            assistantText: lastAssistantFromBranch(source),
+          });
+        } catch (err) {
+          console.error("ltm agent_end observe wire failed:", err);
+        }
+      }
       for (const l of this.listeners) l(event);
     });
     this.resetIdleTimer();

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -17,6 +17,10 @@ import { ExtensionUiBridge } from "./extension-ui-bridge.ts";
 import { desktopApprovalInlineExtension, type AgentModeRef } from "./desktop-approval-extension.ts";
 import { readDesktopSettings } from "./desktop-settings.ts";
 import { findLastAgentMode } from "./agent-mode-persistence.ts";
+import {
+  branchEntriesToMessagesText,
+  safeLtmPreCompactObserve,
+} from "./ltm/observe-hooks.ts";
 
 // ============================================================================
 // Constants
@@ -376,6 +380,12 @@ export class AgentSessionWrapper {
         if (historyEnd <= boundaryStart) {
           throw new Error("Conversation too short to compact");
         }
+        // Best-effort LTM observe of branch text before compaction rewrites context.
+        void safeLtmPreCompactObserve({
+          sessionId: this.sessionId,
+          cwd: this.inner.sessionManager.getHeader()?.cwd ?? process.cwd(),
+          messagesText: branchEntriesToMessagesText(pathEntries),
+        });
         const result = await this.inner.compact(command.customInstructions as string | undefined);
         return result;
       }

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   "scripts": {
     "dev": "next dev -p 30141",
     "build": "npm run build:standalone",
-    "build:standalone": "next build",
+    "build:standalone": "next build && node scripts/ensure-standalone-next-runtimes.mjs",
     "start": "next start -p 30141",
     "lint": "eslint .",
     "check:electron-deps": "node lib/electron-updater-runtime-deps.mjs --check",
-    "test": "node --test --test-force-exit \"lib/**/*.test.ts\" \"lib/**/*.test.mjs\" \"electron/**/*.test.ts\" \"app/**/*.test.ts\" \"hooks/**/*.test.ts\" \"components/**/*.test.ts\" \"package.test.ts\"",
+    "test": "node --test --test-force-exit \"lib/**/*.test.ts\" \"lib/**/*.test.mjs\" \"electron/**/*.test.ts\" \"app/**/*.test.ts\" \"hooks/**/*.test.ts\" \"components/**/*.test.ts\" \"scripts/**/*.test.mjs\" \"package.test.ts\"",
     "release": "npm version patch --no-git-tag-version && npm run build:standalone && npm publish --access public",
     "build:electron": "tsc -p electron/tsconfig.json && node -e \"const fs=require('fs'); fs.copyFileSync('electron/startup.html', 'electron/dist/startup.html'); fs.copyFileSync('electron/startup.js', 'electron/dist/startup.js')\"",
     "dev:electron": "npm run build:electron && npx electron .",

--- a/package.test.ts
+++ b/package.test.ts
@@ -7,7 +7,11 @@ const pkg = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), 
 };
 
 test("build scripts name the standalone Next.js build explicitly", () => {
-  assert.equal(pkg.scripts["build:standalone"], "next build");
+  assert.match(pkg.scripts["build:standalone"], /^next build\b/);
+  assert.match(
+    pkg.scripts["build:standalone"],
+    /ensure-standalone-next-runtimes\.mjs/
+  );
   assert.equal(pkg.scripts.build, "npm run build:standalone");
 });
 

--- a/scripts/ensure-standalone-next-runtimes.mjs
+++ b/scripts/ensure-standalone-next-runtimes.mjs
@@ -1,0 +1,48 @@
+/**
+ * Next.js 16 Turbopack production builds often omit app-route turbo runtime
+ * files from the standalone NFT trace. Packaged Electron then fails to load
+ * API routes with:
+ *   Cannot find module 'next/dist/compiled/next-server/app-route-turbo.runtime.prod.js'
+ *
+ * Copy all *turbo*.runtime.prod.js files into standalone after `next build`.
+ */
+import { cpSync, existsSync, mkdirSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.cwd();
+const src = join(root, "node_modules", "next", "dist", "compiled", "next-server");
+const dst = join(
+  root,
+  ".next",
+  "standalone",
+  "node_modules",
+  "next",
+  "dist",
+  "compiled",
+  "next-server"
+);
+
+if (!existsSync(join(root, ".next", "standalone"))) {
+  console.error("ensure-standalone-next-runtimes: .next/standalone not found (run next build first)");
+  process.exit(1);
+}
+if (!existsSync(src)) {
+  console.error("ensure-standalone-next-runtimes: next compiled next-server not found");
+  process.exit(1);
+}
+
+mkdirSync(dst, { recursive: true });
+
+const names = readdirSync(src).filter(
+  (name) => name.includes("turbo") && name.endsWith(".runtime.prod.js")
+);
+
+if (names.length === 0) {
+  console.error("ensure-standalone-next-runtimes: no turbo runtime.prod.js files in next package");
+  process.exit(1);
+}
+
+for (const name of names) {
+  cpSync(join(src, name), join(dst, name));
+  console.log(`ensure-standalone-next-runtimes: ${name}`);
+}

--- a/scripts/ensure-standalone-next-runtimes.test.mjs
+++ b/scripts/ensure-standalone-next-runtimes.test.mjs
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const script = fileURLToPath(new URL("./ensure-standalone-next-runtimes.mjs", import.meta.url));
+
+test("ensure-standalone-next-runtimes copies turbo prod runtimes into standalone", () => {
+  const root = mkdtempSync(join(tmpdir(), "ensure-turbo-"));
+  try {
+    const src = join(root, "node_modules", "next", "dist", "compiled", "next-server");
+    const dst = join(
+      root,
+      ".next",
+      "standalone",
+      "node_modules",
+      "next",
+      "dist",
+      "compiled",
+      "next-server"
+    );
+    mkdirSync(src, { recursive: true });
+    mkdirSync(join(root, ".next", "standalone"), { recursive: true });
+    // dest may not exist yet — script creates it
+    writeFileSync(join(src, "app-route-turbo.runtime.prod.js"), "/* route turbo */\n");
+    writeFileSync(join(src, "app-page-turbo.runtime.prod.js"), "/* page turbo */\n");
+    writeFileSync(join(src, "app-route-turbo.runtime.dev.js"), "/* should skip */\n");
+    writeFileSync(join(src, "app-route.runtime.prod.js"), "/* non-turbo skip */\n");
+
+    const result = spawnSync(process.execPath, [script], {
+      cwd: root,
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.ok(existsSync(join(dst, "app-route-turbo.runtime.prod.js")));
+    assert.ok(existsSync(join(dst, "app-page-turbo.runtime.prod.js")));
+    assert.equal(existsSync(join(dst, "app-route-turbo.runtime.dev.js")), false);
+    assert.equal(
+      readFileSync(join(dst, "app-route-turbo.runtime.prod.js"), "utf8"),
+      "/* route turbo */\n"
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Add pluggable **long-term memory (LTM)** layer: `MemoryBackend` + SQLite/FTS5 phase-1 store under `~/.pi/agent/memory/ltm.sqlite` (project-scoped via cwd hash).
- Expose **agent tools** `memory_save` / `memory_recall` / `memory_forget` and **HTTP** `/api/memory/*`; auto **observe** on `agent_end` and pre-**compact** (best-effort, zero-LLM).
- No session JSONL schema change; agentmemory REST backend stubbed for later; docs/spec/plan included.

## Test plan

- [x] `npm run test` (411 pass, 0 fail)
- [x] `npx tsc --noEmit`
- [ ] Manual: same cwd, `memory_save` then new session `memory_recall`
- [ ] Manual: `/compact` produces `pre_compact` observation (stats/recall)
- [ ] Manual: disable LTM via desktop-settings → tools/API report disabled

## Design

- Spec: `docs/superpowers/specs/2026-08-03-long-term-memory-design.md`
- Plan: `docs/superpowers/plans/2026-08-03-long-term-memory.md`
- Architecture: `docs/memory-architecture.html`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-scoped long-term memory for saving, recalling, and forgetting information.
  * Added memory tools for desktop sessions, including configurable enablement and backend settings.
  * Added memory health and statistics endpoints.
  * Automatically captures selected session and compaction observations when enabled.
  * Added SQLite-backed search with memory categorization, filtering, and project isolation.

* **Documentation**
  * Added comprehensive memory architecture documentation and implementation specifications.

* **Tests**
  * Added coverage for memory APIs, storage, configuration, tools, recall, observations, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->