### PR TITLE
fix(models): load extension-registered providers and models in pi-runtime

### DIFF
--- a/lib/pi-runtime.test.ts
+++ b/lib/pi-runtime.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { setProviderApiKey, removeProviderApiKey } from "./pi-runtime.ts";
+import { setProviderApiKey, removeProviderApiKey, createPiRuntime } from "./pi-runtime.ts";
 import type { ModelRuntime } from "@earendil-works/pi-coding-agent";
 
 // Regression test for issue #21: API keys must be persisted via the SDK
@@ -52,4 +52,17 @@ test("removeProviderApiKey deletes the stored credential via runtime.logout", as
 
   await removeProviderApiKey(runtime, "deepseek");
   assert.deepEqual(calls, [["deepseek"]]);
+});
+
+test("createPiRuntime loads extension providers and registers models", async () => {
+  const { runtime, registry } = await createPiRuntime({ allowModelNetwork: false });
+  assert.ok(runtime);
+  assert.ok(registry);
+  const providers = runtime.getProviders();
+  assert.ok(Array.isArray(providers));
+  assert.ok(providers.length > 0);
+
+  const allModels = registry.getAll();
+  assert.ok(Array.isArray(allModels));
+  assert.ok(allModels.length > 0);
 });

--- a/lib/pi-runtime.ts
+++ b/lib/pi-runtime.ts
@@ -3,6 +3,7 @@
  * Auth/model routes should use this module instead of the removed AuthStorage public API.
  */
 import {
+  createAgentSessionServices,
   ModelRegistry,
   ModelRuntime,
   getAgentDir,
@@ -13,6 +14,7 @@ import { join } from "path";
 export type { AuthInteraction, AuthType };
 
 export interface CreatePiRuntimeOptions {
+  cwd?: string;
   /** Override models.json path (used by models-config test). */
   modelsPath?: string | null;
   /** Allow network catalog refresh during create. Default false for API routes. */
@@ -29,14 +31,20 @@ export async function createPiRuntime(options: CreatePiRuntimeOptions = {}): Pro
   registry: ModelRegistry;
 }> {
   const agentDir = getAgentDir();
+  const cwd = options.cwd ?? process.cwd();
   const runtime = await ModelRuntime.create({
     authPath: options.authPath ?? join(agentDir, "auth.json"),
     modelsPath: options.modelsPath === undefined ? join(agentDir, "models.json") : options.modelsPath,
     allowModelNetwork: options.allowModelNetwork ?? false,
   });
-  const registry = new ModelRegistry(runtime);
-  await registry.refresh();
-  return { runtime, registry };
+  const services = await createAgentSessionServices({
+    cwd,
+    agentDir,
+    modelRuntime: runtime,
+  });
+  const registry = new ModelRegistry(services.modelRuntime);
+  await registry.refresh({ allowNetwork: options.allowModelNetwork ?? false });
+  return { runtime: services.modelRuntime, registry };
 }
 
 /** Providers that expose OAuth login (for the OAuth panel). */


### PR DESCRIPTION
### Why
Currently, `createPiRuntime` only instantiates `ModelRuntime.create({ authPath, modelsPath })`, which only discovers built-in providers and models configured in `models.json`. It does not load extension-registered providers and models.

As a result, custom providers and models registered dynamically by Pi extensions are not visible in `/api/models` or `/api/auth/*`.

### Scope
1. **Load Extension Providers**: Updated `createPiRuntime` in `lib/pi-runtime.ts` to use `createAgentSessionServices` from `@earendil-works/pi-coding-agent`, aligning behavior with the terminal CLI and ensuring extension-registered providers and models are properly bound to the runtime and registry.
2. **Tests**: Added regression test in `lib/pi-runtime.test.ts` verifying runtime and model registry initialization.

### Out of scope
- Plugin-specific icons, OAuth mappings, or special cases (e.g. antigravity), keeping the desktop harness minimal and generic.

### Verification
- `npm test`: 565 passed, 0 failed
- `npx tsc --noEmit`: 0 errors
- `npx tsc -p electron/tsconfig.json --noEmit`: 0 errors
- `npm run lint`: 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a custom working directory when creating a runtime.
  * Runtime setup now provides access to available model providers and registered models.

* **Tests**
  * Added coverage confirming successful runtime and model registry initialization.
  * Added validation that providers and registered models are available after setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->