### PR TITLE
docs: CONTRIBUTING and GitHub Issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,46 @@
+name: Bug
+description: 功能不正常、崩溃、白屏、数据丢失
+labels: [bug]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: 版本
+      placeholder: v0.8.5 或 main @ commit
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: 系统
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - 浏览器（npm run dev）
+        - 不确定
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: 复现步骤
+      placeholder: 1. … 2. … 3. …
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期望
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: 实际
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: 日志 / 安装包名（不要贴密钥或 .jsonl 全文）

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,22 @@
+name: Feature
+description: 新功能或行为变化
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: 要解决什么
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: 范围
+      placeholder: 做什么、不做什么
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: 其它
+      placeholder: 相关 Issue、截图、替代方案

--- a/.github/ISSUE_TEMPLATE/packaging.yml
+++ b/.github/ISSUE_TEMPLATE/packaging.yml
@@ -1,0 +1,34 @@
+name: Packaging
+description: 安装包、自动更新、签名提示、CI 打包
+labels: [bug]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: 版本 / tag
+      placeholder: v0.8.5
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: 平台
+      options:
+        - Windows NSIS
+        - macOS Universal
+        - Linux deb
+        - 自动更新
+        - Desktop packages workflow
+    validations:
+      required: true
+  - type: input
+    id: asset
+    attributes:
+      label: 安装包或 latest*.yml 文件名
+      placeholder: Pi-Agent-Desktop-0.8.5-mac-universal.dmg
+  - type: textarea
+    id: what
+    attributes:
+      label: 现象
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Why
+
+## Scope
+
+## Out of scope
+
+## Verification
+
+- [ ] 跑过相关测试（全量用 `npm test`，不要去掉 `--test-force-exit`）
+- [ ] 没有在开发中执行 `next build` / `npm run build`
+- [ ] 用户可见文案已同步 `lib/i18n` 的 en / zh-CN（若有文案改动）

--- a/.gitignore
+++ b/.gitignore
@@ -58,5 +58,9 @@ next-env.d.ts
 
 # local SQLite runtime data (pi-coding-agent state store)
 /data/
+
+# agent session leftovers and Windows NUL device file
+/.sessions/
+nul
 # Bun lockfile (project uses npm, see package-lock.json)
 bun.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ macOS CI subset: `npm run test:macos`
 **Never run `next build` during dev** — pollutes `.next/` and breaks `npm run dev`.
 
 Release：按 [docs/RELEASING.md](docs/RELEASING.md) 执行。桌面 GitHub Release 推 `vX.Y.Z` tag，由 `.github/workflows/desktop-packages.yml` 打 Win/Linux/macOS 并上传；不要用会自动 bump patch 的 `npm run release`。
