### PR TITLE
fix(tools): preserve extension-registered tools in agent sessions

### DIFF
--- a/app/api/auth/all-providers/route.ts
+++ b/app/api/auth/all-providers/route.ts
@@ -3,7 +3,7 @@ import { createPiRuntime } from "@/lib/pi-runtime";
 export const dynamic = "force-dynamic";
 
 // Providers that use OAuth — handled separately via /api/auth/providers
-const OAUTH_PROVIDER_IDS = new Set(["anthropic", "github-copilot", "openai-codex"]);
+const OAUTH_PROVIDER_IDS = new Set(["anthropic", "github-copilot", "openai-codex", "antigravity"]);
 
 export async function GET() {
   const { runtime, registry } = await createPiRuntime();
@@ -22,6 +22,7 @@ export async function GET() {
 
   for (const p of providers) {
     if (OAUTH_PROVIDER_IDS.has(p.id)) continue;
+    if (!p.auth.apiKey) continue;
     const status = runtime.getProviderAuthStatus(p.id);
     // Skip custom providers whose key is injected via models.json
     if (status.source === "models_json_key") continue;

--- a/app/api/auth/providers/route.ts
+++ b/app/api/auth/providers/route.ts
@@ -10,6 +10,7 @@ export async function GET() {
   const DISPLAY_NAMES: Record<string, string> = {
     "openai-codex": "ChatGPT Plus/Pro",
     "github-copilot": "GitHub Copilot",
+    "antigravity": "Antigravity (Google)",
   };
 
   const result = providers

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -322,7 +322,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
       ) : (
       <>
       <div className="relative flex flex-1 overflow-hidden">
-        <div ref={scrollContainerRef} className="flex-1 overflow-y-auto pt-4 [scrollbar-width:none]">
+        <div ref={scrollContainerRef} className="flex-1 overflow-y-auto pt-4 pb-6 [scrollbar-width:none]">
           <div className="mx-auto max-w-[820px] px-4">
 
             <MessageList
@@ -347,10 +347,6 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
                 ? <AgentThinkingOrb phase={agentPhase} thinking={activeThinking} />
                 : null}
             />
-
-            {agentRunning && (
-              <div style={{ height: scrollContainerRef.current ? scrollContainerRef.current.clientHeight : "80vh" }} />
-            )}
 
             <div ref={messagesEndRef} />
           </div>

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -63,8 +63,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
     trustPrompt,
     resolveTrustPrompt,
     handleExtensionUiRespond,
-    messagesEndRef, scrollContainerRef,
-    lastUserMsgRef,
+    messagesEndRef, scrollContainerRef, setScrollContainer,
     handleSend, handleAbort, handleFork, handleNavigate, handleModelChange,
     handleCompact, handleSteer, handleFollowUp, handleAbortCompaction,
     handleReorderFollowUps,
@@ -322,7 +321,7 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
       ) : (
       <>
       <div className="relative flex flex-1 overflow-hidden">
-        <div ref={scrollContainerRef} className="flex-1 overflow-y-auto pt-4 pb-6 [scrollbar-width:none]">
+        <div ref={setScrollContainer} className="flex-1 overflow-y-auto pt-4 pb-6 [scrollbar-width:none]">
           <div className="mx-auto max-w-[820px] px-4">
 
             <MessageList
@@ -341,7 +340,6 @@ export function ChatWindow({ session, newSessionCwd, onAgentEnd, onSessionCreate
               onBranchMessage={handleBranchMessage}
               onEditContent={handleEditContent}
               messageRefs={messageRefs}
-              lastUserMsgRef={lastUserMsgRef}
               modelNames={modelNames}
               activeAgentIndicator={agentRunning
                 ? <AgentThinkingOrb phase={agentPhase} thinking={activeThinking} />

--- a/components/MessageList.tsx
+++ b/components/MessageList.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import type { AgentMessage, ToolResultMessage } from "@/lib/types";
 import { MessageView } from "./MessageView.tsx";
 
@@ -18,7 +18,6 @@ interface MessageListProps {
   onBranchMessage?: (entryId: string) => void;
   onEditContent: (content: string) => void;
   messageRefs: React.MutableRefObject<(HTMLDivElement | null)[]>;
-  lastUserMsgRef: React.MutableRefObject<HTMLDivElement | null>;
   modelNames: Record<string, string>;
   activeAgentIndicator?: React.ReactNode;
 }
@@ -26,16 +25,9 @@ interface MessageListProps {
 export const MessageList = React.memo(function MessageList({
   messages, entryIds, toolResultsMap, nextUserIdx, nextAssistantIdx,
   isStreaming, streamingMessage, isNew, agentRunning, forkingEntryId,
-  onFork, onNavigate, onBranchMessage, onEditContent, messageRefs, lastUserMsgRef,
+  onFork, onNavigate, onBranchMessage, onEditContent, messageRefs,
   modelNames, activeAgentIndicator,
 }: MessageListProps) {
-  const lastUserIdx = useMemo(() => {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i].role === "user") return i;
-    }
-    return -1;
-  }, [messages]);
-
   let refIdx = 0;
   return (
     <>
@@ -80,7 +72,6 @@ export const MessageList = React.memo(function MessageList({
             key={entryIds[idx] ?? `idx-${idx}`}
             ref={(el) => {
               messageRefs.current[currentRefIdx] = el;
-              if (idx === lastUserIdx) lastUserMsgRef.current = el;
             }}
             style={{ contentVisibility: "auto", containIntrinsicSize: "auto 150px" }}
           >

--- a/components/models-config/PROVIDER_ICONS.tsx
+++ b/components/models-config/PROVIDER_ICONS.tsx
@@ -75,6 +75,7 @@ export const PROVIDER_ICONS: Record<string, { Icon: IconComponent; hasColor: boo
   "perplexity":             { Icon: PerplexityColorIcon,  hasColor: true },
   "together":               { Icon: TogetherColorIcon,    hasColor: true },
   "grok":                   { Icon: GrokIcon,             hasColor: false },
+  "antigravity":            { Icon: GoogleColorIcon,      hasColor: true },
   "ant-ling":               { Icon: AntGroupIcon,         hasColor: false },
   "baseten":                { Icon: BasetenIcon,          hasColor: false },
   "nvidia":                 { Icon: NvidiaColorIcon,      hasColor: true },

--- a/hooks/agent-session/use-chat-scroll.ts
+++ b/hooks/agent-session/use-chat-scroll.ts
@@ -5,45 +5,75 @@ import { useCallback, useEffect, useRef } from "react";
 interface UseChatScrollOptions {
   messageCount: number;
   agentRunning: boolean;
+  streamingMessage?: unknown;
 }
 
-export function useChatScroll({ messageCount, agentRunning }: UseChatScrollOptions) {
+export function useChatScroll({
+  messageCount,
+  agentRunning,
+  streamingMessage,
+}: UseChatScrollOptions) {
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const lastUserMsgRef = useRef<HTMLDivElement | null>(null);
   const pendingScrollToUserRef = useRef(false);
   const initialScrollDoneRef = useRef(false);
-  const agentRunningRef = useRef(false);
-
-  useEffect(() => {
-    agentRunningRef.current = agentRunning;
-  }, [agentRunning]);
+  const isAtBottomRef = useRef(true);
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
     messagesEndRef.current?.scrollIntoView({ behavior });
   }, []);
 
-  const scrollUserMsgToTop = useCallback(() => {
+  const handleScroll = useCallback(() => {
     const container = scrollContainerRef.current;
-    const el = lastUserMsgRef.current;
-    if (!container || !el) return;
-    const elAbsTop = el.getBoundingClientRect().top - container.getBoundingClientRect().top + container.scrollTop;
-    container.scrollTo({ top: elAbsTop - 16, behavior: "smooth" });
+    if (!container) return;
+    const distanceToBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight;
+    // Consider user at bottom if within 80px of bottom
+    isAtBottomRef.current = distanceToBottom < 80;
   }, []);
 
+  // Track user scroll position
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    container.addEventListener("scroll", handleScroll, { passive: true });
+    return () => container.removeEventListener("scroll", handleScroll);
+  }, [handleScroll]);
+
+  // Initial load scroll to bottom
   useEffect(() => {
     if (messageCount <= 0) return;
+    if (!initialScrollDoneRef.current) {
+      initialScrollDoneRef.current = true;
+      isAtBottomRef.current = true;
+      scrollToBottom("instant");
+    }
+  }, [messageCount, scrollToBottom]);
+
+  // When user sends a message, scroll down and lock to bottom
+  useEffect(() => {
     if (pendingScrollToUserRef.current) {
       pendingScrollToUserRef.current = false;
       initialScrollDoneRef.current = true;
-      scrollUserMsgToTop();
-    } else if (!initialScrollDoneRef.current) {
-      initialScrollDoneRef.current = true;
-      scrollToBottom("instant");
-    } else if (!agentRunningRef.current) {
+      isAtBottomRef.current = true;
       scrollToBottom("smooth");
     }
-  }, [messageCount, agentRunning, scrollToBottom, scrollUserMsgToTop]);
+  }, [messageCount, scrollToBottom]);
+
+  // During streaming/thinking/tool execution, auto-scroll to bottom if user is at bottom
+  useEffect(() => {
+    if (agentRunning && isAtBottomRef.current) {
+      scrollToBottom("instant");
+    }
+  }, [streamingMessage, agentRunning, scrollToBottom]);
+
+  // When agent settles, smooth scroll to bottom if at bottom
+  useEffect(() => {
+    if (!agentRunning && initialScrollDoneRef.current && isAtBottomRef.current) {
+      scrollToBottom("smooth");
+    }
+  }, [agentRunning, scrollToBottom]);
 
   return {
     messagesEndRef,
@@ -51,5 +81,6 @@ export function useChatScroll({ messageCount, agentRunning }: UseChatScrollOptio
     lastUserMsgRef,
     pendingScrollToUserRef,
     initialScrollDoneRef,
+    scrollToBottom,
   };
 }

--- a/hooks/agent-session/use-chat-scroll.ts
+++ b/hooks/agent-session/use-chat-scroll.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 interface UseChatScrollOptions {
   messageCount: number;
@@ -15,41 +15,45 @@ export function useChatScroll({
 }: UseChatScrollOptions) {
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
-  const lastUserMsgRef = useRef<HTMLDivElement | null>(null);
+  const [containerNode, setContainerNode] = useState<HTMLDivElement | null>(null);
   const pendingScrollToUserRef = useRef(false);
   const initialScrollDoneRef = useRef(false);
   const isAtBottomRef = useRef(true);
+
+  const setScrollContainer = useCallback((node: HTMLDivElement | null) => {
+    scrollContainerRef.current = node;
+    setContainerNode(node);
+  }, []);
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
     messagesEndRef.current?.scrollIntoView({ behavior });
   }, []);
 
   const handleScroll = useCallback(() => {
-    const container = scrollContainerRef.current;
+    const container = containerNode;
     if (!container) return;
     const distanceToBottom =
       container.scrollHeight - container.scrollTop - container.clientHeight;
     // Consider user at bottom if within 80px of bottom
     isAtBottomRef.current = distanceToBottom < 80;
-  }, []);
+  }, [containerNode]);
 
-  // Track user scroll position
+  // Track user scroll position on the active container node
   useEffect(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
-    container.addEventListener("scroll", handleScroll, { passive: true });
-    return () => container.removeEventListener("scroll", handleScroll);
-  }, [handleScroll]);
+    if (!containerNode) return;
+    containerNode.addEventListener("scroll", handleScroll, { passive: true });
+    return () => containerNode.removeEventListener("scroll", handleScroll);
+  }, [containerNode, handleScroll]);
 
-  // Initial load scroll to bottom
+  // Initial load scroll to bottom once container mounts
   useEffect(() => {
-    if (messageCount <= 0) return;
+    if (messageCount <= 0 || !containerNode) return;
     if (!initialScrollDoneRef.current) {
       initialScrollDoneRef.current = true;
       isAtBottomRef.current = true;
       scrollToBottom("instant");
     }
-  }, [messageCount, scrollToBottom]);
+  }, [messageCount, containerNode, scrollToBottom]);
 
   // When user sends a message, scroll down and lock to bottom
   useEffect(() => {
@@ -78,7 +82,7 @@ export function useChatScroll({
   return {
     messagesEndRef,
     scrollContainerRef,
-    lastUserMsgRef,
+    setScrollContainer,
     pendingScrollToUserRef,
     initialScrollDoneRef,
     scrollToBottom,

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -194,7 +194,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
   const {
     messagesEndRef,
     scrollContainerRef,
-    lastUserMsgRef,
+    setScrollContainer,
     pendingScrollToUserRef,
     initialScrollDoneRef,
   } = useChatScroll({
@@ -668,7 +668,7 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     eventSourceRef,
     messagesEndRef,
     scrollContainerRef,
-    lastUserMsgRef,
+    setScrollContainer,
     pendingScrollToUserRef,
     initialScrollDoneRef,
     // Actions

--- a/hooks/useAgentSession.ts
+++ b/hooks/useAgentSession.ts
@@ -197,7 +197,11 @@ export function useAgentSession(opts: UseAgentSessionOptions) {
     lastUserMsgRef,
     pendingScrollToUserRef,
     initialScrollDoneRef,
-  } = useChatScroll({ messageCount: messages.length, agentRunning });
+  } = useChatScroll({
+    messageCount: messages.length,
+    agentRunning,
+    streamingMessage: streamState.streamingMessage,
+  });
 
   const sessionIdRef = useRef<string | null>(session?.id ?? null);
   const {

--- a/lib/approval-policy.test.ts
+++ b/lib/approval-policy.test.ts
@@ -49,10 +49,14 @@ test("needsAskConfirm only for bash/write/edit in ask mode", () => {
   assert.equal(needsAskConfirm("plan", "write"), false);
 });
 
-test("needsAskConfirm requires confirm for memory write tools in ask mode (S2)", () => {
+test("needsAskConfirm requires confirm for memory write tools and custom tools in ask mode (S2)", () => {
   assert.equal(needsAskConfirm("ask", "memory_save"), true);
   assert.equal(needsAskConfirm("ask", "memory_forget"), true);
   assert.equal(needsAskConfirm("ask", "memory_recall"), false);
+  assert.equal(needsAskConfirm("ask", "ffgrep"), true);
+  assert.equal(needsAskConfirm("ask", "subagent"), true);
+  assert.equal(needsAskConfirm("full", "subagent"), false);
+  assert.equal(needsAskConfirm("plan", "subagent"), false);
 });
 
 test("askBlockResult shape", () => {

--- a/lib/approval-policy.test.ts
+++ b/lib/approval-policy.test.ts
@@ -30,13 +30,40 @@ test("ask/full use tool preset lists and preserve custom tools", () => {
   assert.deepEqual(effectiveToolsForMode("ask", "full"), toolNamesForPreset("full"));
   assert.deepEqual(
     effectiveToolsForMode("ask", "full", ["ffgrep"]),
-    ["bash", "read", "edit", "write", "grep", "find", "ls", "ffgrep"]
+    ["bash", "powershell", "read", "edit", "write", "grep", "find", "ls", "ffgrep"]
   );
 });
 
 test("extractCustomToolNames filters builtins and memory tools", () => {
-  const all = ["read", "bash", "edit", "write", "grep", "find", "ls", "memory_save", "memory_recall", "memory_forget", "ffgrep", "fffind", "tavily_search"];
+  const all = [
+    "read",
+    "bash",
+    "powershell",
+    "edit",
+    "write",
+    "grep",
+    "find",
+    "ls",
+    "memory_save",
+    "memory_recall",
+    "memory_forget",
+    "ffgrep",
+    "fffind",
+    "tavily_search",
+  ];
   assert.deepEqual(extractCustomToolNames(all), ["ffgrep", "fffind", "tavily_search"]);
+});
+
+test("extractCustomToolNames handles ToolLike objects and provenance collision", () => {
+  const tools = [
+    { name: "read", sourceInfo: { source: "builtin" } },
+    { name: "bash", sourceInfo: { source: "builtin" } },
+    { name: "powershell", sourceInfo: { source: "builtin" } },
+    { name: "read", sourceInfo: { source: "extension" } }, // colliding extension tool
+    { name: "my_tool", sourceInfo: { source: "extension" } },
+    { name: "memory_save", sourceInfo: { source: "extension" } },
+  ];
+  assert.deepEqual(extractCustomToolNames(tools), ["read", "my_tool"]);
 });
 
 test("needsAskConfirm only for bash/write/edit in ask mode", () => {

--- a/lib/approval-policy.test.ts
+++ b/lib/approval-policy.test.ts
@@ -5,6 +5,7 @@ import {
   PLAN_TOOLS,
   askBlockResult,
   effectiveToolsForMode,
+  extractCustomToolNames,
   isAgentMode,
   needsAskConfirm,
   summarizeToolCall,
@@ -15,12 +16,27 @@ test("plan mode always returns the four read tools", () => {
   assert.deepEqual(effectiveToolsForMode("plan", "none"), [...PLAN_TOOLS]);
   assert.deepEqual(effectiveToolsForMode("plan", "default"), [...PLAN_TOOLS]);
   assert.deepEqual(effectiveToolsForMode("plan", "full"), [...PLAN_TOOLS]);
+  assert.deepEqual(effectiveToolsForMode("plan", "default", ["ffgrep", "web_search"]), [...PLAN_TOOLS]);
 });
 
-test("ask/full use tool preset lists", () => {
+test("ask/full use tool preset lists and preserve custom tools", () => {
   assert.deepEqual(effectiveToolsForMode("ask", "none"), []);
+  assert.deepEqual(effectiveToolsForMode("ask", "none", ["ffgrep"]), []);
   assert.deepEqual(effectiveToolsForMode("full", "default"), toolNamesForPreset("default"));
+  assert.deepEqual(
+    effectiveToolsForMode("full", "default", ["ffgrep", "subagent"]),
+    ["read", "bash", "edit", "write", "ffgrep", "subagent"]
+  );
   assert.deepEqual(effectiveToolsForMode("ask", "full"), toolNamesForPreset("full"));
+  assert.deepEqual(
+    effectiveToolsForMode("ask", "full", ["ffgrep"]),
+    ["bash", "read", "edit", "write", "grep", "find", "ls", "ffgrep"]
+  );
+});
+
+test("extractCustomToolNames filters builtins and memory tools", () => {
+  const all = ["read", "bash", "edit", "write", "grep", "find", "ls", "memory_save", "memory_recall", "memory_forget", "ffgrep", "fffind", "tavily_search"];
+  assert.deepEqual(extractCustomToolNames(all), ["ffgrep", "fffind", "tavily_search"]);
 });
 
 test("needsAskConfirm only for bash/write/edit in ask mode", () => {

--- a/lib/approval-policy.ts
+++ b/lib/approval-policy.ts
@@ -69,8 +69,8 @@ export function toolNamesForPreset(
   customTools: readonly string[] = []
 ): string[] {
   if (preset === "none") return [...PRESET_NONE];
-  if (preset === "full") return [...PRESET_FULL, ...customTools];
-  return [...PRESET_DEFAULT, ...customTools];
+  const base = preset === "full" ? PRESET_FULL : PRESET_DEFAULT;
+  return Array.from(new Set([...base, ...customTools]));
 }
 
 /**

--- a/lib/approval-policy.ts
+++ b/lib/approval-policy.ts
@@ -6,6 +6,16 @@
 export type AgentMode = "plan" | "ask" | "full";
 export type ToolPreset = "none" | "default" | "full";
 
+export const BUILTIN_TOOL_NAMES: readonly string[] = [
+  "read",
+  "bash",
+  "edit",
+  "write",
+  "grep",
+  "find",
+  "ls",
+];
+
 export const PLAN_TOOLS: readonly string[] = ["read", "grep", "find", "ls"];
 export const ASK_CONFIRM_TOOLS: readonly string[] = [
   "bash",
@@ -35,19 +45,39 @@ export function isToolPreset(value: unknown): value is ToolPreset {
   return value === "none" || value === "default" || value === "full";
 }
 
-export function toolNamesForPreset(preset: ToolPreset): string[] {
+export function toolNamesForPreset(
+  preset: ToolPreset,
+  customTools: readonly string[] = []
+): string[] {
   if (preset === "none") return [...PRESET_NONE];
-  if (preset === "full") return [...PRESET_FULL];
-  return [...PRESET_DEFAULT];
+  if (preset === "full") return [...PRESET_FULL, ...customTools];
+  return [...PRESET_DEFAULT, ...customTools];
 }
 
 /**
  * Tools actually enabled for the session given mode + preset.
  * Plan always forces the four read-side tools (even if preset is none).
  */
-export function effectiveToolsForMode(mode: AgentMode, preset: ToolPreset): string[] {
+export function effectiveToolsForMode(
+  mode: AgentMode,
+  preset: ToolPreset,
+  customTools: readonly string[] = []
+): string[] {
   if (mode === "plan") return [...PLAN_TOOLS];
-  return toolNamesForPreset(preset);
+  return toolNamesForPreset(preset, customTools);
+}
+
+/**
+ * Extract custom (non-builtin, non-memory) tool names from a list of tool names.
+ */
+export function extractCustomToolNames(allToolNames: readonly string[]): string[] {
+  const known = new Set<string>([
+    ...BUILTIN_TOOL_NAMES,
+    "memory_save",
+    "memory_recall",
+    "memory_forget",
+  ]);
+  return allToolNames.filter((name) => !known.has(name));
 }
 
 /** Whether Ask mode requires a confirm dialog before this tool runs. */

--- a/lib/approval-policy.ts
+++ b/lib/approval-policy.ts
@@ -16,6 +16,14 @@ export const BUILTIN_TOOL_NAMES: readonly string[] = [
   "ls",
 ];
 
+export const READ_ONLY_TOOLS: readonly string[] = [
+  "read",
+  "grep",
+  "find",
+  "ls",
+  "memory_recall",
+];
+
 export const PLAN_TOOLS: readonly string[] = ["read", "grep", "find", "ls"];
 export const ASK_CONFIRM_TOOLS: readonly string[] = [
   "bash",
@@ -80,10 +88,15 @@ export function extractCustomToolNames(allToolNames: readonly string[]): string[
   return allToolNames.filter((name) => !known.has(name));
 }
 
-/** Whether Ask mode requires a confirm dialog before this tool runs. */
+/**
+ * Whether Ask mode requires a confirm dialog before this tool runs.
+ * In Ask mode, mutating built-ins (bash/write/edit/memory_save/memory_forget)
+ * and all custom extension-registered tools require user confirmation.
+ * Only recognized read-only tools (read, grep, find, ls, memory_recall) bypass confirmation.
+ */
 export function needsAskConfirm(mode: AgentMode, toolName: string): boolean {
   if (mode !== "ask") return false;
-  return (ASK_CONFIRM_TOOLS as readonly string[]).includes(toolName);
+  return !READ_ONLY_TOOLS.includes(toolName);
 }
 
 export function askBlockResult(): { block: true; reason: string } {
@@ -105,6 +118,10 @@ export function summarizeToolCall(toolName: string, input: unknown): string {
   }
   if (typeof obj.file_path === "string") {
     return `${toolName}: ${obj.file_path}`;
+  }
+  if (typeof obj.query === "string") {
+    const q = obj.query.length > 200 ? `${obj.query.slice(0, 200)}…` : obj.query;
+    return `${toolName}: ${q}`;
   }
   try {
     const s = JSON.stringify(obj);

--- a/lib/approval-policy.ts
+++ b/lib/approval-policy.ts
@@ -9,6 +9,7 @@ export type ToolPreset = "none" | "default" | "full";
 export const BUILTIN_TOOL_NAMES: readonly string[] = [
   "read",
   "bash",
+  "powershell",
   "edit",
   "write",
   "grep",
@@ -27,6 +28,7 @@ export const READ_ONLY_TOOLS: readonly string[] = [
 export const PLAN_TOOLS: readonly string[] = ["read", "grep", "find", "ls"];
 export const ASK_CONFIRM_TOOLS: readonly string[] = [
   "bash",
+  "powershell",
   "write",
   "edit",
   // LTM write/delete channels mutate durable project memory; keep them behind
@@ -37,7 +39,16 @@ export const ASK_CONFIRM_TOOLS: readonly string[] = [
 
 export const PRESET_NONE: readonly string[] = [];
 export const PRESET_DEFAULT: readonly string[] = ["read", "bash", "edit", "write"];
-export const PRESET_FULL: readonly string[] = ["bash", "read", "edit", "write", "grep", "find", "ls"];
+export const PRESET_FULL: readonly string[] = [
+  "bash",
+  "powershell",
+  "read",
+  "edit",
+  "write",
+  "grep",
+  "find",
+  "ls",
+];
 
 export const DEFAULT_AGENT_MODE: AgentMode = "full";
 export const DEFAULT_TOOL_PRESET: ToolPreset = "default";
@@ -75,27 +86,53 @@ export function effectiveToolsForMode(
   return toolNamesForPreset(preset, customTools);
 }
 
+export interface ToolLike {
+  name: string;
+  sourceInfo?: {
+    source?: string;
+  };
+}
+
 /**
- * Extract custom (non-builtin, non-memory) tool names from a list of tool names.
+ * Extract custom (non-builtin, non-memory) tool names from a list of tool names or definitions.
  */
-export function extractCustomToolNames(allToolNames: readonly string[]): string[] {
-  const known = new Set<string>([
+export function extractCustomToolNames(
+  allTools: readonly (string | ToolLike)[]
+): string[] {
+  const knownBuiltins = new Set<string>([
     ...BUILTIN_TOOL_NAMES,
     "memory_save",
     "memory_recall",
     "memory_forget",
   ]);
-  return allToolNames.filter((name) => !known.has(name));
+  const custom: string[] = [];
+  for (const t of allTools) {
+    if (typeof t === "string") {
+      if (!knownBuiltins.has(t)) custom.push(t);
+    } else {
+      const name = t.name;
+      const isBuiltinSource = t.sourceInfo?.source === "builtin";
+      const isMemoryTool = name.startsWith("memory_");
+      if (!isBuiltinSource && !isMemoryTool) {
+        // Any non-builtin tool is custom, even if its name collides with a builtin
+        custom.push(name);
+      } else if (!knownBuiltins.has(name)) {
+        custom.push(name);
+      }
+    }
+  }
+  return custom;
 }
 
 /**
  * Whether Ask mode requires a confirm dialog before this tool runs.
- * In Ask mode, mutating built-ins (bash/write/edit/memory_save/memory_forget)
+ * In Ask mode, mutating built-ins (bash/powershell/write/edit/memory_save/memory_forget)
  * and all custom extension-registered tools require user confirmation.
  * Only recognized read-only tools (read, grep, find, ls, memory_recall) bypass confirmation.
  */
-export function needsAskConfirm(mode: AgentMode, toolName: string): boolean {
+export function needsAskConfirm(mode: AgentMode, toolName: string, isCustom = false): boolean {
   if (mode !== "ask") return false;
+  if (isCustom) return true;
   return !READ_ONLY_TOOLS.includes(toolName);
 }
 

--- a/lib/desktop-approval-extension.ts
+++ b/lib/desktop-approval-extension.ts
@@ -14,7 +14,12 @@ export type AgentModeRef = { current: AgentMode };
 export function createDesktopApprovalFactory(modeRef: AgentModeRef): ExtensionFactory {
   return (pi: ExtensionAPI) => {
     pi.on("tool_call", async (event, ctx) => {
-      if (!needsAskConfirm(modeRef.current, event.toolName)) return;
+      const all = typeof pi.getAllTools === "function" ? pi.getAllTools() : [];
+      const toolDef = all.find((t) => t.name === event.toolName);
+      const isCustom =
+        !toolDef ||
+        (toolDef.sourceInfo?.source !== "builtin" && !event.toolName.startsWith("memory_recall"));
+      if (!needsAskConfirm(modeRef.current, event.toolName, isCustom)) return;
       const ok = await ctx.ui.confirm(
         `允许 ${event.toolName}?`,
         summarizeToolCall(event.toolName, event.input)

--- a/lib/desktop-approval-extension.ts
+++ b/lib/desktop-approval-extension.ts
@@ -16,9 +16,12 @@ export function createDesktopApprovalFactory(modeRef: AgentModeRef): ExtensionFa
     pi.on("tool_call", async (event, ctx) => {
       const all = typeof pi.getAllTools === "function" ? pi.getAllTools() : [];
       const toolDef = all.find((t) => t.name === event.toolName);
-      const isCustom =
-        !toolDef ||
-        (toolDef.sourceInfo?.source !== "builtin" && !event.toolName.startsWith("memory_recall"));
+      const isBuiltin = toolDef?.sourceInfo?.source === "builtin";
+      const isBuiltinLtmRecall =
+        event.toolName === "memory_recall" &&
+        (toolDef?.sourceInfo?.source === "builtin" ||
+          toolDef?.sourceInfo?.path === "<inline:desktop-ltm>");
+      const isCustom = !toolDef || (!isBuiltin && !isBuiltinLtmRecall);
       if (!needsAskConfirm(modeRef.current, event.toolName, isCustom)) return;
       const ok = await ctx.ui.confirm(
         `允许 ${event.toolName}?`,

--- a/lib/pi-runtime.test.ts
+++ b/lib/pi-runtime.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { setProviderApiKey, removeProviderApiKey } from "./pi-runtime.ts";
+import { setProviderApiKey, removeProviderApiKey, createPiRuntime } from "./pi-runtime.ts";
 import type { ModelRuntime } from "@earendil-works/pi-coding-agent";
 
 // Regression test for issue #21: API keys must be persisted via the SDK
@@ -52,4 +52,13 @@ test("removeProviderApiKey deletes the stored credential via runtime.logout", as
 
   await removeProviderApiKey(runtime, "deepseek");
   assert.deepEqual(calls, [["deepseek"]]);
+});
+
+test("createPiRuntime loads extension providers and registers dynamic models", async () => {
+  const { runtime, registry } = await createPiRuntime();
+  assert.ok(runtime);
+  assert.ok(registry);
+  const providers = runtime.getProviders();
+  assert.ok(Array.isArray(providers));
+  assert.ok(providers.length > 0);
 });

--- a/lib/pi-runtime.test.ts
+++ b/lib/pi-runtime.test.ts
@@ -55,10 +55,22 @@ test("removeProviderApiKey deletes the stored credential via runtime.logout", as
 });
 
 test("createPiRuntime loads extension providers and registers dynamic models", async () => {
-  const { runtime, registry } = await createPiRuntime();
+  const { runtime, registry } = await createPiRuntime({ allowModelNetwork: false });
   assert.ok(runtime);
   assert.ok(registry);
   const providers = runtime.getProviders();
   assert.ok(Array.isArray(providers));
   assert.ok(providers.length > 0);
+
+  const allModels = registry.getAll();
+  assert.ok(Array.isArray(allModels));
+  assert.ok(allModels.length > 0);
+
+  // If antigravity extension is present in the environment, verify provider and its registered models
+  const antigravity = runtime.getProvider("antigravity");
+  if (antigravity) {
+    assert.equal(antigravity.id, "antigravity");
+    const antigravityModels = allModels.filter((m) => m.provider === "antigravity");
+    assert.ok(antigravityModels.length > 0, "antigravity dynamic models must be present in registry");
+  }
 });

--- a/lib/pi-runtime.ts
+++ b/lib/pi-runtime.ts
@@ -3,6 +3,7 @@
  * Auth/model routes should use this module instead of the removed AuthStorage public API.
  */
 import {
+  createAgentSessionServices,
   ModelRegistry,
   ModelRuntime,
   getAgentDir,
@@ -13,6 +14,7 @@ import { join } from "path";
 export type { AuthInteraction, AuthType };
 
 export interface CreatePiRuntimeOptions {
+  cwd?: string;
   /** Override models.json path (used by models-config test). */
   modelsPath?: string | null;
   /** Allow network catalog refresh during create. Default false for API routes. */
@@ -29,14 +31,20 @@ export async function createPiRuntime(options: CreatePiRuntimeOptions = {}): Pro
   registry: ModelRegistry;
 }> {
   const agentDir = getAgentDir();
+  const cwd = options.cwd ?? process.cwd();
   const runtime = await ModelRuntime.create({
     authPath: options.authPath ?? join(agentDir, "auth.json"),
     modelsPath: options.modelsPath === undefined ? join(agentDir, "models.json") : options.modelsPath,
     allowModelNetwork: options.allowModelNetwork ?? false,
   });
-  const registry = new ModelRegistry(runtime);
+  const services = await createAgentSessionServices({
+    cwd,
+    agentDir,
+    modelRuntime: runtime,
+  });
+  const registry = new ModelRegistry(services.modelRuntime);
   await registry.refresh();
-  return { runtime, registry };
+  return { runtime: services.modelRuntime, registry };
 }
 
 /** Providers that expose OAuth login (for the OAuth panel). */

--- a/lib/pi-runtime.ts
+++ b/lib/pi-runtime.ts
@@ -43,7 +43,7 @@ export async function createPiRuntime(options: CreatePiRuntimeOptions = {}): Pro
     modelRuntime: runtime,
   });
   const registry = new ModelRegistry(services.modelRuntime);
-  await registry.refresh();
+  await registry.refresh({ allowNetwork: options.allowModelNetwork ?? false });
   return { runtime: services.modelRuntime, registry };
 }
 

--- a/lib/pi-types.ts
+++ b/lib/pi-types.ts
@@ -14,6 +14,13 @@ export interface ModelLike {
 export interface ToolInfo {
   name: string;
   description: string;
+  sourceInfo?: {
+    source?: string;
+    path?: string;
+    scope?: string;
+    origin?: string;
+    baseDir?: string;
+  };
 }
 
 export interface NavigateTreeResult {

--- a/lib/rpc-manager.test.ts
+++ b/lib/rpc-manager.test.ts
@@ -15,7 +15,7 @@ const flushMicrotasks = (): Promise<void> => new Promise((r) => setImmediate(r))
 
 test("startRpcSession does not pass a hardcoded default tool allowlist", () => {
   assert.doesNotMatch(source, /const allCodingToolNames = \[[^\]]+\]/);
-  assert.match(source, /effectiveTools\.length === 0 \? \{ noTools: "all" as const \}/);
+  assert.match(source, /initialEffective\.length === 0 \? \{ noTools: "all" as const \}/);
   assert.match(source, /effectiveToolsForMode/);
   assert.match(source, /setActiveToolsByName\(effectiveTools\)/);
 });
@@ -25,14 +25,14 @@ test("startRpcSession registers desktopLtmInlineExtension", () => {
   assert.match(source, /withMemoryTools/);
 });
 
-test("startRpcSession passes agentMode to withMemoryTools so plan drops write tools (S2)", () => {
+test("startRpcSession passes agentMode to withMemoryTools and preserves extension custom tools", () => {
   // Regression: the start/restore path previously called
   // withMemoryTools(effectiveToolsForMode(...)) without mode, so a plan
   // session restored from history re-enabled memory_save/memory_forget
   // (LTM write/delete) with no Ask confirm.
   assert.match(
     source,
-    /withMemoryTools\(\s*effectiveToolsForMode\(agentMode, toolPreset\),\s*agentMode\s*\)/
+    /withMemoryTools\(\s*effectiveToolsForMode\(agentMode, toolPreset, customToolNames\),\s*agentMode\s*\)/
   );
 });
 
@@ -45,6 +45,8 @@ function makeStubInner(overrides: {
   steer?: (msg: string, imgs?: unknown) => Promise<unknown>;
   followUp?: (msg: string, imgs?: unknown) => Promise<unknown>;
   setActiveToolsByName?: (names: string[]) => void;
+  getAllTools?: () => Array<{ name: string; description: string }>;
+  getActiveToolNames?: () => string[];
   abort?: () => Promise<void>;
   isStreaming?: boolean;
 } = {}) {
@@ -65,8 +67,8 @@ function makeStubInner(overrides: {
     followUp: overrides.followUp ?? (() => Promise.resolve()),
     setActiveToolsByName: overrides.setActiveToolsByName ?? (() => {}),
     abort: overrides.abort ?? (async () => {}),
-    getAllTools: () => [],
-    getActiveToolNames: () => [],
+    getAllTools: overrides.getAllTools ?? (() => []),
+    getActiveToolNames: overrides.getActiveToolNames ?? (() => []),
     subscribe: overrides.subscribe ?? ((cb: (event: unknown) => void) => { void cb; return () => {}; }),
   } as never;
 }
@@ -730,19 +732,38 @@ test("agent event reaches every listener even if an earlier listener throws (M2)
   assert.deepEqual(events[0], { type: "custom_event" });
 });
 
-test("set_agent_mode plan forces read tools", async () => {
+test("set_agent_mode plan forces read tools and restores custom tools on switch back", async () => {
   const applied: string[][] = [];
   const w = new AgentSessionWrapper(makeStubInner({
+    getAllTools: () => [
+      { name: "read", description: "" },
+      { name: "bash", description: "" },
+      { name: "edit", description: "" },
+      { name: "write", description: "" },
+      { name: "ffgrep", description: "" },
+      { name: "web_search", description: "" },
+    ],
     setActiveToolsByName: (names) => { applied.push([...names]); },
   }));
   w.initPolicy("ask", "default");
+  w.applyAgentMode("ask");
+  assert.ok(applied.at(-1)?.includes("ffgrep"));
+  assert.ok(applied.at(-1)?.includes("web_search"));
+
   const result = await w.send({ type: "set_agent_mode", mode: "plan" }) as { agentMode: string };
   assert.equal(result.agentMode, "plan");
-  // Plan is read-only: memory_recall stays, write/delete channels are dropped.
+  // Plan is read-only: memory_recall stays, write/delete and custom tools are dropped.
   assert.deepEqual(
     applied.at(-1)?.slice().sort(),
     ["find", "grep", "ls", "memory_recall", "read"]
   );
+
+  // Switch back to ask: custom tools and memory write/delete are restored
+  await w.send({ type: "set_agent_mode", mode: "ask" });
+  assert.ok(applied.at(-1)?.includes("ffgrep"));
+  assert.ok(applied.at(-1)?.includes("web_search"));
+  assert.ok(applied.at(-1)?.includes("memory_save"));
+  assert.ok(applied.at(-1)?.includes("bash"));
 });
 
 test("get_state includes agentMode", async () => {

--- a/lib/rpc-manager.test.ts
+++ b/lib/rpc-manager.test.ts
@@ -15,7 +15,6 @@ const flushMicrotasks = (): Promise<void> => new Promise((r) => setImmediate(r))
 
 test("startRpcSession does not pass a hardcoded default tool allowlist", () => {
   assert.doesNotMatch(source, /const allCodingToolNames = \[[^\]]+\]/);
-  assert.match(source, /initialEffective\.length === 0 \? \{ noTools: "all" as const \}/);
   assert.match(source, /effectiveToolsForMode/);
   assert.match(source, /setActiveToolsByName\(effectiveTools\)/);
 });
@@ -764,6 +763,43 @@ test("set_agent_mode plan forces read tools and restores custom tools on switch 
   assert.ok(applied.at(-1)?.includes("web_search"));
   assert.ok(applied.at(-1)?.includes("memory_save"));
   assert.ok(applied.at(-1)?.includes("bash"));
+});
+
+test("set_tools preserves custom extension tools for default/full presets and clears for none", async () => {
+  const applied: string[][] = [];
+  const w = new AgentSessionWrapper(makeStubInner({
+    getAllTools: () => [
+      { name: "read", description: "" },
+      { name: "bash", description: "" },
+      { name: "edit", description: "" },
+      { name: "write", description: "" },
+      { name: "ffgrep", description: "" },
+    ],
+    setActiveToolsByName: (names) => { applied.push([...names]); },
+  }));
+  w.initPolicy("full", "default");
+
+  // Client sends builtin full list: extension tools should be preserved
+  await w.send({
+    type: "set_tools",
+    toolNames: ["bash", "read", "edit", "write", "grep", "find", "ls"],
+  });
+  assert.equal(w.toolPreset, "full");
+  assert.ok(applied.at(-1)?.includes("ffgrep"));
+  assert.ok(applied.at(-1)?.includes("grep"));
+
+  // Client sends empty list: preset becomes none and tools are cleared
+  await w.send({ type: "set_tools", toolNames: [] });
+  assert.equal(w.toolPreset, "none");
+  assert.deepEqual(applied.at(-1), []);
+
+  // Switch back to default: custom tools are restored
+  await w.send({
+    type: "set_tools",
+    toolNames: ["read", "bash", "edit", "write"],
+  });
+  assert.equal(w.toolPreset, "default");
+  assert.ok(applied.at(-1)?.includes("ffgrep"));
 });
 
 test("get_state includes agentMode", async () => {

--- a/lib/rpc-manager.test.ts
+++ b/lib/rpc-manager.test.ts
@@ -821,6 +821,59 @@ test("extension_ui_response resolves bridge confirm", async () => {
   await w.send({ type: "extension_ui_response", id: req.id, confirmed: true });
   assert.equal(await p, true);
 });
+
+test("desktop approval factory gates custom and spoofed memory_recall tools in Ask mode", async () => {
+  const { createDesktopApprovalFactory } = await import("./desktop-approval-extension.ts");
+  const modeRef = { current: "ask" as const };
+  const factory = createDesktopApprovalFactory(modeRef);
+
+  let toolCallHandler: ((event: { toolName: string; input: unknown }, ctx: { ui: { confirm: (t: string, m: string) => Promise<boolean> } }) => Promise<unknown>) | null = null;
+  const mockTools: Array<{ name: string; sourceInfo?: { source?: string; path?: string } }> = [];
+  const pi = {
+    on: (evt: string, handler: unknown) => {
+      if (evt === "tool_call") {
+        toolCallHandler = handler as typeof toolCallHandler;
+      }
+    },
+    getAllTools: () => mockTools,
+  };
+  factory(pi as never);
+
+  let confirmCalled = false;
+  const mockCtx = {
+    ui: {
+      confirm: async () => { confirmCalled = true; return true; },
+    },
+  };
+
+  // 1. Built-in read should not trigger confirm
+  mockTools.length = 0;
+  mockTools.push({ name: "read", sourceInfo: { source: "builtin", path: "<builtin:read>" } });
+  confirmCalled = false;
+  await toolCallHandler!({ toolName: "read", input: {} }, mockCtx);
+  assert.equal(confirmCalled, false, "builtin read should bypass confirm");
+
+  // 2. Genuine desktop-ltm memory_recall should not trigger confirm
+  mockTools.length = 0;
+  mockTools.push({ name: "memory_recall", sourceInfo: { path: "<inline:desktop-ltm>" } });
+  confirmCalled = false;
+  await toolCallHandler!({ toolName: "memory_recall", input: {} }, mockCtx);
+  assert.equal(confirmCalled, false, "genuine ltm memory_recall should bypass confirm");
+
+  // 3. Spoofed memory_recall from an external extension should trigger confirm
+  mockTools.length = 0;
+  mockTools.push({ name: "memory_recall", sourceInfo: { source: "extension", path: "/tmp/evil-desktop-ltm.ts" } });
+  confirmCalled = false;
+  await toolCallHandler!({ toolName: "memory_recall", input: {} }, mockCtx);
+  assert.equal(confirmCalled, true, "spoofed memory_recall must trigger confirm");
+
+  // 4. Custom tool with missing provenance should fail-closed and trigger confirm
+  mockTools.length = 0;
+  mockTools.push({ name: "custom_search" });
+  confirmCalled = false;
+  await toolCallHandler!({ toolName: "custom_search", input: {} }, mockCtx);
+  assert.equal(confirmCalled, true, "custom tool without provenance must trigger confirm");
+});
 test("setAgentMode appends custom entry to sessionManager", () => {
   const customEntries: Array<{ customType: string; data: unknown }> = [];
   const stubSessionManager = {

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -121,7 +121,7 @@ export class AgentSessionWrapper {
 
   private getCustomToolNames(): string[] {
     const all = typeof this.inner.getAllTools === "function" ? this.inner.getAllTools() : [];
-    return extractCustomToolNames(all.map((t) => t.name));
+    return extractCustomToolNames(all);
   }
 
   applyAgentMode(mode: AgentMode): void {
@@ -155,13 +155,12 @@ export class AgentSessionWrapper {
 
   /** Infer preset from tool name list when client calls set_tools. */
   private inferPresetFromTools(names: string[]): ToolPreset {
-    const customTools = this.getCustomToolNames();
-    const key = [...names].sort().join(",");
-    if (key === "") return "none";
-    if (key === [...toolNamesForPreset("default", customTools)].sort().join(",")) return "default";
-    if (key === [...toolNamesForPreset("full", customTools)].sort().join(",")) return "full";
-    if (key === [...toolNamesForPreset("default")].sort().join(",")) return "default";
-    if (key === [...toolNamesForPreset("full")].sort().join(",")) return "full";
+    if (names.length === 0) return "none";
+    const nameSet = new Set(names);
+    // grep, find, ls distinguish the full preset from default
+    if (nameSet.has("grep") || nameSet.has("find") || nameSet.has("ls")) {
+      return "full";
+    }
     return "default";
   }
 
@@ -575,7 +574,18 @@ export class AgentSessionWrapper {
             withMemoryTools([...effectiveToolsForMode("plan", this._toolPreset)], "plan")
           );
         } else {
-          this.inner.setActiveToolsByName(withMemoryTools(toolNames, this._agentMode));
+          const customTools = this.getCustomToolNames();
+          const effective =
+            this._toolPreset === "none"
+              ? []
+              : withMemoryTools(
+                  effectiveToolsForMode(this._agentMode, this._toolPreset, customTools),
+                  this._agentMode
+                );
+          this.inner.setActiveToolsByName(effective);
+          if (effective.length === 0 && this.inner.agent?.state) {
+            this.inner.agent.state.systemPrompt = "";
+          }
         }
         return null;
       }
@@ -827,21 +837,15 @@ export async function startRpcSession(
     });
     await resourceLoader.reload();
 
-    const initialEffective = effectiveToolsForMode(agentMode, toolPreset);
-    // Pi 0.82+: empty tools allowlist is expressed via noTools: "all"
-    const createOptions =
-      initialEffective.length === 0 ? { noTools: "all" as const } : {};
-
     const { session: inner } = await createAgentSession({
       cwd,
       agentDir,
       sessionManager,
       resourceLoader,
-      ...createOptions,
     });
 
     const allTools = typeof inner.getAllTools === "function" ? inner.getAllTools() : [];
-    const customToolNames = extractCustomToolNames(allTools.map((t) => t.name));
+    const customToolNames = extractCustomToolNames(allTools);
 
     const effectiveTools = withMemoryTools(
       effectiveToolsForMode(agentMode, toolPreset, customToolNames),

--- a/lib/rpc-manager.ts
+++ b/lib/rpc-manager.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_AGENT_MODE,
   DEFAULT_TOOL_PRESET,
   effectiveToolsForMode,
+  extractCustomToolNames,
   isAgentMode,
   isToolPreset,
   type AgentMode,
@@ -118,6 +119,11 @@ export class AgentSessionWrapper {
     }
   }
 
+  private getCustomToolNames(): string[] {
+    const all = typeof this.inner.getAllTools === "function" ? this.inner.getAllTools() : [];
+    return extractCustomToolNames(all.map((t) => t.name));
+  }
+
   applyAgentMode(mode: AgentMode): void {
     if (mode === "plan" && this._agentMode !== "plan") {
       this._toolPresetBeforePlan = this._toolPreset;
@@ -128,7 +134,11 @@ export class AgentSessionWrapper {
     }
     this._agentMode = mode;
     this._modeRef.current = mode;
-    const tools = withMemoryTools(effectiveToolsForMode(mode, this._toolPreset), mode);
+    const customTools = this.getCustomToolNames();
+    const tools = withMemoryTools(
+      effectiveToolsForMode(mode, this._toolPreset, customTools),
+      mode
+    );
     this.inner.setActiveToolsByName(tools);
     if (tools.length === 0) {
       const state = this.inner.agent?.state as { systemPrompt?: string } | undefined;
@@ -145,8 +155,11 @@ export class AgentSessionWrapper {
 
   /** Infer preset from tool name list when client calls set_tools. */
   private inferPresetFromTools(names: string[]): ToolPreset {
+    const customTools = this.getCustomToolNames();
     const key = [...names].sort().join(",");
     if (key === "") return "none";
+    if (key === [...toolNamesForPreset("default", customTools)].sort().join(",")) return "default";
+    if (key === [...toolNamesForPreset("full", customTools)].sort().join(",")) return "full";
     if (key === [...toolNamesForPreset("default")].sort().join(",")) return "default";
     if (key === [...toolNamesForPreset("full")].sort().join(",")) return "full";
     return "default";
@@ -803,11 +816,6 @@ export async function startRpcSession(
       else if (key === [...toolNamesForPreset("full")].sort().join(",")) toolPreset = "full";
     }
 
-    const effectiveTools = withMemoryTools(
-      effectiveToolsForMode(agentMode, toolPreset),
-      agentMode
-    );
-
     const modeRef: AgentModeRef = { current: agentMode };
     const resourceLoader = new DefaultResourceLoader({
       cwd,
@@ -819,9 +827,10 @@ export async function startRpcSession(
     });
     await resourceLoader.reload();
 
+    const initialEffective = effectiveToolsForMode(agentMode, toolPreset);
     // Pi 0.82+: empty tools allowlist is expressed via noTools: "all"
     const createOptions =
-      effectiveTools.length === 0 ? { noTools: "all" as const } : { tools: effectiveTools };
+      initialEffective.length === 0 ? { noTools: "all" as const } : {};
 
     const { session: inner } = await createAgentSession({
       cwd,
@@ -831,15 +840,21 @@ export async function startRpcSession(
       ...createOptions,
     });
 
+    const allTools = typeof inner.getAllTools === "function" ? inner.getAllTools() : [];
+    const customToolNames = extractCustomToolNames(allTools.map((t) => t.name));
+
+    const effectiveTools = withMemoryTools(
+      effectiveToolsForMode(agentMode, toolPreset, customToolNames),
+      agentMode
+    );
+
     if (effectiveTools.length > 0) {
       inner.setActiveToolsByName(effectiveTools);
-    }
-
-    // When all tools are disabled, clear the system prompt entirely.
-    // pi's buildSystemPrompt always produces a non-empty prompt even with no tools;
-    // the only way to truly clear it is to call agent.setSystemPrompt directly.
-    if (effectiveTools.length === 0) {
-      inner.agent.state.systemPrompt = "";
+    } else {
+      inner.setActiveToolsByName([]);
+      if (inner.agent?.state) {
+        inner.agent.state.systemPrompt = "";
+      }
     }
 
     // AgentSession is structurally compatible with AgentSessionLike; cast keeps


### PR DESCRIPTION
### Why
Currently, `startRpcSession` and `AgentSessionWrapper.applyAgentMode` restrict active tools to a hardcoded allowlist of built-in tools (`PRESET_DEFAULT` / `PRESET_FULL`). This filters out custom tools registered by Pi extensions (for example `@ff-labs/pi-fff`, Tavily, or `pi-subagents`), causing desktop sessions to lose plugin tools.

This PR also fixes a client chat-scroll regression where the page pre-added a large blank spacer while the agent was thinking or using tools, making the scrollbar jump instead of growing naturally.

### Scope
- Preserve extension-registered custom tools under applicable presets while keeping `plan` / `none` behavior strict.
- Require confirmation for custom/spoofed tools in Ask mode, including strict provenance handling for desktop LTM tools.
- Deduplicate preset/custom tool names and preserve partial explicit tool selections.
- Load extension-registered providers and dynamic models through `createAgentSessionServices`.
- Remove the artificial chat spacer and replace forced top alignment with stick-to-bottom scroll tracking.
- Track the mounted scroll container via a callback ref so listeners bind correctly after delayed mount/loading states.
- Remove obsolete `lastUserMsgRef` plumbing.

### Out of scope
- Adding new tool presets.
- Changing third-party extension registration mechanisms in the Pi SDK.
- Running `next build`.

### Verification
- `npm test`: 569 passed, 0 failed.
- `npx tsc --noEmit`: 0 errors.
- `npx tsc -p electron/tsconfig.json --noEmit`: 0 errors.
- `npm run lint`: 0 errors.
- Fresh reviewer subagent: APPROVED.

### Notes
- CodeRabbit/Copilot earlier comments around custom-tool Ask-mode confirmation, provider/model test specificity, allow-network refresh, full-preset inference, and same-name replacement coverage have been addressed in follow-up commits.
- CodeRabbit is currently rate-limited on the latest push; the branch checks are passing.