### PR TITLE
chore(release): v0.8.8

### DIFF
--- a/docs/releases/v0.8.8.md
+++ b/docs/releases/v0.8.8.md
@@ -1,0 +1,32 @@
+# Pi Agent Desktop v0.8.8
+
+发布日期：2026-09-11
+
+## 修复
+
+- **崩溃兜底不再永久白屏**：渲染进程崩溃的自动重载有 60 秒窗口内最多 3 次的上限；达到上限后此前只记日志、窗口保持空白。现在会加载启动错误页，显示「页面多次崩溃，已停止自动恢复」，用户可感知并重启应用（#20）
+- **跨进程 SQLite 锁竞争不再动辄 500**：与终端 CLI 同时运行时，LTM（长期记忆）的 `/api/memory/*` 请求在 `SQLITE_BUSY` 下做有界重试——快速失败（如 `journal_mode=WAL` 切换）重试满额，慢失败（busy_timeout 烧满的长事务）最多重试一次，避免请求延迟成倍放大
+- **配置写盘原子化**：`settings.json` 与 `desktop-settings.json` 改为 tmp+rename 原子写，Windows 上 rename 被并发读者 EPERM 阻塞时带界重试，预算耗尽降级直写并记日志。防止桌面端与终端 CLI 并发使用时配置文件停留在半写状态丢内容
+
+## 新增
+
+- **layout 层错误兜底**：新增 `global-error.tsx`（自包含文档与样式、context-free 取词），根 layout 自身崩溃也有可重试错误页；前端 `unhandledrejection` / `window error` 全局收口，节流提示且不新增依赖
+- **子进程崩溃可观测**：主进程监听 `child-process-gone`（GPU 等），记录类型/原因/退出码
+
+## 文档
+
+- `docs/investigations/white-screen.md`：白屏问题的沙箱实验记录（`PI_CODING_AGENT_DIR` 隔离复现），含三条因果链的实证判定与修复依据
+- `docs/ARCHITECTURE.md` §14.16 同步加固现状
+
+## 兼容性与已知限制
+
+- Windows / macOS / Linux 安装包均未代码签名。Windows 可能出现 SmartScreen 提示；macOS 可能出现 Gatekeeper 提示；Linux 自动更新经 `dpkg`/`apt` 安装未签名 `.deb`，需要 root 授权。Release 必须带齐 `latest.yml` / `latest-mac.yml` / `latest-linux.yml`，漏传则对应平台收不到更新。
+- 与终端 CLI 同时运行仍共享 `~/.pi/agent` 目录；本版修复了配置写盘与 LTM 锁竞争两类冲突，`.jsonl` 会话文件在实测中健壮，但同一 session 两端同时写入仍未受支持。
+- #33「另一终端运行时桌面白屏」的最终触发机制仍待用户日志确认；本版已消除其中可实证的破坏链。
+
+## 验证
+
+- 本地：`npm run lint`（0 errors）、`npx tsc --noEmit`、`npx tsc -p electron/tsconfig.json --noEmit`、`npm test`（606 pass / 0 fail）、`npm run check:electron-deps`
+- 真机闭环：Electron 开发模式 60 秒窗口内连续 4 次终止渲染进程，窗口显示「页面多次崩溃，已停止自动恢复」错误页而非白屏；跨进程锁下 `recall` 短锁成功、长锁有界失败
+- 版本 PR 的 CI：`lint · typecheck · test`、`test (windows)`、`test (macOS)`、`build (next.js)`
+- tag 后 `Desktop packages` workflow 构建三端并上传本 Release；发布后核对本页资产名称、大小与三份 `latest*.yml` 的 version / SHA512

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chasen-liao/pi-agent-desktop",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chasen-liao/pi-agent-desktop",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.9"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chasen-liao/pi-agent-desktop",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Pi Agent Desktop — desktop client for the pi coding agent",
   "license": "MIT",
   "author": "Chasen",


### PR DESCRIPTION
## 内容

- 版本 bump `0.8.7` → `0.8.8`(package.json / package-lock.json)
- 新增 `docs/releases/v0.8.8.md` 发布说明

## 主体修复(随 #47 进入 main)

- 渲染进程崩溃达自动重载上限后加载错误页,不再永久白屏(#20)
- LTM `/api/memory/*` 的 SQLITE_BUSY 有界重试(#33 相关)
- settings / desktop-settings 写盘原子化(Windows EPERM 重试)
- `global-error.tsx` layout 层兜底 + 全局 `unhandledrejection` 收口
- `child-process-gone` 可观测性日志

## 发布前门禁(本地全过)

`npm run lint`(0 errors)、`npx tsc --noEmit`、`npx tsc -p electron/tsconfig.json --noEmit`、`npm test`(606 pass / 0 fail)、`npm run check:electron-deps`(OK:16 packages)、`npm audit`(8 项与 main 基线一致,均为存量)。

合并后在 main 打 `v0.8.8` tag 推送,由 `desktop-packages.yml` 三端打包上传 Release。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Renderer crashes now automatically recover up to three times within 60 seconds before showing a clear startup error page.
  - Memory service requests use bounded retries to reduce delays during database contention.
  - Settings files are saved more reliably, including improved handling on Windows.

- **New Features**
  - Added global error handling with clearer, context-free notices.
  - Added monitoring for unexpected child-process termination.

- **Documentation**
  - Added v0.8.8 release notes covering compatibility, known limitations, and verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->