+Issue / PR：按 [CONTRIBUTING.md](CONTRIBUTING.md)。默认 merge commit；Fork 第一次 CI 要批准 workflow。
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ npm run dist
 npm run dist:mac
 ```
 
-`AGENTS.md` 明确提醒：开发时不要直接运行 `next build`，会污染 `.next/` 并影响 `npm run dev`。如确需验证生产构建，使用项目脚本 `npm run build` 或完整打包脚本。
+`AGENTS.md` 明确提醒：开发时不要直接运行 `next build`，会污染 `.next/` 并影响 `npm run dev`。如确需验证生产构建，使用项目脚本 `npm run build` 或完整打包脚本。Issue / PR 流程见 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
 ## CodeGraph MCP 代码查询
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# 协作规范
+
+本文是 Issue / PR / 日常维护的权威说明。发版只看 [docs/RELEASING.md](docs/RELEASING.md)。架构只看 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)。Agent 边界看 [AGENTS.md](AGENTS.md)。
+
+中英文都可以。一个 Issue 或 PR 只做一件用户能感知的事。
+
+## Issue
+
+先搜索已有 Issue / PR。新建时用 GitHub 模板。
+
+| 类型 | 用什么 | 必写 |
+|---|---|---|
+| 缺陷 | Bug | 版本（`vX.Y.Z` 或 `main`）、系统、复现步骤、期望 vs 实际。桌面问题附 OS 与安装包文件名。 |
+| 功能 | Feature | 要解决什么、范围、明确不做什么。 |
+| 打包 / 安装 / 更新 | Packaging | 平台、安装包名、是否自动更新、`latest*.yml` 是否在 Release 上。 |
+| 文档 | `documentation` 标签 | 哪份文档、哪句过期、应以哪份代码为准。 |
+
+不要贴 API Key、auth.json、会话 `.jsonl` 全文。日志先打码。
+
+维护者：能当场复现的再标 `bug`；范围不清先 `question`；明确不做的标 `wontfix` 并写原因。
+
+## Pull Request
+
+1. 从最新 `main` 开分支。分支名：`fix/…`、`feat/…`、`docs/…`、`ci/…`。
+2. 标题用 `fix` / `feat` / `docs` / `ci` / `chore`，必要时加范围，例如 `fix(ltm): …`。
+3. 正文写清：**Why**、**Scope**、**Out of scope**、**Verification**（跑过哪条命令）。
+4. 用户可见文案改 `lib/i18n/dictionaries.ts` 的 `en` 与 `zh-CN`，不要硬编码。
+5. 相关测试跟改动走。全量 `npm test` 必须带 `--test-force-exit`（脚本已带，不要去掉）。
+6. **不要在开发机跑 `next build` / `npm run build`**：会污染 `.next/`，弄坏 `npm run dev`。生产构建交给 CI 的 `build (next.js)` 或 `npm run dist`。
+7. 等 CI 全绿：`lint · typecheck · test`、`test (windows)`、`test (macOS)`、`build (next.js)`。Fork 第一次跑 Actions 需要维护者 **Approve and run workflows**。
+8. 合并默认 **Create a merge commit**，保留 PR 内 commit 作为 bisect 点。只有「单 commit 的纯文档/笔误」才 squash。
+9. 不要直接推 `main`。不要用 `npm run release` 发桌面包（会 bump patch 并走 npm）。
+
+## 维护节奏
+
+- `main` 只收已过 CI 的 PR。
+- 发版：同一 PR 里改 `package.json` + lock + `docs/releases/vX.Y.Z.md`，合入后再 `git tag vX.Y.Z && git push origin vX.Y.Z`。tag 必须等于 `v` + `package.json` 的 `version`。
+- 桌面包由 `.github/workflows/desktop-packages.yml` 打 Windows / macOS / Linux。三端和三份 `latest*.yml` 都在 GitHub Release 上才算该版本发完。
+- 只有该 tag **尚未完整发布**（例如缺 macOS）时，才允许说明原因后移动 tag 重跑打包。日常不要 force-push tag，也不要另开一套版本号补包。
+- 打包陷阱（不要删、不要绕）：`ensure-standalone-*-runtimes.mjs`、`dereference-standalone-symlinks.mjs`、`mac.x64ArchFiles`（必须显式包含 `standalone/.next`）。细节在架构文档 §14.10。
+
+## 不要提交
+
+`node_modules/`、`.next/`、`release/`、`.sessions/`、`nul`、密钥和本机会话数据。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,11 @@
 
 ## Pull Request
 
-1. 从最新 `main` 开分支。分支名：`fix/…`、`feat/…`、`docs/…`、`ci/…`。
+1. 从最新 `main` 开分支。前缀：
+   - `dev/…` 日常开发（修 bug、小功能）
+   - `future/…` 较大或尚未排期的功能
+   - `docs/…`、`ci/…`、`release/vX.Y.Z` 仍可用
+   不要再用 `feat/`。
 2. 标题用 `fix` / `feat` / `docs` / `ci` / `chore`，必要时加范围，例如 `fix(ltm): …`。
 3. 正文写清：**Why**、**Scope**、**Out of scope**、**Verification**（跑过哪条命令）。
 4. 用户可见文案改 `lib/i18n/dictionaries.ts` 的 `en` 与 `zh-CN`，不要硬编码。

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ scripts/
   ensure-standalone-next-runtimes.mjs             # 补齐 Turbopack runtime
   ensure-standalone-pi-runtime.mjs                # 补齐 Pi 运行时依赖闭包
   ensure-standalone-macos-universal-runtimes.mjs  # 补齐两套 macOS Sharp 运行时
+  dereference-standalone-symlinks.mjs             # 打包前落实 standalone 符号链接
 ```
 
 ## 技术栈
