### PR TITLE
fix(packaging): dereference standalone symlinks before universal merge

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -804,6 +804,7 @@ Next.js NFT 只会追踪构建宿主架构的可选原生依赖。在 Apple Sili
 
 - `scripts/ensure-standalone-macos-universal-runtimes.mjs` 从 standalone 的 `sharp/package.json` 读取精确可选依赖版本，把宿主已有包复制过去，并通过 `npm pack` 下载另一架构包，最终保证 arm64/x64 Sharp 与 libvips 并存。
 - `electron-builder.yml` 的 `mac.x64ArchFiles` 只匹配 Pi TUI、Clipboard、Sharp 与 libvips 的架构专用目录，让 Universal 合并器保留这些并列资源；Electron 主可执行文件等其他 Mach-O 仍正常执行 `lipo`。
+- standalone `node_modules` 若仍含指向构建机 `node_modules` 的符号链接，`@electron/universal` 会对 x64/arm64 临时目录算出不同的 `relativePath`（同一 `semver.js` 在一边是 `../../../node_modules/...`，另一边是 `../../../../../../../../Users/runner/...`）并中止合并。`scripts/dereference-standalone-symlinks.mjs` 在打包前把这些链接落实成文件。
 - `@electron/rebuild` 由 electron-builder 自动调用，打包脚本不得再显式运行一遍，也不需要作为顶层 devDependency。
 
 验证不能只看构建退出码：最终主程序的 `lipo -archs` 应为 `x86_64 arm64`，并应分别用原生 arm64 与 Rosetta x64 进程加载 packaged standalone 中的 `sharp`。

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "dev": "next dev -p 30141",
     "build": "npm run build:standalone",
-    "build:standalone": "next build && node scripts/ensure-standalone-next-runtimes.mjs && node scripts/ensure-standalone-pi-runtime.mjs && node scripts/ensure-standalone-macos-universal-runtimes.mjs && node scripts/smoke-standalone-server.mjs",
+    "build:standalone": "next build && node scripts/ensure-standalone-next-runtimes.mjs && node scripts/ensure-standalone-pi-runtime.mjs && node scripts/ensure-standalone-macos-universal-runtimes.mjs && node scripts/dereference-standalone-symlinks.mjs && node scripts/smoke-standalone-server.mjs",
     "start": "next start -p 30141",
     "lint": "eslint .",
     "check:electron-deps": "node lib/electron-updater-runtime-deps.mjs --check",

--- a/package.test.ts
+++ b/package.test.ts
@@ -24,6 +24,10 @@ test("build scripts name the standalone Next.js build explicitly", () => {
     pkg.scripts["build:standalone"],
     /ensure-standalone-macos-universal-runtimes\.mjs/
   );
+  assert.match(
+    pkg.scripts["build:standalone"],
+    /dereference-standalone-symlinks\.mjs/
+  );
   assert.equal(pkg.scripts.build, "npm run build:standalone");
 });
 

--- a/scripts/dereference-standalone-symlinks.mjs
+++ b/scripts/dereference-standalone-symlinks.mjs
@@ -1,0 +1,77 @@
+/**
+ * @electron/universal realpath()s every file and compares relative paths.
+ * If standalone/node_modules still contains symlinks into the build-tree
+ * node_modules, x64 and arm64 temp apps sit at different depths, so the same
+ * target becomes two different relative paths and the merge aborts:
+ *
+ *   uniqueToX64:   ../../../../../../../../Users/runner/.../semver/bin/semver.js
+ *   uniqueToArm64: ../../../node_modules/.../semver/bin/semver.js
+ *
+ * Materialize those links into real copies before electron-builder copies
+ * extraResources into the .app.
+ */
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function collectSymlinks(root, found = []) {
+  if (!existsSync(root)) return found;
+  for (const name of readdirSync(root, { withFileTypes: true })) {
+    const path = join(root, name.name);
+    let stat;
+    try {
+      stat = lstatSync(path);
+    } catch {
+      continue;
+    }
+    if (stat.isSymbolicLink()) {
+      found.push(path);
+      continue;
+    }
+    if (stat.isDirectory()) collectSymlinks(path, found);
+  }
+  return found;
+}
+
+export function dereferenceSymlinks(root) {
+  const links = collectSymlinks(root).sort((a, b) => b.length - a.length);
+  let replaced = 0;
+  let removed = 0;
+  for (const link of links) {
+    let target;
+    try {
+      target = realpathSync(link);
+    } catch {
+      rmSync(link, { force: true });
+      removed += 1;
+      continue;
+    }
+    rmSync(link, { force: true, recursive: true });
+    cpSync(target, link, { recursive: true, dereference: true });
+    replaced += 1;
+  }
+  return { replaced, removed };
+}
+
+const isMain =
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+
+if (isMain) {
+  const standalone = join(process.cwd(), ".next", "standalone");
+  if (!existsSync(standalone)) {
+    console.error("dereference-standalone-symlinks: .next/standalone not found");
+    process.exit(1);
+  }
+  const { replaced, removed } = dereferenceSymlinks(standalone);
+  console.log(
+    `dereference-standalone-symlinks: replaced ${replaced}, removed ${removed} dangling`,
+  );
+}

