### PR TITLE
release: v0.8.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ npm run build
 # 打包目录版 Electron 应用
 npm run pack
 
-# 构建当前平台安装包（Windows NSIS / macOS DMG + ZIP）
+# 构建当前平台安装包（Windows NSIS / macOS DMG + ZIP / Linux DEB）
 npm run dist
 
 # 构建 Intel + Apple Silicon Universal macOS 安装包
@@ -65,7 +65,7 @@ npm run dist:mac
 - **会话 Branching & Cloning**：支持从会话节点分叉新分支 (`/api/sessions/[id]/branch`) 或全量 Clone 到目标目录 (`/api/sessions/[id]/clone`)。
 - **会话导出 (HTML/MD)**：支持将会话流式或静态导出为独立的 HTML（含语法高亮）或 Markdown 文件 (`/api/sessions/[id]/export`)。
 - **AgentMode `.jsonl` 持久化**：在模式切换时向 Session `.jsonl` 追加 `desktop_agent_mode` Custom Entry，Session 重载时自动恢复历史模式。
-- **长期记忆 LTM（v0.7.19）**：项目级 SQLite 记忆库 `lib/ltm`；工具 `memory_save` / `memory_recall` / `memory_forget`；API `/api/memory/*`；`agent_end` 与 compact 前自动 observe。设计见 [docs/superpowers/specs/2026-08-03-long-term-memory-design.md](docs/superpowers/specs/2026-08-03-long-term-memory-design.md)；会话记忆基线见 [docs/memory-architecture.html](docs/memory-architecture.html)。
+- **长期记忆 LTM**：项目级 SQLite 记忆库 `lib/ltm`；工具 `memory_save` / `memory_recall` / `memory_forget`；API `/api/memory/*`；FTS5 `trigram` + 短词 LIKE 召回；CJK supersede 用 Dice。设计见 [docs/superpowers/specs/2026-08-03-long-term-memory-design.md](docs/superpowers/specs/2026-08-03-long-term-memory-design.md)。
 - **可重排 Follow-up Queue（v0.8.0）**：Agent 运行中 Enter 发送 steer、Alt+Enter 排队；队列由 `AgentSessionWrapper` 管理并通过 SSE 同步，支持拖拽或键盘重排。
 
 ## 高层架构

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@
 - **会话分叉与克隆** — API/UI 支持从任意节点 Branch 及 Clone 会话到新目录
 - **会话导出** — 一键导出为 HTML / Markdown 格式
 - **AgentMode 持久化** — 自动写入 `.jsonl` 自定义 `desktop_agent_mode` 节点，重载恢复历史模式
-- **长期记忆 LTM** — 项目级 SQLite 记忆（`memory_save` / `memory_recall` / `memory_forget`），跨会话检索；`agent_end` 与 compact 前自动观察写入
+- **长期记忆 LTM** — 项目级 SQLite 记忆（`memory_save` / `memory_recall` / `memory_forget`），跨会话检索；中文/日韩走 FTS5 trigram；`agent_end` 与 compact 前自动观察写入
+- **界面语言** — 中 / 英，可跟随系统
 - **会话内分支** — 回退到任意节点继续对话，在同一文件内创建分支
 - **分支导航器** — 可视化切换同一会话内的各个分支
 - **模型切换** — 对话中途随时切换模型
