### PR TITLE
fix(packaging): cover NFT .next native addons in x64ArchFiles

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -803,7 +803,7 @@ Next.js NFT 只会追踪构建宿主架构的可选原生依赖。在 Apple Sili
 **修复链路**：
 
 - `scripts/ensure-standalone-macos-universal-runtimes.mjs` 从 standalone 的 `sharp/package.json` 读取精确可选依赖版本，把宿主已有包复制过去，并通过 `npm pack` 下载另一架构包，最终保证 arm64/x64 Sharp 与 libvips 并存。
-- `electron-builder.yml` 的 `mac.x64ArchFiles` 只匹配 Pi TUI、Clipboard、Sharp 与 libvips 的架构专用目录，让 Universal 合并器保留这些并列资源；Electron 主可执行文件等其他 Mach-O 仍正常执行 `lipo`。
+- `electron-builder.yml` 的 `mac.x64ArchFiles` 匹配 standalone 与 `standalone/.next`（NFT 哈希目录）下的 Pi TUI / Clipboard / Sharp / libvips 架构专用文件。minimatch 默认不进点目录，必须显式写出 `.next`。这些文件在 x64/arm64 中间包里内容相同，不能 lipo；Electron 主程序仍走 lipo。
 - standalone `node_modules` 若仍含指向构建机 `node_modules` 的符号链接，`@electron/universal` 会对 x64/arm64 临时目录算出不同的 `relativePath`（同一 `semver.js` 在一边是 `../../../node_modules/...`，另一边是 `../../../../../../../../Users/runner/...`）并中止合并。`scripts/dereference-standalone-symlinks.mjs` 在打包前把这些链接落实成文件。
 - `@electron/rebuild` 由 electron-builder 自动调用，打包脚本不得再显式运行一遍，也不需要作为顶层 devDependency。
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -117,7 +117,10 @@ mac:
   # Standalone contains architecture-specific native packages side-by-side.
   # They are identical in both intermediate apps and must not be lipo'd by
   # @electron/universal; runtime package resolution selects the right arch.
-  x64ArchFiles: "Contents/Resources/standalone/node_modules/{@earendil-works/pi-tui/native/darwin/prebuilds/**,@mariozechner/clipboard-darwin-{arm64,x64}/**,@img/sharp-darwin-{arm64,x64}/**,@img/sharp-libvips-darwin-{arm64,x64}/**}"
+  # Brace includes standalone/.next: minimatch skips dotdirs unless named.
+  # NFT copies native addons under hashed pi-coding-agent there; both arch
+  # builds contain the same .node/.dylib and must not be lipo'd.
+  x64ArchFiles: "Contents/Resources/standalone{,/.next}/**/{@earendil-works/pi-tui/native/darwin/prebuilds/**,@mariozechner/clipboard-darwin-{arm64,x64}/**,@img/sharp-darwin-{arm64,x64}/**,@img/sharp-libvips-darwin-{arm64,x64}/**}"
   artifactName: "Pi-Agent-Desktop-${version}-mac-${arch}.${ext}"
 
 dmg:

--- a/lib/electron-builder-config.test.mjs
+++ b/lib/electron-builder-config.test.mjs
@@ -83,6 +83,7 @@ test("Universal merge skips lipo only for architecture-specific runtime paths", 
     "Contents/Resources/standalone/node_modules/@img/sharp-darwin-x64/lib/sharp.node",
     "Contents/Resources/standalone/node_modules/@img/sharp-libvips-darwin-arm64/lib/libvips.dylib",
     "Contents/Resources/standalone/node_modules/@img/sharp-libvips-darwin-x64/lib/libvips.dylib",
+    "Contents/Resources/standalone/.next/node_modules/@earendil-works/pi-coding-agent-4cdde81112ef3dc5/node_modules/@mariozechner/clipboard-darwin-arm64/clipboard.darwin-arm64.node",
   ]) {
     assert.ok(minimatch(path, pattern), `${path} must match x64ArchFiles`);
   }


### PR DESCRIPTION
v0.8.5 retag still failed on macOS. Symlink dereference worked (4 replaced). Next error:

\`Contents/Resources/standalone/.next/node_modules/@earendil-works/pi-coding-agent-<hash>/node_modules/@mariozechner/clipboard-darwin-arm64/clipboard.darwin-arm64.node\` is the same in x64 and arm64 and was not covered by \`x64ArchFiles\`.

minimatch does not enter \`.next\` unless the pattern names it. Expand to \`standalone{,/.next}/**/{...}\`.