--- a/scripts/dereference-standalone-symlinks.test.mjs
+++ b/scripts/dereference-standalone-symlinks.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  collectSymlinks,
+  dereferenceSymlinks,
+} from "./dereference-standalone-symlinks.mjs";
+
+function withTempTree(fn) {
+  const dir = mkdtempSync(join(tmpdir(), "deref-standalone-"));
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("materializes a file symlink that points outside the tree", () => {
+  withTempTree((dir) => {
+    const outside = join(dir, "outside.js");
+    writeFileSync(outside, "module.exports = 1;\n");
+    const nested = join(dir, "standalone", "node_modules", "semver", "bin");
+    mkdirSync(nested, { recursive: true });
+    const link = join(nested, "semver.js");
+    try {
+      symlinkSync(outside, link);
+    } catch (error) {
+      if (error && (error.code === "EPERM" || error.code === "EACCES")) {
+        return;
+      }
+      throw error;
+    }
+    assert.equal(collectSymlinks(join(dir, "standalone")).length, 1);
+    const { replaced, removed } = dereferenceSymlinks(join(dir, "standalone"));
+    assert.equal(replaced, 1);
+    assert.equal(removed, 0);
+    assert.equal(collectSymlinks(join(dir, "standalone")).length, 0);
+    assert.equal(readFileSync(link, "utf8"), "module.exports = 1;\n");
+  });
+});
+
+test("drops dangling symlinks", () => {
+  withTempTree((dir) => {
+    const nested = join(dir, "standalone", "node_modules");
+    mkdirSync(nested, { recursive: true });
+    const link = join(nested, "missing");
+    try {
+      symlinkSync(join(dir, "does-not-exist"), link);
+    } catch (error) {
+      if (error && (error.code === "EPERM" || error.code === "EACCES")) {
+        return;
+      }
+      throw error;
+    }
+    const { replaced, removed } = dereferenceSymlinks(join(dir, "standalone"));
+    assert.equal(replaced, 0);
+    assert.equal(removed, 1);
+    assert.equal(collectSymlinks(join(dir, "standalone")).length, 0);
+  });
+});


### PR DESCRIPTION
## Why

v0.8.5 Desktop packages macOS job failed:

\`\`\`
uniqueToX64:   ../../../../../../../../Users/runner/.../semver/bin/semver.js
uniqueToArm64: ../../../node_modules/@earendil-works/pi-coding-agent/node_modules/semver/bin/semver.js
\`\`\`

Same file. \`@electron/universal\` realpath()s then \`path.relative(app, realpath)\`. The two temp \`.app\` dirs sit at different depths, so one escaped symlink becomes two unique paths and merge aborts.

## Fix

\`scripts/dereference-standalone-symlinks.mjs\` after the other ensure scripts: replace standalone symlinks with real copies (drop dangling).

## After merge

Move tag \`v0.8.5\` to the new main commit and \`git push origin v0.8.5 --force\` so Desktop packages re-runs and \`gh release upload --clobber\` adds the macOS assets. Do not bump the version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS Universal packaging reliability by resolving standalone application symlinks before merging architecture builds.
  * Removed dangling symlinks that could interrupt packaging.

* **Documentation**
  * Added guidance explaining how symlink-related packaging failures occur and are handled.

* **Tests**
  * Added coverage for replacing valid symlinks and removing dangling links.
  * Updated build checks to verify the symlink-resolution step runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->