@@ -134,6 +135,10 @@ scripts/
 
 - [pi-mono](https://github.com/badlogic/pi-mono) — Pi 编程智能体核心
 - [pi-web](https://github.com/agegr/pi-web) — 上游 Web 界面项目
+
+## 协作
+
+报 Issue、提 PR、合并方式见 [CONTRIBUTING.md](CONTRIBUTING.md)。发版见 [docs/RELEASING.md](docs/RELEASING.md)。
 
 ## 许可
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -148,7 +148,9 @@ pi-agent-desktop/
 ├── tailwind.config.ts            Tailwind 4 配置
 ├── tsconfig.json                 strict + bundler resolution
 ├── electron-builder.yml          Windows NSIS + macOS DMG/ZIP + Linux DEB 打包配置
+├── CONTRIBUTING.md               Issue / PR / 合并约定
 ├── .github/workflows/            ci.yml 测试；desktop-packages.yml 打 v* 桌面包
+├── .github/ISSUE_TEMPLATE/       Bug / Feature / Packaging 模板
 ├── eslint.config.mjs             ESLint 9 flat config
 │
 ├── bin/

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -39,7 +39,7 @@
 
 Windows 安装包当前未代码签名，Release Notes 必须披露 SmartScreen 提示。GitHub Actions 打的 macOS 包同样未签名、未公证，Release Notes 必须披露 Gatekeeper 提示。Linux 的 `.deb` 安装包通过 electron-updater 的 `DebUpdater` 自动更新：应用内下载新 `.deb` 后经 `dpkg -i` 或 `apt --allow-unauthenticated` 安装，安装时需要 root 授权提示。下载完整性由 `latest-linux.yml` 的 SHA512 校验（与 Windows NSIS 相同），但 `.deb` 本身未做 debsig，系统包管理器不会再验包签名。自动更新依赖 Release 资产中的 `latest-linux.yml`，漏传则 Linux 端收不到更新。Release Notes 必须披露未签名 deb 与 root 安装。
 
-截至 2026-09-01：桌面 GitHub Release 流程是推 `v*` tag，由 `.github/workflows/desktop-packages.yml` 打 Windows / Linux / macOS。`v0.8.4` 及更早只有 Windows 资产。
+截至 2026-09-01：最新桌面 GitHub Release 是 `v0.8.5`，含 Windows NSIS、macOS Universal、Linux deb 及三份 `latest*.yml`。`v0.8.4` 及更早只有 Windows 资产。Issue / PR 约定见 [CONTRIBUTING.md](../CONTRIBUTING.md)。
 
 ## npm Release
 


### PR DESCRIPTION
## Why

Project needs a single, current rule for issues, PRs, merge style, and what not to commit. Release SOP stays in docs/RELEASING.md.

## Scope

- CONTRIBUTING.md
- .github/ISSUE_TEMPLATE (bug / feature / packaging)
- .github/PULL_REQUEST_TEMPLATE.md
- Pointers in README / AGENTS / CLAUDE / ARCHITECTURE / RELEASING
- .gitignore: .sessions/, nul

## Out of scope

Deleting merged local branches (listed for confirmation in the closeout report).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Chinese contribution guidelines covering issue reporting, pull requests, testing, localization, releases, and packaging.
  * Updated README and architecture documentation with collaboration and project-structure references.
  * Updated release documentation with the latest desktop package status and release guidance.

* **Issue & PR Templates**
  * Added structured forms for bug, feature, and packaging reports.
  * Enabled blank issue submissions.
  * Added a standardized pull request checklist and required sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->