### PR TITLE
fix(ltm): CJK-aware recall and supersede (trigram + LIKE fallback)

### DIFF
--- a/lib/ltm/jaccard.test.ts
+++ b/lib/ltm/jaccard.test.ts
@@ -17,3 +17,27 @@ test("high overlap exceeds 0.7", () => {
   );
   assert.ok(s > 0.7);
 });
+
+test("identical single-char CJK scores 1 (no bigrams, falls back to equality)", () => {
+  assert.equal(jaccardSimilarity("好", "好"), 1);
+});
+
+test("identical CJK strings score 1", () => {
+  assert.equal(jaccardSimilarity("长期记忆用 SQLite 检索", "长期记忆用 SQLite 检索"), 1);
+});
+
+test("CJK near-duplicate exceeds the Dice 0.5 line", () => {
+  const s = jaccardSimilarity(
+    "长期记忆模块使用 SQLite 的 FTS5 做中文检索，需要 trigram 分词",
+    "长期记忆用 SQLite FTS5 做中文检索，必须启用 trigram tokenizer 才支持中文"
+  );
+  assert.ok(s > 0.5);
+});
+
+test("unrelated CJK strings stay well below the threshold", () => {
+  const s = jaccardSimilarity(
+    "长期记忆模块使用 SQLite 的 FTS5 做中文检索",
+    "用户喜欢在周报里用表格展示投放数据"
+  );
+  assert.ok(s < 0.5);
+});

