### PR TITLE
ci: package Windows, Linux, and macOS on v* tags

### DIFF
--- a/.github/workflows/desktop-packages.yml
+++ b/.github/workflows/desktop-packages.yml
@@ -1,0 +1,169 @@
+name: Desktop packages
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+concurrency:
+  group: desktop-packages-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CSC_IDENTITY_AUTO_DISCOVERY: "false"
+
+jobs:
+  package:
+    name: package (${{ matrix.pack_id }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - pack_id: windows
+            runner: windows-latest
+            dist_script: dist
+          - pack_id: linux
+            runner: ubuntu-latest
+            dist_script: dist
+          - pack_id: macos
+            runner: macos-latest
+            dist_script: dist:mac
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Tag must match package.json version
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          version="$(node -p "require('./package.json').version")"
+          if [ "$tag" != "v${version}" ]; then
+            echo "tag ${tag} does not match package.json version v${version}"
+            exit 1
+          fi
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install Linux packaging tools
+        if: matrix.pack_id == 'linux'
+        run: sudo apt-get update && sudo apt-get install -y fakeroot dpkg
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build installer
+        run: npm run ${{ matrix.dist_script }}
+
+      - name: Verify Linux deb
+        if: matrix.pack_id == 'linux'
+        run: dpkg-deb -I release/*.deb
+
+      - name: Verify macOS universal artifacts
+        if: matrix.pack_id == 'macos'
+        run: |
+          hdiutil verify release/*.dmg
+          unzip -t release/*-mac-universal.zip
+          archs="$(lipo -archs "release/mac-universal/Pi Agent Desktop.app/Contents/MacOS/Pi Agent Desktop")"
+          echo "lipo archs: ${archs}"
+          echo "${archs}" | grep -q "x86_64"
+          echo "${archs}" | grep -q "arm64"
+
+      - name: Upload Windows artifacts
+        if: matrix.pack_id == 'windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-windows
+          if-no-files-found: error
+          path: |
+            release/Pi-Agent-Desktop-Setup-*.exe
+            release/Pi-Agent-Desktop-Setup-*.exe.blockmap
+            release/latest.yml
+
+      - name: Upload Linux artifacts
+        if: matrix.pack_id == 'linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-linux
+          if-no-files-found: error
+          path: |
+            release/Pi-Agent-Desktop-*-linux-*.deb
+            release/latest-linux.yml
+
+      - name: Upload macOS artifacts
+        if: matrix.pack_id == 'macos'
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-macos
+          if-no-files-found: error
+          path: |
+            release/Pi-Agent-Desktop-*-mac-universal.dmg
+            release/Pi-Agent-Desktop-*-mac-universal.dmg.blockmap
+            release/Pi-Agent-Desktop-*-mac-universal.zip
+            release/Pi-Agent-Desktop-*-mac-universal.zip.blockmap
+            release/latest-mac.yml
+
+  publish:
+    name: upload GitHub Release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: desktop-*
+          path: dist-artifacts
+          merge-multiple: true
+
+      - name: Publish assets to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          notes="docs/releases/${tag}.md"
+          shopt -s nullglob
+          assets=(
+            dist-artifacts/Pi-Agent-Desktop-Setup-*.exe
+            dist-artifacts/Pi-Agent-Desktop-Setup-*.exe.blockmap
+            dist-artifacts/latest.yml
+            dist-artifacts/Pi-Agent-Desktop-*-linux-*.deb
+            dist-artifacts/latest-linux.yml
+            dist-artifacts/Pi-Agent-Desktop-*-mac-universal.dmg
+            dist-artifacts/Pi-Agent-Desktop-*-mac-universal.dmg.blockmap
+            dist-artifacts/Pi-Agent-Desktop-*-mac-universal.zip
+            dist-artifacts/Pi-Agent-Desktop-*-mac-universal.zip.blockmap
+            dist-artifacts/latest-mac.yml
+          )
+          if [ "${#assets[@]}" -ne 10 ]; then
+            echo "expected 10 release assets, found ${#assets[@]}:"
+            printf '%s\n' "${assets[@]}"
+            ls -la dist-artifacts
+            exit 1
+          fi
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release ${tag} already exists"
+          elif [ -f "$notes" ]; then
+            gh release create "$tag" --title "Pi Agent Desktop ${tag}" --notes-file "$notes" --verify-tag
+          else
+            gh release create "$tag" --title "Pi Agent Desktop ${tag}" --generate-notes --verify-tag
+          fi
+          gh release upload "$tag" "${assets[@]}" --clobber
+          gh release edit "$tag" --draft=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ npm run dev:electron # builds electron + opens window
 # Production build & package
 npm run dist         # Current OS package: NSIS on Windows, DMG + ZIP on macOS, DEB on Linux
 npm run dist:mac     # Universal macOS package (Intel + Apple Silicon)
+# GitHub Release: push tag vX.Y.Z → .github/workflows/desktop-packages.yml
 ```
 
 Typecheck: `npx tsc --noEmit`  
@@ -21,7 +22,7 @@ Windows CI subset: `npm run test:windows`
 macOS CI subset: `npm run test:macos`
 **Never run `next build` during dev** — pollutes `.next/` and breaks `npm run dev`.
 
-Release：按 [docs/RELEASING.md](docs/RELEASING.md) 执行；桌面 GitHub Release 不使用会自动 bump patch 的 `npm run release`。
+Release：按 [docs/RELEASING.md](docs/RELEASING.md) 执行。桌面 GitHub Release 推 `vX.Y.Z` tag，由 `.github/workflows/desktop-packages.yml` 打 Win/Linux/macOS 并上传；不要用会自动 bump patch 的 `npm run release`。
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -148,6 +148,7 @@ pi-agent-desktop/
 ├── tailwind.config.ts            Tailwind 4 配置
 ├── tsconfig.json                 strict + bundler resolution
 ├── electron-builder.yml          Windows NSIS + macOS DMG/ZIP + Linux DEB 打包配置
+├── .github/workflows/            ci.yml 测试；desktop-packages.yml 打 v* 桌面包
 ├── eslint.config.mjs             ESLint 9 flat config
 │
 ├── bin/

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -15,13 +15,14 @@
 
    CI（`.github/workflows/ci.yml`）：Linux 跑 `npm test`（含根目录 `middleware.test.ts`）；Windows 跑 `npm run test:windows`；macOS 跑 `npm run test:macos`。平台任务只覆盖路径、Electron 与打包配置子集，不再全量重复单测，也不上传 standalone artifact。
 3. 创建 PR 到 `main`，等待 CI 全部通过并完成审查后合并。
-4. 从合并后的 `main` 创建干净 worktree并执行 `npm ci`：
-   - Windows 运行 `npm run dist`，生成 NSIS 安装包。
-   - macOS 运行 `npm run dist:mac`，生成 Intel + Apple Silicon Universal DMG 与 ZIP。
-   - Linux 运行 `npm run dist`，生成 DEB 安装包。Linux 打包机需要 `fakeroot` 与 `dpkg`（提供 `dpkg-deb`）；Debian/Ubuntu 执行 `sudo apt-get install fakeroot dpkg`，Arch 需另装 `fakeroot`、`dpkg` 与 `libxcrypt-compat`（fpm 自带的 Ruby 需要 `libcrypt.so.1`）。
-   - macOS 构建会用 `npm pack` 下载 standalone 缺失架构的 Sharp/libvips 可选包；构建机需要能访问 npm registry。不要绕过 `ensure-standalone-macos-universal-runtimes.mjs`，也不要删除 `mac.x64ArchFiles`。
-5. 核对更新元数据中的 `version`、文件名和 SHA512：Windows 为 `release/latest.yml`，macOS 为 `release/latest-mac.yml`，Linux 为 `release/latest-linux.yml`。三端产物都确认后再创建并推送 `vX.Y.Z` tag。
-6. 使用对应的 `docs/releases/vX.Y.Z.md` 创建 GitHub Release，并上传：
+4. 确认 `package.json` 的 `version` 为 `X.Y.Z` 后，在合并后的 `main` 打 tag 并推送：`git tag vX.Y.Z && git push origin vX.Y.Z`。tag 必须等于 `v` + `package.json` version，否则打包 job 会失败。不要用 `npm run release` 发桌面包。
+5. `.github/workflows/desktop-packages.yml` 在 GitHub-hosted runner 上并行打包并上传到该 tag 的 GitHub Release（没有 Release 则用 `docs/releases/vX.Y.Z.md` 创建）：
+   - Windows：`npm run dist` → NSIS
+   - Linux：`npm run dist`（预装 `fakeroot` `dpkg`）→ DEB
+   - macOS：`npm run dist:mac` → Universal DMG + ZIP（`ensure-standalone-macos-universal-runtimes.mjs` + `mac.x64ArchFiles`；不要删）
+   - 三端都跑 `smoke-packaged-standalone`；macOS 额外 `hdiutil verify` / `unzip -t` / `lipo` 双架构；Linux 额外 `dpkg-deb -I`
+   - Actions 设置 `CSC_IDENTITY_AUTO_DISCOVERY=false`，产物均未代码签名。手动 `workflow_dispatch` 只上传 artifact，不发 Release。
+6. 工作流上传的资产：
    - `Pi-Agent-Desktop-Setup-X.Y.Z.exe`
    - `Pi-Agent-Desktop-Setup-X.Y.Z.exe.blockmap`
    - `latest.yml`
@@ -32,13 +33,13 @@
    - `latest-mac.yml`
    - `Pi-Agent-Desktop-X.Y.Z-linux-amd64.deb`
    - `latest-linux.yml`
-7. 重新查询 GitHub Release，确认 tag、目标 commit、资产名称与大小。
+7. 重新查询 GitHub Release，确认 tag、目标 commit、资产名称、大小，以及三份 `latest*.yml` 的 `version` 与 SHA512。
 
-macOS 产物发布前还应运行 `hdiutil verify release/*.dmg`、`unzip -t release/*-mac-universal.zip`，并用 `lipo -archs "release/mac-universal/Pi Agent Desktop.app/Contents/MacOS/Pi Agent Desktop"` 确认输出同时包含 `x86_64 arm64`。Linux 产物发布前用 `dpkg-deb -I release/*.deb` 核对 Package/Version/Maintainer 与依赖列表。
+本地 fallback（Actions 失败或要复现）：干净 worktree `npm ci` 后，Windows / Linux 跑 `npm run dist`，macOS 跑 `npm run dist:mac`。Linux 打包机需要 `fakeroot` 与 `dpkg`；Debian/Ubuntu 执行 `sudo apt-get install fakeroot dpkg`，Arch 需另装 `fakeroot`、`dpkg` 与 `libxcrypt-compat`。不要另开一套版本号。
 
-Windows 安装包当前未代码签名，Release Notes 必须披露 SmartScreen 提示。macOS 构建会在钥匙串中存在有效 Developer ID 证书时自动签名，并在配置了 electron-builder 支持的 Apple 凭据时公证；没有签名或公证的发布包必须在 Release Notes 披露 Gatekeeper 提示。Linux 的 `.deb` 安装包通过 electron-updater 的 `DebUpdater` 自动更新：应用内下载新 `.deb` 后经 `dpkg -i` 或 `apt --allow-unauthenticated` 安装，安装时需要 root 授权提示。下载完整性由 `latest-linux.yml` 的 SHA512 校验（与 Windows NSIS 相同），但 `.deb` 本身未做 debsig，系统包管理器不会再验包签名。自动更新依赖 Release 资产中的 `latest-linux.yml`，漏传则 Linux 端收不到更新。Release Notes 必须披露未签名 deb 与 root 安装。
+Windows 安装包当前未代码签名，Release Notes 必须披露 SmartScreen 提示。GitHub Actions 打的 macOS 包同样未签名、未公证，Release Notes 必须披露 Gatekeeper 提示。Linux 的 `.deb` 安装包通过 electron-updater 的 `DebUpdater` 自动更新：应用内下载新 `.deb` 后经 `dpkg -i` 或 `apt --allow-unauthenticated` 安装，安装时需要 root 授权提示。下载完整性由 `latest-linux.yml` 的 SHA512 校验（与 Windows NSIS 相同），但 `.deb` 本身未做 debsig，系统包管理器不会再验包签名。自动更新依赖 Release 资产中的 `latest-linux.yml`，漏传则 Linux 端收不到更新。Release Notes 必须披露未签名 deb 与 root 安装。
 
-截至 2026-08-31：最新 GitHub Release 仍是 `v0.8.4`，资产只有 Windows 安装包。macOS Universal 打包已合入 `main`（#22），尚未随 Release 发布。macOS 产物可由有 Write 权限的协作者在 macOS 上执行 `npm run dist:mac` 后，上传到**同一** `vX.Y.Z` tag；不要另开一套版本号。
+截至 2026-09-01：最新 GitHub Release 仍是 `v0.8.4`，资产只有 Windows 安装包。下一轮 `v*` tag 起由 Desktop packages workflow 打三端。
 
 ## npm Release
 

--- a/lib/desktop-packages-workflow.test.mjs
+++ b/lib/desktop-packages-workflow.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const workflow = readFileSync(
+  join(root, ".github/workflows/desktop-packages.yml"),
+  "utf8",
+).replace(/\r\n/g, "\n");
+
+test("desktop package workflow builds three hosts on v* tags", () => {
+  assert.match(workflow, /^name: Desktop packages/m);
+  assert.match(workflow, /tags:\n\s+- "v\*"/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /runner: windows-latest/);
+  assert.match(workflow, /runner: ubuntu-latest/);
+  assert.match(workflow, /runner: macos-latest/);
+  assert.match(workflow, /dist_script: dist\n/);
+  assert.match(workflow, /dist_script: dist:mac/);
+  assert.match(workflow, /npm run \$\{\{ matrix\.dist_script \}\}/);
+  assert.doesNotMatch(workflow, /npm run release/);
+  assert.match(workflow, /CSC_IDENTITY_AUTO_DISCOVERY: "false"/);
+  assert.match(workflow, /sudo apt-get install -y fakeroot dpkg/);
+});
+
+test("desktop package workflow uploads GitHub Release assets only on tags", () => {
+  assert.match(workflow, /if: startsWith\(github\.ref, 'refs\/tags\/v'\)/);
+  assert.match(workflow, /gh release upload/);
+  assert.match(workflow, /permissions:\n\s+contents: write/);
+  assert.match(workflow, /latest-linux\.yml/);
+  assert.match(workflow, /latest-mac\.yml/);
+  assert.match(workflow, /mac-universal\.dmg/);
+  assert.doesNotMatch(workflow, /electron-builder --publish always/);
+});


### PR DESCRIPTION
## Why

Desktop installers were built on local Windows / macOS / Linux machines. Linux cannot be packaged from Windows, and macOS Universal needed a Mac. Tag-triggered Actions replace that.

## Scope

- `.github/workflows/desktop-packages.yml`: on `v*` tags (and manual `workflow_dispatch`)
  - Windows `npm run dist` → NSIS
  - Linux `npm run dist` (installs `fakeroot` `dpkg`) → deb
  - macOS `npm run dist:mac` → Universal DMG + ZIP, unsigned (`CSC_IDENTITY_AUTO_DISCOVERY=false`)
  - smoke + `dpkg-deb` / `hdiutil` / `lipo` checks
  - tag job uploads 10 assets to the GitHub Release (creates it from `docs/releases/vX.Y.Z.md` when missing)
  - `workflow_dispatch` artifacts only
- Docs: `docs/RELEASING.md`, `AGENTS.md`, `docs/ARCHITECTURE.md`
- Pin test: `lib/desktop-packages-workflow.test.mjs`

Out of scope: Apple signing/notarization, Linux debsig, running this on every PR.

## Verification

```
node --test --test-force-exit lib/desktop-packages-workflow.test.mjs lib/electron-builder-config.test.mjs
```

9/9 pass. Full installer run happens on the first `v*` tag after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated desktop installer builds for Windows, Linux, and macOS.
  * Version-tagged releases now publish platform installers and update the corresponding GitHub Release.
  * Manual runs can build and upload installers without creating a release.

* **Documentation**
  * Updated release and architecture documentation with the new desktop packaging workflow.
  * Documented unsigned macOS artifacts and platform-specific installation considerations.

* **Tests**
  * Added coverage to verify supported platforms, triggers, packaging settings, and release behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->