### PR TITLE
docs: pin dev/ and future/ branch prefixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ macOS CI subset: `npm run test:macos`
 **Never run `next build` during dev** — pollutes `.next/` and breaks `npm run dev`.
 
 Release：按 [docs/RELEASING.md](docs/RELEASING.md) 执行。桌面 GitHub Release 推 `vX.Y.Z` tag，由 `.github/workflows/desktop-packages.yml` 打 Win/Linux/macOS 并上传；不要用会自动 bump patch 的 `npm run release`。
-Issue / PR：按 [CONTRIBUTING.md](CONTRIBUTING.md)。默认 merge commit；Fork 第一次 CI 要批准 workflow。
+Issue / PR：按 [CONTRIBUTING.md](CONTRIBUTING.md)。新分支用 `dev/`（日常）或 `future/`（大功能），不要用 `feat/`。默认 merge commit；Fork 第一次 CI 要批准 workflow。
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ npm run dist
 npm run dist:mac
 ```
 
-`AGENTS.md` 明确提醒：开发时不要直接运行 `next build`，会污染 `.next/` 并影响 `npm run dev`。如确需验证生产构建，使用项目脚本 `npm run build` 或完整打包脚本。Issue / PR 流程见 [CONTRIBUTING.md](CONTRIBUTING.md)。
+`AGENTS.md` 明确提醒：开发时不要直接运行 `next build`，会污染 `.next/` 并影响 `npm run dev`。如确需验证生产构建，使用项目脚本 `npm run build` 或完整打包脚本。Issue / PR 流程见 [CONTRIBUTING.md](CONTRIBUTING.md)。新分支前缀：`dev/`、`future/`，不要用 `feat/`。
 
 ## CodeGraph MCP 代码查询
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ scripts/
 
 ## 协作
 
-报 Issue、提 PR、合并方式见 [CONTRIBUTING.md](CONTRIBUTING.md)。发版见 [docs/RELEASING.md](docs/RELEASING.md)。
+报 Issue、提 PR、合并方式见 [CONTRIBUTING.md](CONTRIBUTING.md)。新功能用 `dev/` 或 `future/` 分支。发版见 [docs/RELEASING.md](docs/RELEASING.md)。
 
 ## 许可
 


### PR DESCRIPTION
## Why

Leftover feat/ feature/ branches are gone. Agent-facing docs must state the new prefixes.

## Scope

AGENTS.md, CLAUDE.md, README.md. CONTRIBUTING.md already has the rule.

## Verification

Docs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance with branch naming conventions.
  * Clarified that routine work should use `dev/` branches and larger features should use `future/` branches.
  * Removed `feat/` from the recommended branch prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->