### PR TITLE
release: v0.8.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,7 +6,7 @@ body:
     id: version
     attributes:
       label: 版本
-      placeholder: v0.8.5 或 main @ commit
+      placeholder: v0.8.6 或 main @ commit
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/packaging.yml
+++ b/.github/ISSUE_TEMPLATE/packaging.yml
@@ -6,7 +6,7 @@ body:
     id: version
     attributes:
       label: 版本 / tag
-      placeholder: v0.8.5
+      placeholder: v0.8.6
     validations:
       required: true
   - type: dropdown
@@ -25,7 +25,7 @@ body:
     id: asset
     attributes:
       label: 安装包或 latest*.yml 文件名
-      placeholder: Pi-Agent-Desktop-0.8.5-mac-universal.dmg
+      placeholder: Pi-Agent-Desktop-0.8.6-mac-universal.dmg
   - type: textarea
     id: what
     attributes:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,9 +3,9 @@
 > 本文档是项目的**权威架构参考**，由 CodeGraph 静态分析 + 源码核对生成。
 > 若与 `AGENTS.md` / `CLAUDE.md` 中的简要描述冲突，以本文档为准。
 >
-- **项目**：`@chasen-liao/pi-agent-desktop` v0.8.5
+- **项目**：`@chasen-liao/pi-agent-desktop` v0.8.6
 - **上游 SDK**：`@earendil-works/pi-coding-agent` ^0.84.3 / `@earendil-works/pi-ai` ^0.84.3
-- **更新日期**：2026-09-01
+- **更新日期**：2026-09-06
 
 ---
 
