### PR TITLE
fix(packaging): restore Pi runtime in v0.8.1

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 > 本文档是项目的**权威架构参考**，由 CodeGraph 静态分析 + 源码核对生成。
 > 若与 `AGENTS.md` / `CLAUDE.md` 中的简要描述冲突，以本文档为准。
 >
-- **项目**：`@chasen-liao/pi-agent-desktop` v0.8.0
+- **项目**：`@chasen-liao/pi-agent-desktop` v0.8.1
 - **上游 SDK**：`@earendil-works/pi-coding-agent` ^0.84.3 / `@earendil-works/pi-ai` ^0.84.3
 - **更新日期**：2026-08-25
 
@@ -142,7 +142,7 @@ flowchart TD
 
 ```text
 pi-agent-desktop/
-├── package.json                  @chasen-liao/pi-agent-desktop v0.8.0
+├── package.json                  @chasen-liao/pi-agent-desktop v0.8.1
 ├── next.config.ts                output:"standalone" + server external packages
 ├── tailwind.config.ts            Tailwind 4 配置
 ├── tsconfig.json                 strict + bundler resolution

--- a/docs/releases/v0.8.1.md
+++ b/docs/releases/v0.8.1.md
@@ -1,0 +1,22 @@
+# Pi Agent Desktop v0.8.1
+
+发布日期：2026-08-25
+
+## 修复
+
+- 修复 Windows v0.8.0 安装包启动后左侧会话列表显示 `Error: HTTP 500` 的问题。
+- 补齐 Next.js standalone 对 `@earendil-works/pi-ai` 的运行时文件追踪，避免安装包缺少 `dist/index.js`。
+- standalone 构建现在会自动启动生产服务，并验证 `/api/health`、`/api/sessions` 和 `/api/auth/providers`；关键运行时缺失时构建会直接失败。
+
+## 兼容性与已知限制
+
+- Windows x64 安装包未进行代码签名，首次运行可能触发 SmartScreen 提示。
+- `@lobehub/icons` 的传递依赖仍对 React 19 产生 peer warning。
+- 完整 `npm audit` 仍可能报告 Electron 36 及其传递依赖的已知风险；Electron 大版本升级将作为独立任务处理。
+- Next.js 16.3 仍兼容当前 `middleware.ts`，但已提示未来迁移到 `proxy.ts`。
+
+## 验证
+
+- 单元测试、Lint、Web/Electron TypeScript 类型检查和 Electron updater 依赖检查通过。
+- standalone 生产服务的健康、会话列表和认证 provider 接口冒烟通过。
+- Windows `win-unpacked` 与 NSIS 安装结果均完成原始 HTTP 500 场景复测。

--- a/docs/releases/v0.8.1.md
+++ b/docs/releases/v0.8.1.md
@@ -5,8 +5,8 @@
 ## 修复
 
 - 修复 Windows v0.8.0 安装包启动后左侧会话列表显示 `Error: HTTP 500` 的问题。
-- 补齐 Next.js standalone 对 `@earendil-works/pi-ai` 的运行时文件追踪，避免安装包缺少 `dist/index.js`。
-- standalone 构建现在会自动启动生产服务，并验证 `/api/health`、`/api/sessions` 和 `/api/auth/providers`；关键运行时缺失时构建会直接失败。
+- 将 Pi runtime 及其完整生产依赖闭包补入 Next.js standalone，确保安装目录不再依赖开发机的 `node_modules`。
+- standalone 构建现在会复制到系统临时隔离目录启动生产服务，并验证 `/api/health`、`/api/sessions` 和 `/api/auth/providers`；关键运行时缺失时构建会直接失败。
 
 ## 兼容性与已知限制
 

--- a/docs/releases/v0.8.1.md
+++ b/docs/releases/v0.8.1.md
@@ -12,7 +12,7 @@
 
 - Windows x64 安装包未进行代码签名，首次运行可能触发 SmartScreen 提示。
 - `@lobehub/icons` 的传递依赖仍对 React 19 产生 peer warning。
-- 完整 `npm audit` 仍可能报告 Electron 36 及其传递依赖的已知风险；Electron 大版本升级将作为独立任务处理。
+- 完整 `npm audit` 仍报告 Electron 36 及其传递依赖的 2 项 high；Electron 大版本升级将作为独立任务处理。
 - Next.js 16.3 仍兼容当前 `middleware.ts`，但已提示未来迁移到 `proxy.ts`。
 
 ## 验证

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,6 +14,9 @@ const nextConfig: NextConfig = {
   turbopack: {},
   serverExternalPackages: ["@earendil-works/pi-coding-agent", "@earendil-works/pi-ai"],
   allowedDevOrigins: ["127.0.0.1", "localhost", "192.168.*.*"],
+  outputFileTracingIncludes: {
+    "/*": ["./node_modules/@earendil-works/pi-ai/**/*"],
+  },
   outputFileTracingExcludes: {
     '*': [
       'release/**/*',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chasen-liao/pi-agent-desktop",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chasen-liao/pi-agent-desktop",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.9"

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "release": "npm version patch --no-git-tag-version && npm run build:standalone && npm publish --access public",
     "build:electron": "tsc -p electron/tsconfig.json && node -e \"const fs=require('fs'); fs.copyFileSync('electron/startup.html', 'electron/dist/startup.html'); fs.copyFileSync('electron/startup.js', 'electron/dist/startup.js')\"",
     "dev:electron": "npm run build:electron && npx electron .",
-    "pack": "npm run build:standalone && npm run build:electron && npx @electron/rebuild && npx electron-builder --dir && node scripts/smoke-standalone-server.mjs release/win-unpacked/resources/standalone",
-    "dist": "npm run build:standalone && npm run build:electron && npx @electron/rebuild && npx electron-builder --publish never && node scripts/smoke-standalone-server.mjs release/win-unpacked/resources/standalone"
+    "pack": "npm run build:standalone && npm run build:electron && npx @electron/rebuild && npx electron-builder --dir && node scripts/smoke-packaged-standalone.mjs",
+    "dist": "npm run build:standalone && npm run build:electron && npx @electron/rebuild && npx electron-builder --publish never && node scripts/smoke-packaged-standalone.mjs"
   },
   "build": {
     "extends": "electron-builder.yml"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chasen-liao/pi-agent-desktop",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Pi Agent Desktop — desktop client for the pi coding agent",
   "license": "MIT",
   "author": "Chasen",
@@ -21,7 +21,7 @@
   "scripts": {
     "dev": "next dev -p 30141",
     "build": "npm run build:standalone",
-    "build:standalone": "next build && node scripts/ensure-standalone-next-runtimes.mjs",
+    "build:standalone": "next build && node scripts/ensure-standalone-next-runtimes.mjs && node scripts/smoke-standalone-server.mjs",
     "start": "next start -p 30141",
     "lint": "eslint .",
     "check:electron-deps": "node lib/electron-updater-runtime-deps.mjs --check",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "release": "npm version patch --no-git-tag-version && npm run build:standalone && npm publish --access public",
     "build:electron": "tsc -p electron/tsconfig.json && node -e \"const fs=require('fs'); fs.copyFileSync('electron/startup.html', 'electron/dist/startup.html'); fs.copyFileSync('electron/startup.js', 'electron/dist/startup.js')\"",
     "dev:electron": "npm run build:electron && npx electron .",
-    "pack": "npm run build:standalone && npm run build:electron && npx @electron/rebuild && npx electron-builder --dir",
-    "dist": "npm run build:standalone && npm run build:electron && npx @electron/rebuild && npx electron-builder --publish never"
+    "pack": "npm run build:standalone && npm run build:electron && npx @electron/rebuild && npx electron-builder --dir && node scripts/smoke-standalone-server.mjs release/win-unpacked/resources/standalone",
+    "dist": "npm run build:standalone && npm run build:electron && npx @electron/rebuild && npx electron-builder --publish never && node scripts/smoke-standalone-server.mjs release/win-unpacked/resources/standalone"
   },
   "build": {
     "extends": "electron-builder.yml"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "dev": "next dev -p 30141",
     "build": "npm run build:standalone",
-    "build:standalone": "next build && node scripts/ensure-standalone-next-runtimes.mjs && node scripts/smoke-standalone-server.mjs",
+    "build:standalone": "next build && node scripts/ensure-standalone-next-runtimes.mjs && node scripts/ensure-standalone-pi-runtime.mjs && node scripts/smoke-standalone-server.mjs",
     "start": "next start -p 30141",
     "lint": "eslint .",
     "check:electron-deps": "node lib/electron-updater-runtime-deps.mjs --check",

--- a/package.test.ts
+++ b/package.test.ts
@@ -23,4 +23,10 @@ test("packaging and release scripts call build:standalone", () => {
   assert.match(pkg.scripts.release, /npm run build:standalone/);
   assert.match(pkg.scripts.pack, /^npm run build:standalone &&/);
   assert.match(pkg.scripts.dist, /^npm run build:standalone &&/);
+  for (const scriptName of ["pack", "dist"]) {
+    assert.match(
+      pkg.scripts[scriptName],
+      /electron-builder.+&& node scripts\/smoke-standalone-server\.mjs release\/win-unpacked\/resources\/standalone/
+    );
+  }
 });

--- a/package.test.ts
+++ b/package.test.ts
@@ -16,6 +16,10 @@ test("build scripts name the standalone Next.js build explicitly", () => {
     pkg.scripts["build:standalone"],
     /smoke-standalone-server\.mjs/
   );
+  assert.match(
+    pkg.scripts["build:standalone"],
+    /ensure-standalone-pi-runtime\.mjs/
+  );
   assert.equal(pkg.scripts.build, "npm run build:standalone");
 });
 

--- a/package.test.ts
+++ b/package.test.ts
@@ -55,4 +55,11 @@ test("packaged smoke test targets the current Windows output", () => {
     ),
     /ELECTRON_RUN_AS_NODE/
   );
+  assert.match(
+    readFileSync(
+      new URL("./scripts/smoke-standalone-server.mjs", import.meta.url),
+      "utf8"
+    ),
+    /child\.once\("error"/
+  );
 });

--- a/package.test.ts
+++ b/package.test.ts
@@ -26,7 +26,7 @@ test("packaging and release scripts call build:standalone", () => {
   for (const scriptName of ["pack", "dist"]) {
     assert.match(
       pkg.scripts[scriptName],
-      /electron-builder.+&& node scripts\/smoke-standalone-server\.mjs release\/win-unpacked\/resources\/standalone/
+      /electron-builder.+&& node scripts\/smoke-packaged-standalone\.mjs/
     );
   }
 });

--- a/package.test.ts
+++ b/package.test.ts
@@ -42,6 +42,17 @@ test("packaged smoke test targets the current Windows output", () => {
   );
   assert.match(
     script,
-    /releaseDir, "win-unpacked", "resources", "standalone"/
+    /join\(outputDir, "resources", "standalone"\)/
+  );
+  assert.match(
+    script,
+    /join\(outputDir, "Pi Agent Desktop\.exe"\)/
+  );
+  assert.match(
+    readFileSync(
+      new URL("./scripts/smoke-standalone-server.mjs", import.meta.url),
+      "utf8"
+    ),
+    /ELECTRON_RUN_AS_NODE/
   );
 });

--- a/package.test.ts
+++ b/package.test.ts
@@ -30,3 +30,14 @@ test("packaging and release scripts call build:standalone", () => {
     );
   }
 });
+
+test("packaged smoke test targets the current Windows output", () => {
+  const script = readFileSync(
+    new URL("./scripts/smoke-packaged-standalone.mjs", import.meta.url),
+    "utf8"
+  );
+  assert.match(
+    script,
+    /releaseDir, "win-unpacked", "resources", "standalone"/
+  );
+});

--- a/package.test.ts
+++ b/package.test.ts
@@ -12,6 +12,10 @@ test("build scripts name the standalone Next.js build explicitly", () => {
     pkg.scripts["build:standalone"],
     /ensure-standalone-next-runtimes\.mjs/
   );
+  assert.match(
+    pkg.scripts["build:standalone"],
+    /smoke-standalone-server\.mjs/
+  );
   assert.equal(pkg.scripts.build, "npm run build:standalone");
 });
 

--- a/scripts/ensure-standalone-pi-runtime.mjs
+++ b/scripts/ensure-standalone-pi-runtime.mjs
@@ -1,0 +1,92 @@
+/**
+ * Next.js standalone tracing can copy an external Pi package without its
+ * production dependencies. Copy the complete installed runtime dependency
+ * closure while preserving npm's node_modules layout.
+ */
+import { cpSync, existsSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+
+const projectRoot = process.cwd();
+const sourceNodeModules = join(projectRoot, "node_modules");
+const standaloneNodeModules = join(projectRoot, ".next", "standalone", "node_modules");
+const roots = ["@earendil-works/pi-coding-agent", "@earendil-works/pi-ai"];
+
+function packageDirectory(name, fromDirectory) {
+  let current = fromDirectory;
+  const packageParts = name.split("/");
+
+  while (true) {
+    const candidate = join(current, "node_modules", ...packageParts);
+    if (existsSync(join(candidate, "package.json"))) return candidate;
+
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function readManifest(directory) {
+  return JSON.parse(readFileSync(join(directory, "package.json"), "utf8"));
+}
+
+if (!existsSync(standaloneNodeModules)) {
+  console.error("ensure-standalone-pi-runtime: .next/standalone/node_modules not found");
+  process.exit(1);
+}
+
+const queue = roots.map((name) => ({
+  name,
+  directory: packageDirectory(name, projectRoot),
+  required: true,
+}));
+const visited = new Set();
+let copied = 0;
+
+while (queue.length > 0) {
+  const item = queue.shift();
+  if (!item.directory) {
+    if (item.required) {
+      console.error(`ensure-standalone-pi-runtime: required package ${item.name} not found`);
+      process.exit(1);
+    }
+    continue;
+  }
+
+  const sourceDirectory = realpathSync(item.directory);
+  if (visited.has(sourceDirectory)) continue;
+  visited.add(sourceDirectory);
+
+  const relativeDirectory = relative(sourceNodeModules, sourceDirectory);
+  if (relativeDirectory.startsWith("..")) {
+    console.error(`ensure-standalone-pi-runtime: package escaped node_modules: ${sourceDirectory}`);
+    process.exit(1);
+  }
+
+  cpSync(sourceDirectory, join(standaloneNodeModules, relativeDirectory), {
+    recursive: true,
+    force: true,
+  });
+  copied += 1;
+
+  const manifest = readManifest(sourceDirectory);
+  const requiredDependencies = Object.keys(manifest.dependencies ?? {});
+  const optionalDependencies = Object.keys(manifest.optionalDependencies ?? {});
+  const peerDependencies = Object.keys(manifest.peerDependencies ?? {});
+
+  for (const dependency of requiredDependencies) {
+    queue.push({
+      name: dependency,
+      directory: packageDirectory(dependency, sourceDirectory),
+      required: true,
+    });
+  }
+  for (const dependency of [...optionalDependencies, ...peerDependencies]) {
+    queue.push({
+      name: dependency,
+      directory: packageDirectory(dependency, sourceDirectory),
+      required: false,
+    });
+  }
+}
+
+console.log(`ensure-standalone-pi-runtime: copied ${copied} runtime packages`);

--- a/scripts/smoke-packaged-standalone.mjs
+++ b/scripts/smoke-packaged-standalone.mjs
@@ -11,40 +11,58 @@ function hasStandaloneServer(path) {
   return existsSync(join(path, "server.js"));
 }
 
-function findPackagedStandalone() {
+function findPackagedOutput() {
   if (!existsSync(releaseDir)) return null;
 
   if (process.platform === "win32") {
-    const windows = join(releaseDir, "win-unpacked", "resources", "standalone");
-    return hasStandaloneServer(windows) ? windows : null;
+    const outputDir = join(releaseDir, "win-unpacked");
+    const standaloneDir = join(outputDir, "resources", "standalone");
+    const runtimeExecutable = join(outputDir, "Pi Agent Desktop.exe");
+    return hasStandaloneServer(standaloneDir) && existsSync(runtimeExecutable)
+      ? { standaloneDir, runtimeExecutable }
+      : null;
   }
 
   if (process.platform === "linux") {
-    const linux = join(releaseDir, "linux-unpacked", "resources", "standalone");
-    return hasStandaloneServer(linux) ? linux : null;
+    const outputDir = join(releaseDir, "linux-unpacked");
+    const standaloneDir = join(outputDir, "resources", "standalone");
+    const runtimeExecutable = ["pi-agent-desktop", "Pi Agent Desktop"]
+      .map((name) => join(outputDir, name))
+      .find((path) => existsSync(path));
+    return hasStandaloneServer(standaloneDir) && runtimeExecutable
+      ? { standaloneDir, runtimeExecutable }
+      : null;
   }
 
   const macDir = join(releaseDir, "mac");
   if (process.platform === "darwin" && existsSync(macDir)) {
     for (const entry of readdirSync(macDir, { withFileTypes: true })) {
       if (!entry.isDirectory() || !entry.name.endsWith(".app")) continue;
-      const mac = join(macDir, entry.name, "Contents", "Resources", "standalone");
-      if (hasStandaloneServer(mac)) return mac;
+      const appDir = join(macDir, entry.name, "Contents");
+      const standaloneDir = join(appDir, "Resources", "standalone");
+      const runtimeExecutable = join(appDir, "MacOS", entry.name.slice(0, -4));
+      if (hasStandaloneServer(standaloneDir) && existsSync(runtimeExecutable)) {
+        return { standaloneDir, runtimeExecutable };
+      }
     }
   }
 
   return null;
 }
 
-const standaloneDir = findPackagedStandalone();
-if (!standaloneDir) {
-  console.error(`smoke-packaged-standalone: packaged standalone not found under ${releaseDir}`);
+const packagedOutput = findPackagedOutput();
+if (!packagedOutput) {
+  console.error(`smoke-packaged-standalone: packaged output not found under ${releaseDir}`);
   process.exit(1);
 }
 
 const result = spawnSync(
   process.execPath,
-  [join(scriptsDir, "smoke-standalone-server.mjs"), standaloneDir],
+  [
+    join(scriptsDir, "smoke-standalone-server.mjs"),
+    packagedOutput.standaloneDir,
+    packagedOutput.runtimeExecutable,
+  ],
   {
     cwd: projectRoot,
     stdio: "inherit",

--- a/scripts/smoke-packaged-standalone.mjs
+++ b/scripts/smoke-packaged-standalone.mjs
@@ -1,0 +1,55 @@
+import { existsSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(scriptsDir, "..");
+const releaseDir = join(projectRoot, "release");
+
+function hasStandaloneServer(path) {
+  return existsSync(join(path, "server.js"));
+}
+
+function findPackagedStandalone() {
+  if (!existsSync(releaseDir)) return null;
+
+  const outputDirs = readdirSync(releaseDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(releaseDir, entry.name));
+
+  for (const outputDir of outputDirs) {
+    const direct = join(outputDir, "resources", "standalone");
+    if (hasStandaloneServer(direct)) return direct;
+
+    for (const entry of readdirSync(outputDir, { withFileTypes: true })) {
+      if (!entry.isDirectory() || !entry.name.endsWith(".app")) continue;
+      const mac = join(outputDir, entry.name, "Contents", "Resources", "standalone");
+      if (hasStandaloneServer(mac)) return mac;
+    }
+  }
+
+  return null;
+}
+
+const standaloneDir = findPackagedStandalone();
+if (!standaloneDir) {
+  console.error(`smoke-packaged-standalone: packaged standalone not found under ${releaseDir}`);
+  process.exit(1);
+}
+
+const result = spawnSync(
+  process.execPath,
+  [join(scriptsDir, "smoke-standalone-server.mjs"), standaloneDir],
+  {
+    cwd: projectRoot,
+    stdio: "inherit",
+    windowsHide: true,
+  }
+);
+
+if (result.error) {
+  console.error(`smoke-packaged-standalone: ${result.error.message}`);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);

--- a/scripts/smoke-packaged-standalone.mjs
+++ b/scripts/smoke-packaged-standalone.mjs
@@ -14,17 +14,21 @@ function hasStandaloneServer(path) {
 function findPackagedStandalone() {
   if (!existsSync(releaseDir)) return null;
 
-  const outputDirs = readdirSync(releaseDir, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => join(releaseDir, entry.name));
+  if (process.platform === "win32") {
+    const windows = join(releaseDir, "win-unpacked", "resources", "standalone");
+    return hasStandaloneServer(windows) ? windows : null;
+  }
 
-  for (const outputDir of outputDirs) {
-    const direct = join(outputDir, "resources", "standalone");
-    if (hasStandaloneServer(direct)) return direct;
+  if (process.platform === "linux") {
+    const linux = join(releaseDir, "linux-unpacked", "resources", "standalone");
+    return hasStandaloneServer(linux) ? linux : null;
+  }
 
-    for (const entry of readdirSync(outputDir, { withFileTypes: true })) {
+  const macDir = join(releaseDir, "mac");
+  if (process.platform === "darwin" && existsSync(macDir)) {
+    for (const entry of readdirSync(macDir, { withFileTypes: true })) {
       if (!entry.isDirectory() || !entry.name.endsWith(".app")) continue;
-      const mac = join(outputDir, entry.name, "Contents", "Resources", "standalone");
+      const mac = join(macDir, entry.name, "Contents", "Resources", "standalone");
       if (hasStandaloneServer(mac)) return mac;
     }
   }

--- a/scripts/smoke-standalone-server.mjs
+++ b/scripts/smoke-standalone-server.mjs
@@ -54,7 +54,7 @@ async function stopChild(child) {
       windowsHide: true,
     });
   } else {
-    child.kill("SIGTERM");
+    process.kill(-child.pid, "SIGTERM");
   }
 
   await Promise.race([
@@ -62,7 +62,8 @@ async function stopChild(child) {
     new Promise((resolveTimeout) => setTimeout(resolveTimeout, 2_000)),
   ]);
   if (child.exitCode === null && child.signalCode === null) {
-    child.kill("SIGKILL");
+    if (process.platform === "win32" || !child.pid) child.kill("SIGKILL");
+    else process.kill(-child.pid, "SIGKILL");
     await Promise.race([
       exited,
       new Promise((resolveTimeout) => setTimeout(resolveTimeout, 2_000)),
@@ -119,6 +120,7 @@ const child = spawn(process.execPath, [serverScript], {
     PORT: String(port),
   },
   stdio: ["ignore", "ignore", "pipe"],
+  detached: process.platform !== "win32",
   windowsHide: true,
 });
 

--- a/scripts/smoke-standalone-server.mjs
+++ b/scripts/smoke-standalone-server.mjs
@@ -1,0 +1,126 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createServer } from "node:net";
+import { join, resolve } from "node:path";
+
+const STARTUP_TIMEOUT_MS = 30_000;
+const REQUEST_TIMEOUT_MS = 10_000;
+
+function getFreePort() {
+  return new Promise((resolvePort, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("smoke-standalone-server: failed to allocate a test port"));
+        return;
+      }
+      server.close((error) => {
+        if (error) reject(error);
+        else resolvePort(address.port);
+      });
+    });
+  });
+}
+
+async function waitForHealth(url, child, stderr) {
+  const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(
+        `standalone server exited before health check (code ${child.exitCode})${stderr()}`
+      );
+    }
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
+      if (response.ok) return;
+    } catch {
+      // The server may still be starting.
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 100));
+  }
+  throw new Error(`standalone server did not become healthy within ${STARTUP_TIMEOUT_MS}ms${stderr()}`);
+}
+
+async function stopChild(child) {
+  if (child.exitCode !== null) return;
+  child.kill();
+  await Promise.race([
+    new Promise((resolveExit) => child.once("exit", resolveExit)),
+    new Promise((resolveTimeout) => setTimeout(resolveTimeout, 2_000)),
+  ]);
+  if (child.exitCode === null) child.kill("SIGKILL");
+}
+
+async function getJsonArray(baseUrl, endpoint, key, stderr) {
+  const response = await fetch(`${baseUrl}${endpoint}`, {
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(`GET ${endpoint} returned HTTP ${response.status}${stderr()}`);
+  }
+  const payload = JSON.parse(body);
+  if (!Array.isArray(payload[key])) {
+    throw new Error(`GET ${endpoint} did not return a ${key} array`);
+  }
+  return payload[key];
+}
+
+const standaloneDir = resolve(process.argv[2] ?? join(process.cwd(), ".next", "standalone"));
+const serverScript = join(standaloneDir, "server.js");
+const piAiEntry = join(
+  standaloneDir,
+  "node_modules",
+  "@earendil-works",
+  "pi-ai",
+  "dist",
+  "index.js"
+);
+
+if (!existsSync(serverScript)) {
+  console.error(`smoke-standalone-server: server.js not found at ${serverScript}`);
+  process.exit(1);
+}
+if (!existsSync(piAiEntry)) {
+  console.error(`smoke-standalone-server: Pi runtime entry not found at ${piAiEntry}`);
+  process.exit(1);
+}
+
+const port = await getFreePort();
+let stderrText = "";
+const child = spawn(process.execPath, [serverScript], {
+  cwd: standaloneDir,
+  env: {
+    ...process.env,
+    NODE_ENV: "production",
+    HOSTNAME: "127.0.0.1",
+    PORT: String(port),
+  },
+  stdio: ["ignore", "ignore", "pipe"],
+  windowsHide: true,
+});
+
+child.stderr?.on("data", (chunk) => {
+  stderrText = `${stderrText}${chunk.toString()}`.slice(-8_000);
+});
+const stderr = () => (stderrText.trim() ? `\n${stderrText.trim()}` : "");
+
+try {
+  const baseUrl = `http://127.0.0.1:${port}`;
+  await waitForHealth(`${baseUrl}/api/health`, child, stderr);
+
+  const sessions = await getJsonArray(baseUrl, "/api/sessions", "sessions", stderr);
+  const providers = await getJsonArray(baseUrl, "/api/auth/providers", "providers", stderr);
+
+  console.log(
+    `smoke-standalone-server: health 200, sessions 200 (${sessions.length}), auth providers 200 (${providers.length})`
+  );
+} catch (error) {
+  console.error(`smoke-standalone-server: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+} finally {
+  await stopChild(child);
+}

--- a/scripts/smoke-standalone-server.mjs
+++ b/scripts/smoke-standalone-server.mjs
@@ -1,6 +1,7 @@
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { cpSync, existsSync, mkdtempSync, rmSync } from "node:fs";
 import { createServer } from "node:net";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 const STARTUP_TIMEOUT_MS = 30_000;
@@ -89,10 +90,10 @@ async function getJsonArray(baseUrl, endpoint, key, stderr) {
   return payload[key];
 }
 
-const standaloneDir = resolve(process.argv[2] ?? join(process.cwd(), ".next", "standalone"));
-const serverScript = join(standaloneDir, "server.js");
+const sourceStandaloneDir = resolve(process.argv[2] ?? join(process.cwd(), ".next", "standalone"));
+const sourceServerScript = join(sourceStandaloneDir, "server.js");
 const piAiEntry = join(
-  standaloneDir,
+  sourceStandaloneDir,
   "node_modules",
   "@earendil-works",
   "pi-ai",
@@ -100,8 +101,8 @@ const piAiEntry = join(
   "index.js"
 );
 
-if (!existsSync(serverScript)) {
-  console.error(`smoke-standalone-server: server.js not found at ${serverScript}`);
+if (!existsSync(sourceServerScript)) {
+  console.error(`smoke-standalone-server: server.js not found at ${sourceServerScript}`);
   process.exit(1);
 }
 if (!existsSync(piAiEntry)) {
@@ -109,27 +110,32 @@ if (!existsSync(piAiEntry)) {
   process.exit(1);
 }
 
-const port = await getFreePort();
-let stderrText = "";
-const child = spawn(process.execPath, [serverScript], {
-  cwd: standaloneDir,
-  env: {
-    ...process.env,
-    NODE_ENV: "production",
-    HOSTNAME: "127.0.0.1",
-    PORT: String(port),
-  },
-  stdio: ["ignore", "ignore", "pipe"],
-  detached: process.platform !== "win32",
-  windowsHide: true,
-});
-
-child.stderr?.on("data", (chunk) => {
-  stderrText = `${stderrText}${chunk.toString()}`.slice(-8_000);
-});
-const stderr = () => (stderrText.trim() ? `\n${stderrText.trim()}` : "");
+const isolatedRoot = mkdtempSync(join(tmpdir(), "pi-agent-standalone-smoke-"));
+let child = null;
 
 try {
+  const standaloneDir = join(isolatedRoot, "standalone");
+  cpSync(sourceStandaloneDir, standaloneDir, { recursive: true });
+  const serverScript = join(standaloneDir, "server.js");
+  const port = await getFreePort();
+  let stderrText = "";
+  child = spawn(process.execPath, [serverScript], {
+    cwd: standaloneDir,
+    env: {
+      ...process.env,
+      NODE_ENV: "production",
+      HOSTNAME: "127.0.0.1",
+      PORT: String(port),
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+    detached: process.platform !== "win32",
+    windowsHide: true,
+  });
+  child.stderr?.on("data", (chunk) => {
+    stderrText = `${stderrText}${chunk.toString()}`.slice(-8_000);
+  });
+  const stderr = () => (stderrText.trim() ? `\n${stderrText.trim()}` : "");
+
   const baseUrl = `http://127.0.0.1:${port}`;
   await waitForHealth(`${baseUrl}/api/health`, child, stderr);
 
@@ -143,5 +149,6 @@ try {
   console.error(`smoke-standalone-server: ${error instanceof Error ? error.message : String(error)}`);
   process.exitCode = 1;
 } finally {
-  await stopChild(child);
+  if (child) await stopChild(child);
+  rmSync(isolatedRoot, { recursive: true, force: true });
 }

--- a/scripts/smoke-standalone-server.mjs
+++ b/scripts/smoke-standalone-server.mjs
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { createServer } from "node:net";
 import { join, resolve } from "node:path";
@@ -35,7 +35,7 @@ async function waitForHealth(url, child, stderr) {
     }
     try {
       const response = await fetch(url, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
-      if (response.ok) return;
+      if (response.status === 200) return;
     } catch {
       // The server may still be starting.
     }
@@ -45,13 +45,32 @@ async function waitForHealth(url, child, stderr) {
 }
 
 async function stopChild(child) {
-  if (child.exitCode !== null) return;
-  child.kill();
+  if (child.exitCode !== null || child.signalCode !== null) return;
+
+  const exited = new Promise((resolveExit) => child.once("exit", resolveExit));
+  if (process.platform === "win32" && child.pid) {
+    spawnSync("taskkill", ["/PID", String(child.pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+  } else {
+    child.kill("SIGTERM");
+  }
+
   await Promise.race([
-    new Promise((resolveExit) => child.once("exit", resolveExit)),
+    exited,
     new Promise((resolveTimeout) => setTimeout(resolveTimeout, 2_000)),
   ]);
-  if (child.exitCode === null) child.kill("SIGKILL");
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill("SIGKILL");
+    await Promise.race([
+      exited,
+      new Promise((resolveTimeout) => setTimeout(resolveTimeout, 2_000)),
+    ]);
+  }
+  if (child.exitCode === null && child.signalCode === null) {
+    throw new Error(`standalone server process ${child.pid ?? "unknown"} did not exit`);
+  }
 }
 
 async function getJsonArray(baseUrl, endpoint, key, stderr) {
@@ -59,7 +78,7 @@ async function getJsonArray(baseUrl, endpoint, key, stderr) {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   const body = await response.text();
-  if (!response.ok) {
+  if (response.status !== 200) {
     throw new Error(`GET ${endpoint} returned HTTP ${response.status}${stderr()}`);
   }
   const payload = JSON.parse(body);

--- a/scripts/smoke-standalone-server.mjs
+++ b/scripts/smoke-standalone-server.mjs
@@ -91,6 +91,8 @@ async function getJsonArray(baseUrl, endpoint, key, stderr) {
 }
 
 const sourceStandaloneDir = resolve(process.argv[2] ?? join(process.cwd(), ".next", "standalone"));
+const runtimeExecutable = resolve(process.argv[3] ?? process.execPath);
+const usesElectronRuntime = process.argv[3] !== undefined;
 const sourceServerScript = join(sourceStandaloneDir, "server.js");
 const piAiEntry = join(
   sourceStandaloneDir,
@@ -109,6 +111,10 @@ if (!existsSync(piAiEntry)) {
   console.error(`smoke-standalone-server: Pi runtime entry not found at ${piAiEntry}`);
   process.exit(1);
 }
+if (!existsSync(runtimeExecutable)) {
+  console.error(`smoke-standalone-server: runtime executable not found at ${runtimeExecutable}`);
+  process.exit(1);
+}
 
 const isolatedRoot = mkdtempSync(join(tmpdir(), "pi-agent-standalone-smoke-"));
 let child = null;
@@ -119,13 +125,14 @@ try {
   const serverScript = join(standaloneDir, "server.js");
   const port = await getFreePort();
   let stderrText = "";
-  child = spawn(process.execPath, [serverScript], {
+  child = spawn(runtimeExecutable, [serverScript], {
     cwd: standaloneDir,
     env: {
       ...process.env,
       NODE_ENV: "production",
       HOSTNAME: "127.0.0.1",
       PORT: String(port),
+      ...(usesElectronRuntime ? { ELECTRON_RUN_AS_NODE: "1" } : {}),
     },
     stdio: ["ignore", "ignore", "pipe"],
     detached: process.platform !== "win32",
@@ -149,6 +156,14 @@ try {
   console.error(`smoke-standalone-server: ${error instanceof Error ? error.message : String(error)}`);
   process.exitCode = 1;
 } finally {
-  if (child) await stopChild(child);
-  rmSync(isolatedRoot, { recursive: true, force: true });
+  try {
+    if (child) await stopChild(child);
+  } finally {
+    rmSync(isolatedRoot, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 100,
+    });
+  }
 }

--- a/scripts/smoke-standalone-server.mjs
+++ b/scripts/smoke-standalone-server.mjs
@@ -26,9 +26,13 @@ function getFreePort() {
   });
 }
 
-async function waitForHealth(url, child, stderr) {
+async function waitForHealth(url, child, stderr, spawnError) {
   const deadline = Date.now() + STARTUP_TIMEOUT_MS;
   while (Date.now() < deadline) {
+    const startupError = spawnError();
+    if (startupError) {
+      throw new Error(`standalone server failed to start: ${startupError.message}${stderr()}`);
+    }
     if (child.exitCode !== null) {
       throw new Error(
         `standalone server exited before health check (code ${child.exitCode})${stderr()}`
@@ -47,6 +51,7 @@ async function waitForHealth(url, child, stderr) {
 
 async function stopChild(child) {
   if (child.exitCode !== null || child.signalCode !== null) return;
+  if (!child.pid) return;
 
   const exited = new Promise((resolveExit) => child.once("exit", resolveExit));
   if (process.platform === "win32" && child.pid) {
@@ -125,6 +130,7 @@ try {
   const serverScript = join(standaloneDir, "server.js");
   const port = await getFreePort();
   let stderrText = "";
+  let childSpawnError = null;
   child = spawn(runtimeExecutable, [serverScript], {
     cwd: standaloneDir,
     env: {
@@ -141,10 +147,13 @@ try {
   child.stderr?.on("data", (chunk) => {
     stderrText = `${stderrText}${chunk.toString()}`.slice(-8_000);
   });
+  child.once("error", (error) => {
+    childSpawnError = error;
+  });
   const stderr = () => (stderrText.trim() ? `\n${stderrText.trim()}` : "");
 
   const baseUrl = `http://127.0.0.1:${port}`;
-  await waitForHealth(`${baseUrl}/api/health`, child, stderr);
+  await waitForHealth(`${baseUrl}/api/health`, child, stderr, () => childSpawnError);
 
   const sessions = await getJsonArray(baseUrl, "/api/sessions", "sessions", stderr);
   const providers = await getJsonArray(baseUrl, "/api/auth/providers", "providers", stderr);


### PR DESCRIPTION
## Summary

- bundle the complete Pi production runtime dependency closure into Next.js standalone output
- run standalone smoke tests from an isolated temporary directory so repository dependencies cannot mask missing files
- run packaged smoke tests with the platform Electron executable in `ELECTRON_RUN_AS_NODE` mode
- fail builds unless health, sessions, and auth provider endpoints all return valid HTTP 200 responses
- bump the desktop release to v0.8.1 and add release notes

## Validation

- `npm test` — 482 passed, 2 skipped
- `npm run lint` — 0 errors, 6 pre-existing warnings
- `npx tsc --noEmit`
- `npx tsc -p electron/tsconfig.json --noEmit`
- `npm run check:electron-deps`
- isolated standalone smoke — health 200, sessions 200, auth providers 200
- packaged Electron runtime smoke — health 200, sessions 200, auth providers 200
- NSIS install to `D:\APP\Pi Agent Desktop`, then full Electron launch — health 200, sessions 200, auth providers 200
- injected executable spawn failure — failed as expected and leaked 0 temporary directories

Closes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows installer session-list failures caused by HTTP 500 errors.
  * Improved standalone and packaged builds by ensuring required runtime components are included.

* **Quality Improvements**
  * Added automated checks for standalone servers, packaged applications, health endpoints, sessions, and authentication providers.
  * Builds now detect missing critical runtime files and fail early with diagnostics.

* **Documentation**
  * Updated the project version to 0.8.1 and documented fixes, validation results, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->