### PR TITLE
chore(release): prepare v0.8.2

### DIFF
--- a/docs/releases/v0.8.2.md
+++ b/docs/releases/v0.8.2.md
@@ -1,0 +1,27 @@
+# Pi Agent Desktop v0.8.2
+
+发布日期：2026-08-26
+
+## 修复
+
+- 修复首次会话在打断输出后发送“继续”可能创建第二个会话、导致上下文被截断的问题。
+- 修复新会话已获得真实 session ID、但界面仍处于过渡状态时，Full 权限或模型切换没有作用到当前会话的问题。
+- 修复普通 prompt 的乐观消息与 canonical SSE 消息同时显示，造成同一用户消息出现两个气泡的问题。
+- 新增同步发送门闩，阻止 React 状态提交前的快速重入实际发出两次 prompt。
+- transcript reload 现在会清理过期的 optimistic delivery refs，避免同文本消息被错误吞掉或破坏 `messages` / `entryIds` 对齐。
+
+## 默认行为
+
+- 新会话默认使用 Full Agent Mode；历史会话仍优先恢复自身持久化的模式。
+
+## 兼容性与已知限制
+
+- Windows x64 安装包未进行代码签名，首次运行可能触发 SmartScreen 提示。
+- `@lobehub/icons` 的传递依赖仍可能对 React 19 产生 peer warning。
+- Electron 36 及其传递依赖的安全审计结果将在后续 Electron 大版本升级中单独处理。
+
+## 验证
+
+- 单元测试、Lint、Web/Electron TypeScript 类型检查和 Electron updater 依赖检查。
+- Next.js standalone 生产服务与打包后 runtime 冒烟检查。
+- NSIS 安装包、blockmap 与 `latest.yml` 版本及 SHA512 一致性核验。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chasen-liao/pi-agent-desktop",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chasen-liao/pi-agent-desktop",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.9"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chasen-liao/pi-agent-desktop",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Pi Agent Desktop — desktop client for the pi coding agent",
   "license": "MIT",
   "author": "Chasen",


### PR DESCRIPTION
## Summary
- bump desktop version to 0.8.2
- add v0.8.2 release notes for harness context/session fixes
- document unsigned Windows installer and Electron audit limitation

## Validation
- npm run lint
- npx tsc --noEmit
- npx tsc -p electron/tsconfig.json --noEmit
- npm test (493 passed, 2 skipped)
- npm run check:electron-deps
- packaged standalone smoke checks passed
- installer SHA512 matches latest.yml

## Review
- Standards: 0 findings
- Spec: release metadata complete; publishing steps pending this PR merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 发布 Pi Agent Desktop v0.8.2。
  * 明确新旧会话的默认模式行为及权限切换体验。
* **问题修复**
  * 改进消息去重、同步发送和会话记录重新加载，提升会话稳定性。
* **已知限制**
  * Windows 安装包签名、React 19 peer warning 及 Electron 安全审计限制仍需关注。
* **验证**
  * 完成测试、类型检查、运行时冒烟测试及安装包完整性验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->