--- a/lib/ltm/jaccard.test.ts
+++ b/lib/ltm/jaccard.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { jaccardSimilarity } from "./jaccard.ts";
+import { jaccardSimilarity, isNearDuplicate } from "./jaccard.ts";
 
 test("identical multi-word strings score 1", () => {
   assert.equal(jaccardSimilarity("prefer dark mode theme", "prefer dark mode theme"), 1);
@@ -40,4 +40,28 @@ test("unrelated CJK strings stay well below the threshold", () => {
     "用户喜欢在周报里用表格展示投放数据"
   );
   assert.ok(s < 0.5);
+});
+
+test("shared Latin tokens alone do not make CJK records duplicates (CR-2)", () => {
+  const s = jaccardSimilarity("你好 SQLite", "您好 SQLite");
+  assert.ok(s < 0.5, "distinct CJK must not reach the duplicate line on Latin overlap");
+  assert.equal(isNearDuplicate("你好 SQLite", "您好 SQLite"), false);
+});
+
+test("short CJK plus a shared Latin token is not a duplicate (CR-2)", () => {
+  assert.equal(isNearDuplicate("好 SQLite 检索", "差 SQLite 分析"), false);
+});
+
+test("Japanese revisions are scored without word spacing (CR-1)", () => {
+  const s = jaccardSimilarity(
+    "日本語のテキストを保存する長期記憶",
+    "日本語の文章を保存する長期記憶機能"
+  );
+  assert.ok(s > 0.5);
+  assert.equal(isNearDuplicate("日本語のテキストを保存する長期記憶", "日本語の文章を保存する長期記憶機能"), true);
+});
+
+test("Korean revisions are scored without word spacing (CR-1)", () => {
+  const s = jaccardSimilarity("장기 기억 모듈 설정", "장기 기억 모듈 설정값");
+  assert.ok(s > 0.5);
 });

--- a/lib/ltm/jaccard.ts
+++ b/lib/ltm/jaccard.ts
@@ -4,15 +4,20 @@
  * v1 scored whitespace tokens only. CJK text has no whitespace, so every
  * Chinese memory was a single giant token and two different memories scored
  * ~0 — the supersede path never fired for Chinese. Now CJK runs are tokenized
- * into character bigrams, and pairs containing CJK are scored with the Dice
+ * into character bigrams and pairs carrying CJK are scored with the Dice
  * coefficient (higher than Jaccard for near-duplicates: bigram sets are large,
  * so Jaccard under-scores them and the threshold stays out of reach).
  */
 const CJK_DICE_THRESHOLD = 0.5;
 const LATIN_JACCARD_THRESHOLD = 0.7;
 
+// Han (incl. Ext-A), Hiragana, Katakana, Hangul — the scripts written without
+// word spacing, so they need character-level tokenization.
+const CJK_CHAR = /[\u3400-\u4dbf\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]/;
+const CJK_RUN = new RegExp(`${CJK_CHAR.source}+`, "g");
+
 function hasCJK(text: string): boolean {
-  return /[\u4e00-\u9fff]/.test(text);
+  return CJK_CHAR.test(text);
 }
 
 function cjkBigrams(text: string): Set<string> {
@@ -20,7 +25,7 @@ function cjkBigrams(text: string): Set<string> {
   // Bigrams come only from contiguous CJK runs — bigramming Latin words too
   // ("alpha beta gamma" -> "ta" shared via alphabetagamma/delta) pollutes the
   // token set and makes disjoint English strings score > 0.
-  for (const run of text.match(/[\u4e00-\u9fff]+/g) ?? []) {
+  for (const run of text.match(CJK_RUN) ?? []) {
     for (let i = 0; i + 1 < run.length; i++) set.add(run.slice(i, i + 2));
   }
   return set;
@@ -30,11 +35,28 @@ function latinTokens(text: string): Set<string> {
   return new Set(text.split(/\s+/).filter((t) => t.length > 2));
 }
 
+function dice(a: Set<string>, b: Set<string>): number {
+  let inter = 0;
+  for (const t of a) if (b.has(t)) inter++;
+  return (2 * inter) / (a.size + b.size);
+}
+
 export function jaccardSimilarity(a: string, b: string): number {
   const na = a.normalize("NFC").toLowerCase();
   const nb = b.normalize("NFC").toLowerCase();
-  const setA = new Set([...cjkBigrams(na), ...latinTokens(na)]);
-  const setB = new Set([...cjkBigrams(nb), ...latinTokens(nb)]);
+  const bigramsA = cjkBigrams(na);
+  const bigramsB = cjkBigrams(nb);
+
+  // Both sides carry CJK: score the CJK bigrams alone. Scoring the union with
+  // Latin tokens lets one shared term ("SQLite") push semantically different
+  // records ("你好 SQLite" / "您好 SQLite") to exactly 0.5, silently marking a
+  // distinct memory non-latest.
+  if (bigramsA.size > 0 && bigramsB.size > 0) {
+    return dice(bigramsA, bigramsB);
+  }
+
+  const setA = new Set([...bigramsA, ...latinTokens(na)]);
+  const setB = new Set([...bigramsB, ...latinTokens(nb)]);
   if (setA.size === 0 || setB.size === 0) {
     // Single-char CJK has no bigrams; fall back to the v1 rule so identical
     // strings still score 1 (regression guard: jaccardSimilarity("好","好") === 1).
@@ -42,9 +64,6 @@ export function jaccardSimilarity(a: string, b: string): number {
   }
   let inter = 0;
   for (const t of setA) if (setB.has(t)) inter++;
-  if (hasCJK(na) || hasCJK(nb)) {
-    return (2 * inter) / (setA.size + setB.size);
-  }
   return inter / (setA.size + setB.size - inter);
 }
 

--- a/lib/ltm/jaccard.ts
+++ b/lib/ltm/jaccard.ts
@@ -1,17 +1,54 @@
-/** Whitespace tokens, drop length <= 2 (ASCII-oriented v1). */
+/**
+ * Similarity for the supersede check in SqliteBackend.remember().
+ *
+ * v1 scored whitespace tokens only. CJK text has no whitespace, so every
+ * Chinese memory was a single giant token and two different memories scored
+ * ~0 — the supersede path never fired for Chinese. Now CJK runs are tokenized
+ * into character bigrams, and pairs containing CJK are scored with the Dice
+ * coefficient (higher than Jaccard for near-duplicates: bigram sets are large,
+ * so Jaccard under-scores them and the threshold stays out of reach).
+ */
+const CJK_DICE_THRESHOLD = 0.5;
+const LATIN_JACCARD_THRESHOLD = 0.7;
+
+function hasCJK(text: string): boolean {
+  return /[\u4e00-\u9fff]/.test(text);
+}
+
+function cjkBigrams(text: string): Set<string> {
+  const set = new Set<string>();
+  // Bigrams come only from contiguous CJK runs — bigramming Latin words too
+  // ("alpha beta gamma" -> "ta" shared via alphabetagamma/delta) pollutes the
+  // token set and makes disjoint English strings score > 0.
+  for (const run of text.match(/[\u4e00-\u9fff]+/g) ?? []) {
+    for (let i = 0; i + 1 < run.length; i++) set.add(run.slice(i, i + 2));
+  }
+  return set;
+}
+
+function latinTokens(text: string): Set<string> {
+  return new Set(text.split(/\s+/).filter((t) => t.length > 2));
+}
+
 export function jaccardSimilarity(a: string, b: string): number {
   const na = a.normalize("NFC").toLowerCase();
   const nb = b.normalize("NFC").toLowerCase();
-  const setA = tokens(na);
-  const setB = tokens(nb);
+  const setA = new Set([...cjkBigrams(na), ...latinTokens(na)]);
+  const setB = new Set([...cjkBigrams(nb), ...latinTokens(nb)]);
   if (setA.size === 0 || setB.size === 0) {
+    // Single-char CJK has no bigrams; fall back to the v1 rule so identical
+    // strings still score 1 (regression guard: jaccardSimilarity("好","好") === 1).
     return na.trim().replace(/\s+/g, " ") === nb.trim().replace(/\s+/g, " ") ? 1 : 0;
   }
   let inter = 0;
   for (const t of setA) if (setB.has(t)) inter++;
+  if (hasCJK(na) || hasCJK(nb)) {
+    return (2 * inter) / (setA.size + setB.size);
+  }
   return inter / (setA.size + setB.size - inter);
 }
 
-function tokens(text: string): Set<string> {
-  return new Set(text.split(/\s+/).filter((t) => t.length > 2));
+/** Supersede decision: Dice 0.5 for CJK-containing pairs, Jaccard 0.7 for Latin (unchanged v1 behavior). */
+export function isNearDuplicate(a: string, b: string): boolean {
+  return jaccardSimilarity(a, b) >= (hasCJK(a) || hasCJK(b) ? CJK_DICE_THRESHOLD : LATIN_JACCARD_THRESHOLD);
 }

--- a/lib/ltm/sqlite-backend.test.ts
+++ b/lib/ltm/sqlite-backend.test.ts
@@ -455,3 +455,114 @@ test("close runs wal_checkpoint(TRUNCATE) before db.close (LTM-12)", () => {
   assert.match(source, /try\s*\{[^{}]*wal_checkpoint[^{}]*\}\s*catch\s*\(/);
   assert.match(source, /console\.error\([^)]*checkpoint[^)]*\)/i);
 });
+
+test("CJK substring queries are recallable via trigram (CJK-1)", async () => {
+  await withTempBackend(async (backend) => {
+    await backend.remember({
+      projectId: "proj_cjk",
+      content: "项目使用 SQLite 存储长期记忆，检索走 FTS5 全文索引",
+    });
+    const hits = await backend.recall({
+      projectId: "proj_cjk",
+      query: "长期记忆",
+      limit: 5,
+    });
+    assert.ok(hits.length > 0, "CJK substring query should hit via trigram");
+  });
+});
+
+test("short CJK queries fall back to LIKE when trigram cannot match (CJK-2)", async () => {
+  await withTempBackend(async (backend) => {
+    await backend.remember({
+      projectId: "proj_like",
+      content: "压缩前要把即将被摘要的分支文本存进 observations 表",
+    });
+    const hits = await backend.recall({
+      projectId: "proj_like",
+      query: "压缩",
+      limit: 5,
+    });
+    assert.ok(hits.length > 0, "2-char CJK query should hit via LIKE fallback");
+  });
+});
+
+test("LIKE fallback does not leak across projects (CJK-3)", async () => {
+  await withTempBackend(async (backend) => {
+    await backend.remember({
+      projectId: "proj_x",
+      content: "用户偏好：回复简洁直接，不要客套话",
+    });
+    const hits = await backend.recall({
+      projectId: "proj_y",
+      query: "偏好",
+      limit: 5,
+    });
+    assert.equal(hits.length, 0);
+  });
+});
+
+test("CJK revision of an existing memory supersedes it (CJK-4)", async () => {
+  await withTempBackend(async (backend) => {
+    const first = await backend.remember({
+      projectId: "proj_sup",
+      content: "长期记忆模块使用 SQLite 的 FTS5 做中文检索，需要 trigram 分词",
+    });
+    const second = await backend.remember({
+      projectId: "proj_sup",
+      content: "长期记忆用 SQLite FTS5 做中文检索，必须启用 trigram tokenizer 才支持中文",
+    });
+    const stats = await backend.stats("proj_sup");
+    assert.equal(stats.memoryCount, 1, "near-duplicate CJK save should supersede");
+    assert.notEqual(second.id, first.id);
+  });
+});
+
+test("migration rebuilds a legacy unicode61 FTS index with trigram (CJK-5)", async () => {
+  const { DatabaseSync } = await import("node:sqlite");
+  const dir = mkdtempSync(join(tmpdir(), "ltm-mig-"));
+  const dbPath = join(dir, "legacy.sqlite");
+  try {
+    // Simulate a pre-CJK database: base tables + FTS without tokenizer.
+    {
+      const db = new DatabaseSync(dbPath);
+      db.exec(`
+        CREATE TABLE memories (
+          id TEXT PRIMARY KEY, project_id TEXT NOT NULL, type TEXT NOT NULL,
+          title TEXT NOT NULL, content TEXT NOT NULL, concepts_json TEXT,
+          files_json TEXT, source_observation_ids_json TEXT,
+          is_latest INTEGER NOT NULL, parent_id TEXT,
+          created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+        );
+        CREATE TABLE observations (
+          id TEXT PRIMARY KEY, project_id TEXT NOT NULL, session_id TEXT NOT NULL,
+          kind TEXT NOT NULL, title TEXT NOT NULL, narrative TEXT NOT NULL,
+          source_json TEXT, created_at TEXT NOT NULL
+        );
+        CREATE VIRTUAL TABLE memories_fts USING fts5(
+          id UNINDEXED, project_id UNINDEXED, title, content
+        );
+        INSERT INTO memories VALUES (
+          'mem_legacy', 'proj_legacy', 'fact', '存储长期记忆标题',
+          '项目使用 SQLite 存储长期记忆', NULL, NULL, NULL, 1, NULL,
+          '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z'
+        );
+        INSERT INTO memories_fts(id, project_id, title, content)
+          VALUES ('mem_legacy', 'proj_legacy', '存储长期记忆标题', '项目使用 SQLite 存储长期记忆');
+      `);
+      db.close();
+    }
+    const backend = new SqliteBackend(dbPath);
+    try {
+      const hits = await backend.recall({
+        projectId: "proj_legacy",
+        query: "长期记忆",
+        limit: 5,
+      });
+      assert.ok(hits.length > 0, "legacy row should be recallable after migration");
+    } finally {
+      await backend.close?.();
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/lib/ltm/sqlite-backend.ts
+++ b/lib/ltm/sqlite-backend.ts
@@ -2,7 +2,7 @@ import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import type { MemoryBackend } from "./backend";
-import { jaccardSimilarity } from "./jaccard.ts";
+import { isNearDuplicate } from "./jaccard.ts";
 import type {
   ForgetInput,
   MemoryType,
@@ -14,7 +14,6 @@ import type {
 
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 50;
-const SUPERSEDE_THRESHOLD = 0.7;
 const SNIPPET_MAX = 240;
 const TITLE_MAX = 80;
 const NARRATIVE_MAX = 4000;
@@ -31,6 +30,16 @@ export function sanitizeFtsQuery(q: string): string {
   const tokens = cleaned.split(/\s+/).filter((t) => t.length > 0);
   if (tokens.length === 0) return "";
   return tokens.map((t) => `"${t.replace(/"/g, "")}"`).join(" ");
+}
+
+/** Tokens shorter than 3 chars cannot be matched by the trigram tokenizer. */
+function shortTokens(q: string): string[] {
+  if (!q || !q.trim()) return [];
+  const cleaned = q
+    .normalize("NFC")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]+/gu, " ");
+  return cleaned.split(/\s+/).filter((t) => t.length > 0 && t.length < 3);
 }
 
 function newId(prefix: "mem" | "obs"): string {
@@ -123,16 +132,76 @@ export class SqliteBackend implements MemoryBackend {
         id UNINDEXED,
         project_id UNINDEXED,
         title,
-        narrative
+        narrative,
+        tokenize = 'trigram'
       );
 
       CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
         id UNINDEXED,
         project_id UNINDEXED,
         title,
-        content
+        content,
+        tokenize = 'trigram'
       );
     `);
+    this.migrateFtsIfNeeded();
+  }
+
+  /**
+   * v0 -> v1: rebuild FTS tables with the trigram tokenizer.
+   *
+   * Tables created before CJK support used the default unicode61 tokenizer,
+   * which cannot match CJK substrings at all. CREATE VIRTUAL TABLE IF NOT
+   * EXISTS never rewrites an existing table, and the FTS5 'rebuild' command
+   * cannot change a tokenizer (it only reindexes the table's own content), so
+   * the only path is drop + recreate + repopulate from the base tables, which
+   * are the authoritative copy. A regular FTS5 table stores its text inside
+   * its shadow tables, so dropping it loses nothing memories/observations
+   * does not already hold. Runs in a transaction and is guarded by
+   * PRAGMA user_version (unused elsewhere in this project).
+   */
+  private migrateFtsIfNeeded(): void {
+    const row = this.db.prepare("PRAGMA user_version").get() as {
+      user_version: number;
+    };
+    if (row.user_version >= 1) return;
+    this.db.exec("BEGIN");
+    try {
+      this.db.exec("DROP TABLE IF EXISTS memories_fts;");
+      this.db.exec(`
+        CREATE VIRTUAL TABLE memories_fts USING fts5(
+          id UNINDEXED, project_id UNINDEXED, title, content,
+          tokenize = 'trigram'
+        );
+      `);
+      this.db.exec(`
+        INSERT INTO memories_fts(id, project_id, title, content)
+        SELECT id, project_id, title, content FROM memories;
+      `);
+      this.db.exec("DROP TABLE IF EXISTS observations_fts;");
+      this.db.exec(`
+        CREATE VIRTUAL TABLE observations_fts USING fts5(
+          id UNINDEXED, project_id UNINDEXED, title, narrative,
+          tokenize = 'trigram'
+        );
+      `);
+      this.db.exec(`
+        INSERT INTO observations_fts(id, project_id, title, narrative)
+        SELECT id, project_id, title, narrative FROM observations;
+      `);
+      this.db.exec("COMMIT");
+    } catch (err) {
+      try {
+        this.db.exec("ROLLBACK");
+      } catch (rollbackErr) {
+        console.error(
+          "LTM: ROLLBACK failed after FTS migration error",
+          rollbackErr
+        );
+      }
+      throw err;
+    }
+    this.db.exec("PRAGMA user_version = 1;");
   }
 
   async remember(
@@ -157,7 +226,7 @@ export class SqliteBackend implements MemoryBackend {
         .all(input.projectId) as Array<{ id: string; content: string }>;
 
       for (const row of latest) {
-        if (jaccardSimilarity(content, row.content) > SUPERSEDE_THRESHOLD) {
+        if (isNearDuplicate(content, row.content)) {
           parentId = row.id;
           this.db
             .prepare(
@@ -292,6 +361,83 @@ export class SqliteBackend implements MemoryBackend {
           type: r.kind as RecallHit["type"],
           createdAt: r.created_at,
         });
+      }
+    }
+
+    // Trigram MATCH needs >= 3 characters per token, so 1-2 char CJK lookups
+    // ("记忆", "压缩") return nothing from FTS. Fall back to a per-token LIKE
+    // scan (not whole-query: multi-token queries are rarely contiguous in the
+    // text) — project-scoped, per-project row counts are small. LIKE hits get
+    // score 0 so FTS hits (bm25 > 0) rank above them.
+    const shortToks = shortTokens(input.query);
+    if (shortToks.length > 0) {
+      const seen = new Set(hits.map((h) => h.id));
+      if (wantMemory) {
+        for (const tok of shortToks) {
+          const rows = this.db
+            .prepare(
+              `SELECT id, title, content, type, created_at FROM memories
+               WHERE project_id = ? AND is_latest = 1
+                 AND (title LIKE ? OR content LIKE ?)
+               LIMIT ?`
+            )
+            .all(
+              input.projectId,
+              `%${tok}%`,
+              `%${tok}%`,
+              limit
+            ) as Array<{
+            id: string;
+            title: string;
+            content: string;
+            type: MemoryType;
+            created_at: string;
+          }>;
+          for (const r of rows) {
+            if (seen.has(r.id)) continue;
+            seen.add(r.id);
+            hits.push({
+              kind: "memory",
+              id: r.id,
+              title: r.title,
+              snippet: snippetOf(r.content),
+              score: 0,
+              type: r.type,
+              createdAt: r.created_at,
+            });
+          }
+        }
+      }
+      if (wantObs) {
+        for (const tok of shortToks) {
+          const rows = this.db
+            .prepare(
+              `SELECT id, title, narrative, kind, created_at FROM observations
+               WHERE project_id = ?
+                 AND (title LIKE ? OR narrative LIKE ?)
+               LIMIT ?`
+            )
+            .all(input.projectId, `%${tok}%`, `%${tok}%`, limit) as Array<{
+            id: string;
+            title: string;
+            narrative: string;
+            kind: string;
+            created_at: string;
+          }>;
+          for (const r of rows) {
+            if (seen.has(r.id)) continue;
+            seen.add(r.id);
+            hits.push({
+              kind: "observation",
+              id: r.id,
+              title: r.title,
+              snippet: snippetOf(r.narrative),
+              score: 0,
+              type: r.kind as RecallHit["type"],
+              createdAt: r.created_at,
+            });
+          }
+        }
       }
     }
 


### PR DESCRIPTION
# 修复 LTM 长期记忆在中文场景下近乎失效的问题

## 问题

现状（v0.8.4）对中文用户，LTM 的两个核心路径都基本失效：

1. **`memory_recall` 中文查询大面积 0 hits。** FTS5 默认 `unicode61` 分词器不切分连续 CJK 文本（一段中文 = 一个巨型 token），而 FTS5 的 `MATCH` 是 token 级匹配——子串查询（`记忆` ⊂ `长期记忆`）全部 miss。
2. **`memory_save` 的 supersede 去重对中文永不触发。** `jaccardSimilarity` 按空白 `\s+` 切词，中文无空格 → 一条记忆 = 1 个 token → 两条不同中文记忆相似度恒为 0，`> 0.7` 永不满足，版本链永远建立不起来。

以上结论均经 `node:sqlite`（SQLite 3.53 / Node 24）实测证实：9 个中文查询中 6 个 0 hits。

## 改动

### 1. FTS5 换 `trigram` 分词器（`sqlite-backend.ts`）

两张 FTS 虚表加 `tokenize='trigram'`，天然支持中文子串/部分匹配，无需分词词典。

### 2. legacy 库迁移（`sqlite-backend.ts`）

已存在的库其 FTS 索引仍是 unicode61，且 `CREATE VIRTUAL TABLE IF NOT EXISTS` 不会重建表、FTS5 的 `'rebuild'` 命令无法更换 tokenizer（实测证伪）。因此新增 `migrateFtsIfNeeded()`：

- `PRAGMA user_version`（仓库内零占用，已确认）守卫，只跑一次
- 事务内 `DROP + CREATE(trigram) + INSERT...SELECT 从 base 表回填`
- base 表 `memories` / `observations` 是权威源，常规 FTS5 表文本在其影子表内，DROP 不丢数据

### 3. 短查询 LIKE 兜底（`sqlite-backend.ts`）

trigram 的 MATCH 要求查询 ≥ 3 字符，1–2 字中文查询（`记忆`、`压缩`）仍无法走索引。`recall()` 对 < 3 字 token 逐个跑 `LIKE %tok%`（注意不是整句——多 token 查询整句在正文中不连续，恒 miss），按 `project_id` 限定、`is_latest = 1` 过滤，LIKE 命中 score=0 排在 FTS 命中之后。

### 4. CJK 感知的相似度（`jaccard.ts`）

- CJK 连续段提取字符 bigram（只对 CJK run 切，避免英文单词被切碎污染 token 集——曾实测 `alpha beta gamma` vs `delta epsilon zeta` 因共享 bigram `ta` 得分 0.0645）
- 含 CJK 的配对用 **Dice 系数**（bigram 集合大，Jaccard 对近重复系统性偏低），阈值 0.5；拉丁配对保持原 Jaccard 0.7，**行为零回归**
- 新增导出 `isNearDuplicate()` 作为 supersede 判定，`remember()` 改用它
- token 集为空（单字 CJK）时回退归一化等值判断，保证 `jaccardSimilarity("好", "好") === 1`（曾在此处引入回归，已修）

## 验证

- `node --test`：**35/35 通过**（含 9 个新用例：trigram 召回 / LIKE 兜底 / 项目隔离 / CJK supersede / legacy 迁移 ×2 / jaccard CJK ×4）。基线中 `observe-hooks` / `service` 两个文件的失败系缺 `node_modules`（`@earendil-works/pi-coding-agent`），与本 PR 无关
- 端到端（真实 `SqliteBackend` + 临时库）：**8/8 中文查询命中**；6 条近义中文记忆存入后 latest=5（**supersede 首次对中文生效**）；legacy 库迁移后 user_version=1 且老数据可召回
- 对抗性边界：legacy observations 迁移召回 / 单字查询 / 迁移幂等（二次构造数据完好）/ 非 LTM 库进构造器（无行为变化）均通过
- 已知取舍：trigram 索引体积大于 unicode61（中文场景约 3 倍），observations retention 治理属后续 PR

## 测试

```
node --test lib/ltm/jaccard.test.ts lib/ltm/sqlite-backend.test.ts
```

## 后续（不在本 PR 内）

- 阈值采样校准：中文近义修订实测 Dice ≈ 0.59，0.5 是保守线；更稳做法是给 `memory_save` 加 `supersedes?: string[]` 显式声明
- 会话启动自动注入 top-K 记忆（否则模型不会主动 recall）
- observations retention + projectId alias


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved near-duplicate detection for Chinese, Japanese, Korean, and mixed-script content.
  * Enhanced CJK search with trigram matching and support for short one- and two-character queries.
  * Preserved project isolation and supersession behavior during CJK searches.

* **Bug Fixes**
  * Prevented shared Latin words from incorrectly classifying distinct mixed-script text as duplicates.
  * Improved compatibility when upgrading existing search indexes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->