@@ -143,7 +143,7 @@ flowchart TD
 
 ```text
 pi-agent-desktop/
-├── package.json                  @chasen-liao/pi-agent-desktop v0.8.5
+├── package.json                  @chasen-liao/pi-agent-desktop v0.8.6
 ├── next.config.ts                output:"standalone" + server external packages
 ├── tailwind.config.ts            Tailwind 4 配置
 ├── tsconfig.json                 strict + bundler resolution

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -39,7 +39,7 @@
 
 Windows 安装包当前未代码签名，Release Notes 必须披露 SmartScreen 提示。GitHub Actions 打的 macOS 包同样未签名、未公证，Release Notes 必须披露 Gatekeeper 提示。Linux 的 `.deb` 安装包通过 electron-updater 的 `DebUpdater` 自动更新：应用内下载新 `.deb` 后经 `dpkg -i` 或 `apt --allow-unauthenticated` 安装，安装时需要 root 授权提示。下载完整性由 `latest-linux.yml` 的 SHA512 校验（与 Windows NSIS 相同），但 `.deb` 本身未做 debsig，系统包管理器不会再验包签名。自动更新依赖 Release 资产中的 `latest-linux.yml`，漏传则 Linux 端收不到更新。Release Notes 必须披露未签名 deb 与 root 安装。
 
-截至 2026-09-01：最新桌面 GitHub Release 是 `v0.8.5`，含 Windows NSIS、macOS Universal、Linux deb 及三份 `latest*.yml`。`v0.8.4` 及更早只有 Windows 资产。Issue / PR 约定见 [CONTRIBUTING.md](../CONTRIBUTING.md)。
+截至 2026-09-06：最新桌面 GitHub Release 是 `v0.8.6`，含 Windows NSIS、macOS Universal、Linux deb 及三份 `latest*.yml`。`v0.8.4` 及更早只有 Windows 资产。Issue / PR 约定见 [CONTRIBUTING.md](../CONTRIBUTING.md)。
 
 ## npm Release
 

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -1373,7 +1373,7 @@
 
     <div class="file-tree">
       <div class="ft-line ft-dir" style="--depth:0"><span class="ft-icon">📁</span><span class="ft-name">pi-agent-desktop/</span></div>
-      <div class="ft-line" style="--depth:1"><span class="ft-icon">📦</span><span class="ft-name">package.json</span><span class="ft-comment">@chasen-liao/pi-agent-desktop v0.8.5</span></div>
+      <div class="ft-line" style="--depth:1"><span class="ft-icon">📦</span><span class="ft-name">package.json</span><span class="ft-comment">@chasen-liao/pi-agent-desktop v0.8.6</span></div>
       <div class="ft-line" style="--depth:1"><span class="ft-icon">⚙️</span><span class="ft-name">next.config.ts</span><span class="ft-comment">standalone + 外部包</span></div>
       <div class="ft-line" style="--depth:1"><span class="ft-icon">🎨</span><span class="ft-name">tailwind.config.ts</span></div>
       <div class="ft-line" style="--depth:1"><span class="ft-icon">📘</span><span class="ft-name">tsconfig.json</span><span class="ft-comment">strict + bundler</span></div>
@@ -1513,7 +1513,7 @@
 </section>
 
 <footer>
-  <p>Pi Agent Desktop 架构深度解析 · 版本 0.8.5 · 2026-09-01 · <a href="https://github.com/Chasen-Liao/pi-agent-desktop" style="color:var(--accent3);text-decoration:none;">pi-agent-desktop</a></p>
+  <p>Pi Agent Desktop 架构深度解析 · 版本 0.8.6 · 2026-09-06 · <a href="https://github.com/Chasen-Liao/pi-agent-desktop" style="color:var(--accent3);text-decoration:none;">pi-agent-desktop</a></p>
 </footer>
 
 <script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -720,7 +720,7 @@
         <div class="container hero-inner">
           <div class="hero-badge reveal">
             <span>Pi 编程智能体的原生桌面客户端</span>
-            <span class="tag">v0.8.5</span>
+            <span class="tag">v0.8.6</span>
           </div>
           <h1 id="hero-title" class="reveal d1">
             个人极简版 Codex

--- a/docs/releases/v0.8.6.md
+++ b/docs/releases/v0.8.6.md
@@ -1,0 +1,23 @@
+# Pi Agent Desktop v0.8.6
+
+发布日期：2026-09-06
+
+## 新增
+
+- **Git Worktree Clone**：会话 Clone 可在源 Git 仓库外创建独立 worktree 与新分支；目标、分支与 worktree 身份无法证明时 fail closed（#37）
+
+## 改进
+
+- **代码质量收口**：去掉死代码与 AgentMemory stub 后端；API 错误 / fetch 兜底 / modal 外壳 / 点外关闭监听收敛到单一 helper（#41）
+- **Worktree 清理加固**：所有权与回滚路径按文件系统身份校验，避免误删非本应用创建的 worktree
+
+## 兼容性与已知限制
+
+- 手改 `desktop-settings.json` 把 `ltm.backend` 设为 `agentmemory` 已不再可用；长期记忆仅 SQLite（启用）或 Noop（关闭）。需要旧 REST stub 时可 `git show fd5bca1 -- lib/ltm/agentmemory-backend.ts`。
+- Windows / macOS / Linux 安装包均未代码签名。Windows 可能出现 SmartScreen；macOS 可能出现 Gatekeeper；Linux 自动更新经 `dpkg`/`apt` 安装未签名 `.deb`，需要 root 授权。Release 必须带齐 `latest.yml` / `latest-mac.yml` / `latest-linux.yml`，漏传则对应平台收不到更新。
+- 仅环境变量认证的 provider（如 GitHub Copilot）不支持在弹窗中保存 API Key。
+
+## 验证
+
+- 版本 PR 的 CI：`lint · typecheck · test`、`test (windows)`、`test (macOS)`、`build (next.js)`
+- tag 后 `Desktop packages` workflow 构建三端并上传本 Release；发布后核对本页资产名称、大小与三份 `latest*.yml` 的 version / SHA512

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chasen-liao/pi-agent-desktop",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chasen-liao/pi-agent-desktop",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.9"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chasen-liao/pi-agent-desktop",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Pi Agent Desktop — desktop client for the pi coding agent",
   "license": "MIT",
   "author": "Chasen",


### PR DESCRIPTION
## Why

Cut a patch desktop release after Git worktree clone (#37) and the quality-optimization cleanup (#41).

## Scope

- Bump `package.json` / `package-lock.json` to `0.8.6`
- Add [docs/releases/v0.8.6.md](docs/releases/v0.8.6.md)
- Sync version strings in ARCHITECTURE / RELEASING / landing pages / issue-template placeholders

## Out of scope

- npm publish (`npm run release` is not used for desktop packages)
- Signing / notarization
- Tag is pushed **after** this PR merges, not in this PR

## Verification

CI on this PR: `lint · typecheck · test`, `test (windows)`, `test (macOS)`, `build (next.js)`.
After merge: `git tag v0.8.6 && git push origin v0.8.6` → Desktop packages workflow uploads Win/macOS/Linux assets to the GitHub Release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Git Worktree Clone support.
  * Improved worktree cleanup reliability.
* **Bug Fixes**
  * Completed code-quality improvements for a more stable experience.
* **Documentation**
  * Added Pi Agent Desktop v0.8.6 release notes.
  * Updated version information across project documentation and support templates.
  * Documented compatibility limitations, unsigned installer requirements, automatic update requirements, and API key storage limitations for environment-variable authentication.
  * Added release validation and packaging process details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->