### PR TITLE
release: v0.8.7

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -39,7 +39,7 @@
 
 Windows 安装包当前未代码签名，Release Notes 必须披露 SmartScreen 提示。GitHub Actions 打的 macOS 包同样未签名、未公证，Release Notes 必须披露 Gatekeeper 提示。Linux 的 `.deb` 安装包通过 electron-updater 的 `DebUpdater` 自动更新：应用内下载新 `.deb` 后经 `dpkg -i` 或 `apt --allow-unauthenticated` 安装，安装时需要 root 授权提示。下载完整性由 `latest-linux.yml` 的 SHA512 校验（与 Windows NSIS 相同），但 `.deb` 本身未做 debsig，系统包管理器不会再验包签名。自动更新依赖 Release 资产中的 `latest-linux.yml`，漏传则 Linux 端收不到更新。Release Notes 必须披露未签名 deb 与 root 安装。
 
-截至 2026-09-06：最新桌面 GitHub Release 是 `v0.8.6`，含 Windows NSIS、macOS Universal、Linux deb 及三份 `latest*.yml`。`v0.8.4` 及更早只有 Windows 资产。Issue / PR 约定见 [CONTRIBUTING.md](../CONTRIBUTING.md)。
+截至 2026-09-08：最新桌面 GitHub Release 是 `v0.8.7`，含 Windows NSIS、macOS Universal、Linux deb 及三份 `latest*.yml`。`v0.8.4` 及更早只有 Windows 资产。Issue / PR 约定见 [CONTRIBUTING.md](../CONTRIBUTING.md)。
 
 ## npm Release
 

--- a/docs/releases/v0.8.7.md
+++ b/docs/releases/v0.8.7.md
@@ -1,0 +1,19 @@
+# Pi Agent Desktop v0.8.7
+
+发布日期：2026-09-08
+
+## 改进
+
+- **扩展模型进选择器**：`createPiRuntime` 走官方 `createAgentSessionServices`，把本机 Pi 扩展动态注册的 provider / model 暴露给 `/api/models` 和 `/api/auth/*`。桌面端作为本地 Pi Agent 的界面，模型列表与认证面板与终端 CLI 对齐（#34）
+
+## 兼容性与已知限制
+
+- Windows / macOS / Linux 安装包均未代码签名。Windows 可能出现 SmartScreen；macOS 可能出现 Gatekeeper；Linux 自动更新经 `dpkg`/`apt` 安装未签名 `.deb`，需要 root 授权。Release 必须带齐 `latest.yml` / `latest-mac.yml` / `latest-linux.yml`，漏传则对应平台收不到更新。
+- 仅环境变量认证的 provider（如 GitHub Copilot）不支持在弹窗中保存 API Key。
+- 模型列表按进程 cwd 加载扩展；项目级扩展是否出现取决于应用启动目录。扩展加载失败目前静默，列表可能缺项。
+
+## 验证
+
+- 合并 #34 后本地：`npm run lint`（0 errors）、`npx tsc --noEmit`、`npx tsc -p electron/tsconfig.json --noEmit`、`npm test`（591 pass / 0 fail）、`npm run check:electron-deps`
+- 版本 PR 的 CI：`lint · typecheck · test`、`test (windows)`、`test (macOS)`、`build (next.js)`
+- tag 后 `Desktop packages` workflow 构建三端并上传本 Release；发布后核对本页资产名称、大小与三份 `latest*.yml` 的 version / SHA512

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chasen-liao/pi-agent-desktop",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chasen-liao/pi-agent-desktop",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.9"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chasen-liao/pi-agent-desktop",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Pi Agent Desktop — desktop client for the pi coding agent",
   "license": "MIT",
   "author": "Chasen",


### PR DESCRIPTION
### Why
Ship desktop v0.8.7 after merging #34 so the model picker and auth panel load extension-registered providers from the local Pi Agent.

### Scope
- `package.json` / `package-lock.json` → `0.8.7`
- `docs/releases/v0.8.7.md`
- `docs/RELEASING.md` current-release pointer

### Out of scope
- Code changes (already on main via #34)
- npm CLI publish (`npm run release`)

### Verification
Local after #34 merge:
- `npm run lint`: 0 errors
- `npx tsc --noEmit` / `npx tsc -p electron/tsconfig.json --noEmit`: 0 errors
- `npm test`: 591 pass, 0 fail
- `npm run check:electron-deps`: OK

After merge: `git tag v0.8.7 && git push origin v0.8.7`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Local Pi extension providers and models can now be registered dynamically through the agent session services.
  - Added support for extension loading with documented platform and authentication-provider compatibility limitations.

- **Documentation**
  - Added release notes for Pi Agent Desktop v0.8.7, including validation and build information.
  - Updated release-status documentation to reference the v0.8.7 desktop release.

- **Release**
  - Updated the application version to 0.8.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->