@@ -50,9 +51,11 @@
 
 前往 [Releases](https://github.com/Chasen-Liao/pi-agent-desktop/releases) 页面下载最新版安装程序。
 
-Windows 用户下载 `Pi-Agent-Desktop-Setup-x.x.x.exe`，运行即可安装。
+按系统下载对应安装包（以当前 Release 资产为准）：
 
-macOS 打包支持 Intel 与 Apple Silicon 的 Universal 应用。发布页提供 Mac 资产时，下载 `Pi-Agent-Desktop-x.x.x-mac-universal.dmg`；ZIP 是自动更新所需的配套产物。实际可下载版本以 Releases 资产为准。
+- Windows：`Pi-Agent-Desktop-Setup-x.x.x.exe`
+- macOS Universal（Intel + Apple Silicon）：`Pi-Agent-Desktop-x.x.x-mac-universal.dmg`（ZIP 供自动更新）
+- Linux x64：`Pi-Agent-Desktop-x.x.x-linux-amd64.deb`
 
 ## 开发
 
@@ -81,11 +84,13 @@ npm run test:windows
 # macOS CI 子集（路径 / Electron / 打包配置）
 npm run test:macos
 
-# 构建安装包
+# 构建当前系统安装包（Windows NSIS / Linux DEB；macOS 请用下一行）
 npm run dist
 
-# 在 macOS 上构建 Universal DMG + ZIP
+# 构建 Intel + Apple Silicon Universal macOS 安装包
 npm run dist:mac
+
+# GitHub Release：推 vX.Y.Z tag，由 Actions 打三端（见 docs/RELEASING.md）
 ```
 
 ## 项目结构
@@ -122,7 +127,7 @@ scripts/
 
 - **前端**：Next.js + React + TypeScript
 - **桌面**：Electron
-- **打包**：electron-builder（Windows NSIS；macOS Universal DMG + ZIP）
+- **打包**：electron-builder（Windows NSIS；macOS Universal DMG + ZIP；Linux DEB）
 - **通信**：SSE (Server-Sent Events) 实时流式传输
 
 ## 致谢

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,9 +3,9 @@
 > 本文档是项目的**权威架构参考**，由 CodeGraph 静态分析 + 源码核对生成。
 > 若与 `AGENTS.md` / `CLAUDE.md` 中的简要描述冲突，以本文档为准。
 >
-- **项目**：`@chasen-liao/pi-agent-desktop` v0.8.4
+- **项目**：`@chasen-liao/pi-agent-desktop` v0.8.5
 - **上游 SDK**：`@earendil-works/pi-coding-agent` ^0.84.3 / `@earendil-works/pi-ai` ^0.84.3
-- **更新日期**：2026-08-31
+- **更新日期**：2026-09-01
 
 ---
 
@@ -143,7 +143,7 @@ flowchart TD
 
 ```text
 pi-agent-desktop/
-├── package.json                  @chasen-liao/pi-agent-desktop v0.8.4
+├── package.json                  @chasen-liao/pi-agent-desktop v0.8.5
 ├── next.config.ts                output:"standalone" + server external packages
 ├── tailwind.config.ts            Tailwind 4 配置
 ├── tsconfig.json                 strict + bundler resolution

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -39,7 +39,7 @@
 
 Windows 安装包当前未代码签名，Release Notes 必须披露 SmartScreen 提示。GitHub Actions 打的 macOS 包同样未签名、未公证，Release Notes 必须披露 Gatekeeper 提示。Linux 的 `.deb` 安装包通过 electron-updater 的 `DebUpdater` 自动更新：应用内下载新 `.deb` 后经 `dpkg -i` 或 `apt --allow-unauthenticated` 安装，安装时需要 root 授权提示。下载完整性由 `latest-linux.yml` 的 SHA512 校验（与 Windows NSIS 相同），但 `.deb` 本身未做 debsig，系统包管理器不会再验包签名。自动更新依赖 Release 资产中的 `latest-linux.yml`，漏传则 Linux 端收不到更新。Release Notes 必须披露未签名 deb 与 root 安装。
 
-截至 2026-09-01：最新 GitHub Release 仍是 `v0.8.4`，资产只有 Windows 安装包。下一轮 `v*` tag 起由 Desktop packages workflow 打三端。
+截至 2026-09-01：桌面 GitHub Release 流程是推 `v*` tag，由 `.github/workflows/desktop-packages.yml` 打 Windows / Linux / macOS。`v0.8.4` 及更早只有 Windows 资产。
 
 ## npm Release
 

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1091,7 +1091,7 @@
     <div class="section-tag">// Components</div>
     <h2 class="section-title">核心组件与子组件目录</h2>
     <p class="section-desc">
-      全部手写，零 UI 组件库依赖。每个组件通过 CSS 变量实现暗色/亮色主题，使用 React 19 的最新特性构建。CodeGraph 索引实际统计：顶层 17 个 + 子组件目录 3 个（<code>chat-input/</code>、<code>session-sidebar/</code>、<code>models-config/</code>）。
+      全部手写，零 UI 组件库依赖。每个组件通过 CSS 变量实现暗色/亮色主题，使用 React 19 的最新特性构建。顶层 27 个组件文件 + 子组件目录 3 个（<code>chat-input/</code>、<code>session-sidebar/</code>、<code>models-config/</code>）。
     </p>
 
     <div class="comp-grid">
@@ -1271,7 +1271,7 @@
       </div>
       <div class="tech-item" style="transition-delay:0.55s">
         <div class="tech-icon">📦</div>
-        <div><div class="tech-name">electron-builder</div><div class="tech-ver">^26.15.3 NSIS + DMG/ZIP</div></div>
+        <div><div class="tech-name">electron-builder</div><div class="tech-ver">^26.15.3 NSIS + DMG/ZIP + DEB</div></div>
       </div>
       <div class="tech-item" style="transition-delay:0.6s">
         <div class="tech-icon">🔄</div>
@@ -1373,12 +1373,13 @@
 
     <div class="file-tree">
       <div class="ft-line ft-dir" style="--depth:0"><span class="ft-icon">📁</span><span class="ft-name">pi-agent-desktop/</span></div>
-      <div class="ft-line" style="--depth:1"><span class="ft-icon">📦</span><span class="ft-name">package.json</span><span class="ft-comment">@chasen-liao/pi-agent-desktop v0.8.4</span></div>
+      <div class="ft-line" style="--depth:1"><span class="ft-icon">📦</span><span class="ft-name">package.json</span><span class="ft-comment">@chasen-liao/pi-agent-desktop v0.8.5</span></div>
       <div class="ft-line" style="--depth:1"><span class="ft-icon">⚙️</span><span class="ft-name">next.config.ts</span><span class="ft-comment">standalone + 外部包</span></div>
       <div class="ft-line" style="--depth:1"><span class="ft-icon">🎨</span><span class="ft-name">tailwind.config.ts</span></div>
       <div class="ft-line" style="--depth:1"><span class="ft-icon">📘</span><span class="ft-name">tsconfig.json</span><span class="ft-comment">strict + bundler</span></div>
-      <div class="ft-line" style="--depth:1"><span class="ft-icon">📦</span><span class="ft-name">electron-builder.yml</span><span class="ft-comment">NSIS + Universal DMG/ZIP + 原生模块合并规则</span></div>
-      <div class="ft-line" style="--depth:1"><span class="ft-icon">🧹</span><span class="ft-name">eslint.config.mjs</span><span class="ft-comment">flat config</span></div>
+      <div class="ft-line" style="--depth:1"><span class="ft-icon">📦</span><span class="ft-name">electron-builder.yml</span><span class="ft-comment">NSIS + Universal DMG/ZIP + Linux DEB + 原生模块合并规则</span></div>
+      <div class="ft-line" style="--depth:1"><span class="ft-icon">⚙️</span><span class="ft-name">.github/workflows/</span><span class="ft-comment">ci.yml 测试；desktop-packages.yml 打 v* 桌面包</span></div>
+        <div class="ft-line" style="--depth:1"><span class="ft-icon">🧹</span><span class="ft-name">eslint.config.mjs</span><span class="ft-comment">flat config</span></div>
       <div class="ft-line" style="--depth:1"><span class="ft-icon">🤖</span><span class="ft-name">AGENTS.md</span><span class="ft-comment">开发速查摘要</span></div>
       <div class="ft-line" style="--depth:1"><span class="ft-icon">🧠</span><span class="ft-name">CLAUDE.md</span><span class="ft-comment">Claude Code 指南</span></div>
 
@@ -1512,7 +1513,7 @@
 </section>
 
 <footer>
-  <p>Pi Agent Desktop 架构深度解析 · 版本 0.8.4 · 2026-08-31 · <a href="https://github.com/Chasen-Liao/pi-agent-desktop" style="color:var(--accent3);text-decoration:none;">pi-agent-desktop</a></p>
+  <p>Pi Agent Desktop 架构深度解析 · 版本 0.8.5 · 2026-09-01 · <a href="https://github.com/Chasen-Liao/pi-agent-desktop" style="color:var(--accent3);text-decoration:none;">pi-agent-desktop</a></p>
 </footer>
 
 <script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -413,7 +413,7 @@
       .start-col h3 { font-size: 20px; margin: 12px 0 6px; }
       .start-col > p { color: var(--muted); font-size: 14.5px; margin-bottom: 22px; }
 
-      .os-row { display: flex; gap: 10px; margin-bottom: 12px; }
+      .os-row { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 12px; }
       .os-note { font-size: 13px; color: var(--muted); line-height: 1.65; margin: 0 0 18px; }
       .os-note a { color: var(--primary); }
       .os-chip {
@@ -720,7 +720,7 @@
         <div class="container hero-inner">
           <div class="hero-badge reveal">
             <span>Pi 编程智能体的原生桌面客户端</span>
-            <span class="tag">v0.8.4</span>
+            <span class="tag">v0.8.5</span>
           </div>
           <h1 id="hero-title" class="reveal d1">
             个人极简版 Codex
@@ -732,7 +732,7 @@
           <div class="hero-actions reveal d3">
             <a class="btn btn--primary btn--lg" href="https://github.com/Chasen-Liao/pi-agent-desktop/releases" target="_blank" rel="noopener">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12m0 0l-4-4m4 4l4-4M4 21h16"/></svg>
-              下载 Windows 版
+              下载桌面版
             </a>
             <a class="btn btn--ghost btn--lg" href="#start">
               从源码运行
@@ -1065,8 +1065,13 @@
                   <b>macOS</b>
                   <span style="font-size:12px;color:var(--dim)">Universal DMG</span>
                 </div>
+                <div class="os-chip">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="3" width="16" height="18" rx="2"/><path d="M8 7h8M8 11h8M8 15h5"/></svg>
+                  <b>Linux</b>
+                  <span style="font-size:12px;color:var(--dim)">amd64 .deb</span>
+                </div>
               </div>
-              <p class="os-note">macOS 打包支持 Intel 与 Apple Silicon。是否提供 Mac 下载，请以当前 GitHub Release 的资产列表为准。</p>
+              <p class="os-note">Windows NSIS、macOS Universal（Intel + Apple Silicon）、Linux x64 deb。安装包未代码签名；实际文件名以 GitHub Release 资产为准。</p>
               <a class="btn btn--brand" href="https://github.com/Chasen-Liao/pi-agent-desktop/releases" target="_blank" rel="noopener" style="width:100%">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12m0 0l-4-4m4 4l4-4M4 21h16"/></svg>
                 打开 Releases 下载

--- a/docs/releases/v0.8.5.md
+++ b/docs/releases/v0.8.5.md
@@ -1,0 +1,26 @@
+# Pi Agent Desktop v0.8.5
+
+发布日期：2026-09-01
+
+## 新增
+
+- **Linux 桌面包**：`electron-builder` 增加 x64 `deb` 目标，产物 `Pi-Agent-Desktop-X.Y.Z-linux-amd64.deb`，配套 `latest-linux.yml`（#24）
+- **macOS Universal 进入正式 Release 通道**：Intel + Apple Silicon DMG / ZIP 随 tag 由 Actions 构建（#22 合入后的首个三端发行）
+- **桌面包 GitHub Actions**：推 `vX.Y.Z` tag 后 `.github/workflows/desktop-packages.yml` 在 Windows / Ubuntu / macOS runner 打包并上传同一 GitHub Release；手动 `workflow_dispatch` 只出 artifact（#25）
+- **界面中英**：用户可见文案走 `lib/i18n`（`en` / `zh-CN`，偏好可 `system`）（#22）
+
+## 修复
+
+- **长期记忆中文近乎失效**：FTS5 改 `trigram`，短查询 LIKE 兜底；CJK 近重复用 Dice 0.5 supersede；覆盖假名/韩文，且双方都有 CJK 时不因共享拉丁词误判重复（#23）
+- **渲染进程白屏**：全局 error boundary，渲染崩溃后有界自动重载（#20）
+
+## 兼容性与已知限制
+
+- Windows / macOS / Linux 安装包均未代码签名。Windows 可能出现 SmartScreen；macOS 可能出现 Gatekeeper；Linux 自动更新经 `dpkg`/`apt` 安装未签名 `.deb`，需要 root 授权。Release 必须带齐 `latest.yml` / `latest-mac.yml` / `latest-linux.yml`，漏传则对应平台收不到更新。
+- 中英混合短词查询（如 `压缩 sqlite`）可能走 LIKE 而非 FTS 排序；CJK 双方只比较汉字/假名/韩文 bigram，拉丁词不参与 Dice。
+- 仅环境变量认证的 provider（如 GitHub Copilot）不支持在弹窗中保存 API Key。
+
+## 验证
+
+- 版本 PR 的 CI：`lint · typecheck · test`、`test (windows)`、`test (macOS)`、`build (next.js)`
+- tag 后 `Desktop packages` workflow 构建三端并上传本 Release；发布后核对本页资产名称、大小与三份 `latest*.yml` 的 version / SHA512

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chasen-liao/pi-agent-desktop",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chasen-liao/pi-agent-desktop",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.9"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chasen-liao/pi-agent-desktop",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Pi Agent Desktop — desktop client for the pi coding agent",
   "license": "MIT",
   "author": "Chasen",


### PR DESCRIPTION
## Why

Ship the first three-platform desktop release: Linux deb, macOS Universal, Windows NSIS, CJK LTM, crash recovery, i18n, and tag-triggered Actions packaging.

## Scope

- `package.json` / lock → **0.8.5**
- `docs/releases/v0.8.5.md`
- Landing page + README + architecture pages + CLAUDE.md + RELEASING.md

After merge: `git tag v0.8.5 && git push origin v0.8.5` so `desktop-packages.yml` builds and uploads the GitHub Release.

Do **not** run `npm run release` (that bumps patch again and publishes npm).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Linux x64 `.deb` desktop installers alongside Windows and macOS packages.
  - Added interface language support documentation for Chinese and English.
  - Improved Chinese, Japanese, and Korean long-term memory search coverage.

- **Bug Fixes**
  - Documented improved recovery from rendering-process crashes.

- **Documentation**
  - Updated version information to 0.8.5.
  - Added platform-specific download guidance, release notes, packaging details, and compatibility limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->